### PR TITLE
Update getYears.js

### DIFF
--- a/packages/strapi-design-system/src/DatePicker/utils/getYears.js
+++ b/packages/strapi-design-system/src/DatePicker/utils/getYears.js
@@ -6,5 +6,5 @@ export const getYears = () => {
 
   return Array(101)
     .fill(null)
-    .map((_, index) => currentYear - 50 + index);
+    .map((_, index) => currentYear - 125 + index);
 };


### PR DESCRIPTION
As it should be possible to use the Date field as "Birthday" -50 is a bit low