### PR TITLE
Map box to shadow key in theme

### DIFF
--- a/packages/strapi-design-system/src/Box/Box.js
+++ b/packages/strapi-design-system/src/Box/Box.js
@@ -27,6 +27,9 @@ export const Box = styled.div.withConfig({
 
   // Radius
   border-radius: ${({ theme, hasRadius }) => (hasRadius ? theme.borderRadius : undefined)};
+
+  // Shadows
+  box-shadow: ${({ theme, shadow }) => theme.shadows[shadow]};
 `;
 
 Box.displayName = Box;
@@ -40,6 +43,7 @@ Box.defaultProps = {
   paddingBottom: undefined,
   paddingLeft: undefined,
   hasRadius: false,
+  shadow: undefined,
 };
 
 Box.propTypes = {
@@ -52,4 +56,5 @@ Box.propTypes = {
   paddingLeft: PropTypes.number,
   paddingRight: PropTypes.number,
   paddingTop: PropTypes.number,
+  shadow: PropTypes.string,
 };

--- a/packages/strapi-design-system/src/Box/Box.stories.mdx
+++ b/packages/strapi-design-system/src/Box/Box.stories.mdx
@@ -26,7 +26,7 @@ Description...
 
 <Canvas>
   <Story name="base">
-    <Box padding={4} background="primary700" color="neutral0">
+    <Box padding={4} background="primary700" color="neutral0" shadow="filterShadow">
       Hello world
     </Box>
   </Story>


### PR DESCRIPTION
# Add shadow prop to box

## Description

Add a shadow prop to the box component to create card on the fly

## Demo
Example on : [deployed story link]

## API

```jsx
<Box padding={4} background="primary700" color="neutral0" shadow="filterShadow">
      Hello world
    </Box>
```
