### PR TITLE
Add bundle per component

### DIFF
--- a/packages/strapi-design-system/webpack.config.js
+++ b/packages/strapi-design-system/webpack.config.js
@@ -29,11 +29,11 @@ if (process.env.BUNDLE_ANALYZE) {
 }
 
 module.exports = {
-  entry: entry,
+  entry,
   mode: 'production',
   output: {
     filename: '[name].js',
-    path: path.resolve(__dirname, './dist'),
+    path: path.resolve(__dirname, 'dist'),
     libraryTarget: 'umd',
   },
   module: {


### PR DESCRIPTION
Same as the Icons:

Allows to create distinct bundles for each component in the dist folder for people wanting to import only specific components such as

```js
 import Button from '@strapi/design-system/Button
```