### PR TITLE
Accordion overflow // TO MERGE AFTER ERROR STATE

### DIFF
--- a/packages/strapi-design-system/src/Accordion/Accordion.js
+++ b/packages/strapi-design-system/src/Accordion/Accordion.js
@@ -31,7 +31,6 @@ export const AccordionTypography = styled(Typography)``;
 
 const AccordionWrapper = styled(Box)`
   border: ${getBorder};
-  overflow: hidden;
 
   &:hover:not([aria-disabled='true']) {
     border: 1px solid ${({ theme }) => theme.colors.primary600};

--- a/packages/strapi-design-system/src/Accordion/Accordion.js
+++ b/packages/strapi-design-system/src/Accordion/Accordion.js
@@ -7,8 +7,8 @@ import { useId } from '../helpers/useId';
 import { Box } from '../Box';
 import { Flex } from '../Flex';
 
-const getBorder = ({ theme, expanded, variant, disabled, hasError }) => {
-  if (hasError) {
+const getBorder = ({ theme, expanded, variant, disabled, error }) => {
+  if (error) {
     return `1px solid ${theme.colors.danger600} !important`;
   }
 
@@ -54,7 +54,7 @@ const AccordionWrapper = styled(Box)`
   }
 `;
 
-export const Accordion = ({ children, toggle, expanded, id, size, variant, disabled, hasError, errorMessage }) => {
+export const Accordion = ({ children, toggle, expanded, id, size, variant, disabled, error, hasErrorMessage }) => {
   const generatedId = useId('accordion', id);
 
   return (
@@ -66,14 +66,14 @@ export const Accordion = ({ children, toggle, expanded, id, size, variant, disab
         expanded={expanded}
         hasRadius
         variant={variant}
-        hasError={hasError}
+        error={error}
       >
         {children}
       </AccordionWrapper>
-      {errorMessage && (
+      {error && hasErrorMessage && (
         <Box paddingTop={1}>
           <Typography variant="pi" textColor="danger600">
-            {errorMessage}
+            {error}
           </Typography>
         </Box>
       )}
@@ -83,9 +83,9 @@ export const Accordion = ({ children, toggle, expanded, id, size, variant, disab
 
 Accordion.defaultProps = {
   disabled: false,
-  errorMessage: undefined,
+  error: undefined,
   expanded: false,
-  hasError: false,
+  hasErrorMessage: true,
   id: undefined,
   toggle: false,
   size: 'M',
@@ -95,9 +95,9 @@ Accordion.defaultProps = {
 Accordion.propTypes = {
   children: PropTypes.node.isRequired,
   disabled: PropTypes.bool,
-  errorMessage: PropTypes.string,
+  error: PropTypes.string,
   expanded: PropTypes.bool,
-  hasError: PropTypes.bool,
+  hasErrorMessage: PropTypes.bool,
   id: PropTypes.string,
   size: PropTypes.oneOf(['S', 'M']),
   toggle: PropTypes.func.isRequired,

--- a/packages/strapi-design-system/src/Accordion/Accordion.js
+++ b/packages/strapi-design-system/src/Accordion/Accordion.js
@@ -7,13 +7,17 @@ import { useId } from '../helpers/useId';
 import { Box } from '../Box';
 import { Flex } from '../Flex';
 
-const getBorder = ({ theme, expanded, variant, disabled }) => {
-  if (expanded) {
-    return `1px solid ${theme.colors.primary600}`;
+const getBorder = ({ theme, expanded, variant, disabled, hasError }) => {
+  if (hasError) {
+    return `1px solid ${theme.colors.danger600} !important`;
   }
 
   if (disabled) {
     return `1px solid ${theme.colors.neutral150}`;
+  }
+
+  if (expanded) {
+    return `1px solid ${theme.colors.primary600}`;
   }
 
   if (variant === 'primary') {
@@ -50,7 +54,7 @@ const AccordionWrapper = styled(Box)`
   }
 `;
 
-export const Accordion = ({ children, toggle, expanded, id, size, variant, disabled }) => {
+export const Accordion = ({ children, toggle, expanded, id, size, variant, disabled, hasError, errorMessage }) => {
   const generatedId = useId('accordion', id);
 
   return (
@@ -62,16 +66,26 @@ export const Accordion = ({ children, toggle, expanded, id, size, variant, disab
         expanded={expanded}
         hasRadius
         variant={variant}
+        hasError={hasError}
       >
         {children}
       </AccordionWrapper>
+      {errorMessage && (
+        <Box paddingTop={1}>
+          <Typography variant="pi" textColor="danger600">
+            {errorMessage}
+          </Typography>
+        </Box>
+      )}
     </AccordionContext.Provider>
   );
 };
 
 Accordion.defaultProps = {
   disabled: false,
+  errorMessage: undefined,
   expanded: false,
+  hasError: false,
   id: undefined,
   toggle: false,
   size: 'M',
@@ -81,7 +95,9 @@ Accordion.defaultProps = {
 Accordion.propTypes = {
   children: PropTypes.node.isRequired,
   disabled: PropTypes.bool,
+  errorMessage: PropTypes.string,
   expanded: PropTypes.bool,
+  hasError: PropTypes.bool,
   id: PropTypes.string,
   size: PropTypes.oneOf(['S', 'M']),
   toggle: PropTypes.func.isRequired,

--- a/packages/strapi-design-system/src/Accordion/Accordion.stories.mdx
+++ b/packages/strapi-design-system/src/Accordion/Accordion.stories.mdx
@@ -58,7 +58,7 @@ import { Box } from '@strapi/design-system/Box';
       return (
         <div>
           <Box padding={8} background="neutral100">
-            <Accordion hasError={true} errorMessage='Min length required' expanded={expanded} toggle={() => setExpanded((s) => !s)} id="acc-1" size="S">
+            <Accordion error='The component contain error(s)' expanded={expanded} toggle={() => setExpanded((s) => !s)} id="acc-1" size="S">
               <AccordionToggle title="User informations" />
               <AccordionContent>
                 <Box padding={3}>My name is John Duff</Box>
@@ -117,7 +117,7 @@ import { Box } from '@strapi/design-system/Box';
         <div>
           <Box padding={8} background="neutral0">
             <AccordionGroup
-              hasError='The components contain error(s)'
+              error='The components contain error(s)'
               footer={
                 <Flex justifyContent="center" height="48px" background="neutral150">
                   <TextButton disabled={true} startIcon={<Plus />}>
@@ -141,7 +141,7 @@ import { Box } from '@strapi/design-system/Box';
                 </Tooltip>
               }
             >
-              <Accordion hasError={true} error expanded={expanded} toggle={() => setExpanded((s) => !s)} id="acc-1" size="S">
+              <Accordion error='The components contain error(s)' expanded={expanded} toggle={() => setExpanded((s) => !s)} id="acc-1" size="S">
                 <AccordionToggle
                   startIcon={<User aria-hidden={true} />}
                   action={
@@ -157,7 +157,7 @@ import { Box } from '@strapi/design-system/Box';
                   <Box padding={3}>My name is John Duff</Box>
                 </AccordionContent>
               </Accordion>
-              <Accordion expanded={false} toggle={() => setExpanded((s) => !s)} id="acc-2" size="S">
+              <Accordion error='The component contain error(s)' expanded={false} toggle={() => setExpanded((s) => !s)} id="acc-2" size="S">
                 <AccordionToggle title="User informations" togglePosition="left" />
                 <AccordionContent>
                   <Box padding={3}>My name is John Duff</Box>

--- a/packages/strapi-design-system/src/Accordion/Accordion.stories.mdx
+++ b/packages/strapi-design-system/src/Accordion/Accordion.stories.mdx
@@ -58,7 +58,7 @@ import { Box } from '@strapi/design-system/Box';
       return (
         <div>
           <Box padding={8} background="neutral100">
-            <Accordion expanded={expanded} toggle={() => setExpanded((s) => !s)} id="acc-1" size="S">
+            <Accordion hasError={true} errorMessage='Min length required' expanded={expanded} toggle={() => setExpanded((s) => !s)} id="acc-1" size="S">
               <AccordionToggle title="User informations" />
               <AccordionContent>
                 <Box padding={3}>My name is John Duff</Box>
@@ -117,6 +117,7 @@ import { Box } from '@strapi/design-system/Box';
         <div>
           <Box padding={8} background="neutral0">
             <AccordionGroup
+              hasError='The components contain error(s)'
               footer={
                 <Flex justifyContent="center" height="48px" background="neutral150">
                   <TextButton disabled={true} startIcon={<Plus />}>
@@ -140,7 +141,7 @@ import { Box } from '@strapi/design-system/Box';
                 </Tooltip>
               }
             >
-              <Accordion expanded={expanded} toggle={() => setExpanded((s) => !s)} id="acc-1" size="S">
+              <Accordion hasError={true} error expanded={expanded} toggle={() => setExpanded((s) => !s)} id="acc-1" size="S">
                 <AccordionToggle
                   startIcon={<User aria-hidden={true} />}
                   action={
@@ -156,7 +157,7 @@ import { Box } from '@strapi/design-system/Box';
                   <Box padding={3}>My name is John Duff</Box>
                 </AccordionContent>
               </Accordion>
-              <Accordion expanded={false} toggle={() => setExpanded((s) => !s)} id="acc-2" size="S" variant="secondary">
+              <Accordion expanded={false} toggle={() => setExpanded((s) => !s)} id="acc-2" size="S">
                 <AccordionToggle title="User informations" togglePosition="left" />
                 <AccordionContent>
                   <Box padding={3}>My name is John Duff</Box>
@@ -169,12 +170,10 @@ import { Box } from '@strapi/design-system/Box';
                 </AccordionContent>
               </Accordion>
               <Accordion
-                disabled={true}
                 expanded={false}
                 toggle={() => setExpanded((s) => !s)}
                 id="acc-2"
                 size="S"
-                variant="secondary"
               >
                 <AccordionToggle startIcon={<User aria-hidden={true} />} title="User informations" togglePosition="left" />
                 <AccordionContent>

--- a/packages/strapi-design-system/src/Accordion/AccordionGroup.js
+++ b/packages/strapi-design-system/src/Accordion/AccordionGroup.js
@@ -15,6 +15,12 @@ const AccordionFooter = styled(Box)`
 
 const EnhancedGroup = styled(Box)`
   & > * {
+    & > * {
+      border-radius: unset;
+    }
+  }
+
+  & > * {
     border-radius: unset;
     border-right: 1px solid ${({ theme }) => theme.colors.neutral200};
     border-left: 1px solid ${({ theme }) => theme.colors.neutral200};
@@ -24,6 +30,9 @@ const EnhancedGroup = styled(Box)`
   & > *:first-of-type {
     border-top: 1px solid ${({ theme }) => theme.colors.neutral200};
     border-radius: ${({ theme }) => theme.borderRadius} ${({ theme }) => theme.borderRadius} 0 0;
+    & > * {
+      border-radius: ${({ theme }) => theme.borderRadius} ${({ theme }) => theme.borderRadius} 0 0;
+    }
 
     &:hover {
       border-top: 1px solid ${({ theme }) => theme.colors.primary600};

--- a/packages/strapi-design-system/src/Accordion/AccordionGroup.js
+++ b/packages/strapi-design-system/src/Accordion/AccordionGroup.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Children, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Box } from '../Box';
@@ -49,7 +49,11 @@ const LabelAction = styled(Box)`
   }
 `;
 
-export const AccordionGroup = ({ children, footer, label, labelAction, hasError }) => {
+export const AccordionGroup = ({ children, footer, label, labelAction, error }) => {
+  const childrenArray = Children.toArray(children).map((child) => {
+    return cloneElement(child, { hasErrorMessage: false });
+  });
+
   return (
     <KeyboardNavigable attributeName="data-strapi-accordion-toggle">
       {label && (
@@ -60,12 +64,12 @@ export const AccordionGroup = ({ children, footer, label, labelAction, hasError 
           {labelAction && <LabelAction paddingLeft={1}>{labelAction}</LabelAction>}
         </Flex>
       )}
-      <EnhancedGroup footer={footer}>{children}</EnhancedGroup>
+      <EnhancedGroup footer={footer}>{childrenArray}</EnhancedGroup>
       {footer && <AccordionFooter>{footer}</AccordionFooter>}
-      {hasError && (
+      {error && (
         <Box paddingTop={1}>
           <Typography variant="pi" textColor="danger600">
-            {hasError}
+            {error}
           </Typography>
         </Box>
       )}
@@ -75,15 +79,15 @@ export const AccordionGroup = ({ children, footer, label, labelAction, hasError 
 
 AccordionGroup.defaultProps = {
   footer: null,
-  hasError: undefined,
+  error: undefined,
   label: null,
   labelAction: undefined,
 };
 
 AccordionGroup.propTypes = {
   children: PropTypes.node.isRequired,
+  error: PropTypes.string,
   footer: PropTypes.node,
-  hasError: PropTypes.string,
   label: PropTypes.string,
   labelAction: PropTypes.node,
 };

--- a/packages/strapi-design-system/src/Accordion/AccordionGroup.js
+++ b/packages/strapi-design-system/src/Accordion/AccordionGroup.js
@@ -49,7 +49,7 @@ const LabelAction = styled(Box)`
   }
 `;
 
-export const AccordionGroup = ({ children, footer, label, labelAction }) => {
+export const AccordionGroup = ({ children, footer, label, labelAction, hasError }) => {
   return (
     <KeyboardNavigable attributeName="data-strapi-accordion-toggle">
       {label && (
@@ -62,12 +62,20 @@ export const AccordionGroup = ({ children, footer, label, labelAction }) => {
       )}
       <EnhancedGroup footer={footer}>{children}</EnhancedGroup>
       {footer && <AccordionFooter>{footer}</AccordionFooter>}
+      {hasError && (
+        <Box paddingTop={1}>
+          <Typography variant="pi" textColor="danger600">
+            {hasError}
+          </Typography>
+        </Box>
+      )}
     </KeyboardNavigable>
   );
 };
 
 AccordionGroup.defaultProps = {
   footer: null,
+  hasError: undefined,
   label: null,
   labelAction: undefined,
 };
@@ -75,6 +83,7 @@ AccordionGroup.defaultProps = {
 AccordionGroup.propTypes = {
   children: PropTypes.node.isRequired,
   footer: PropTypes.node,
+  hasError: PropTypes.string,
   label: PropTypes.string,
   labelAction: PropTypes.node,
 };

--- a/packages/strapi-design-system/src/Accordion/AccordionToggle.js
+++ b/packages/strapi-design-system/src/Accordion/AccordionToggle.js
@@ -76,7 +76,7 @@ export const AccordionToggle = ({ title, description, as, togglePosition, action
     >
       <Icon
         as={DropdownIcon}
-        width={size === 'M' ? `${11 / 16}rem` : `${8 / 16}rem}`}
+        width={size === 'M' ? `${11 / 16}rem` : `${8 / 16}rem`}
         color={expanded ? 'primary600' : 'neutral600'}
       />
     </Flex>

--- a/packages/strapi-design-system/src/Accordion/AccordionToggle.js
+++ b/packages/strapi-design-system/src/Accordion/AccordionToggle.js
@@ -26,6 +26,8 @@ const ToggleButton = styled(TextButton)`
 
 const FlexWithSize = styled(Flex)`
   height: ${({ theme, size }) => theme.sizes.accordions[size]};
+  border-radius: ${({ theme, expanded }) =>
+    expanded ? `${theme.borderRadius} ${theme.borderRadius} 0 0` : theme.borderRadius};
 
   &:hover {
     svg {
@@ -88,6 +90,7 @@ export const AccordionToggle = ({ title, description, as, togglePosition, action
         paddingLeft={boxPadding}
         paddingRight={boxPadding}
         background={boxBackground}
+        expanded={expanded}
         justifyContent="space-between"
         size={size}
         cursor={disabled ? 'not-allowed' : ''}
@@ -138,6 +141,7 @@ export const AccordionToggle = ({ title, description, as, togglePosition, action
       paddingRight={boxPadding}
       paddingLeft={boxPadding}
       background={boxBackground}
+      expanded={expanded}
       size={size}
       justifyContent="space-between"
       cursor={disabled ? 'not-allowed' : ''}


### PR DESCRIPTION
## What

Removed overflow hidden on Accordion causing issues when users add certain type of component inside AccordionContent needing to overflow the parent

Added the border radius with CSS selectors instead

