### PR TITLE
GridItem: prevent column blowout

### DIFF
--- a/packages/strapi-design-system/src/Grid/GridItem.js
+++ b/packages/strapi-design-system/src/Grid/GridItem.js
@@ -6,6 +6,7 @@ import { useGrid } from './GridContext';
 
 const GridItemWrapper = styled.div`
   grid-column: span ${({ col }) => col};
+  max-width: 100%;
 
   ${({ theme }) => theme.mediaQueries.tablet} {
     grid-column: span ${({ s }) => s};

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -18525,6 +18525,7 @@ exports[`Storyshots Design System/Components/LightTheme colors 1`] = `
 
 .c2 {
   grid-column: span;
+  max-width: 100%;
 }
 
 @media (max-width:68.75rem) {
@@ -18860,6 +18861,7 @@ exports[`Storyshots Design System/Components/LightTheme shadows 1`] = `
 
 .c3 {
   grid-column: span 3;
+  max-width: 100%;
 }
 
 @media (max-width:68.75rem) {
@@ -41548,6 +41550,7 @@ exports[`Storyshots Design System/Components/Tooltip grid 1`] = `
 
 .c3 {
   grid-column: span 3;
+  max-width: 100%;
 }
 
 @media (max-width:68.75rem) {
@@ -41721,10 +41724,12 @@ exports[`Storyshots Design System/Components/TwoColsLayout base 1`] = `
 
 .c3 {
   grid-column: span 9;
+  max-width: 100%;
 }
 
 .c6 {
   grid-column: span 3;
+  max-width: 100%;
 }
 
 @media (max-width:68.75rem) {
@@ -42862,6 +42867,7 @@ exports[`Storyshots Design System/Technical Components/Grid base 1`] = `
 
 .c2 {
   grid-column: span 1;
+  max-width: 100%;
 }
 
 @media (max-width:68.75rem) {
@@ -42952,6 +42958,7 @@ exports[`Storyshots Design System/Technical Components/Grid base grid 1`] = `
 
 .c2 {
   grid-column: span 1;
+  max-width: 100%;
 }
 
 @media (max-width:68.75rem) {
@@ -43124,18 +43131,22 @@ exports[`Storyshots Design System/Technical Components/Grid complex grid 1`] = `
 
 .c3 {
   grid-column: span 6;
+  max-width: 100%;
 }
 
 .c5 {
   grid-column: span 3;
+  max-width: 100%;
 }
 
 .c6 {
   grid-column: span 8;
+  max-width: 100%;
 }
 
 .c7 {
   grid-column: span 2;
+  max-width: 100%;
 }
 
 @media (max-width:68.75rem) {


### PR DESCRIPTION
## Description

In it's current state `GridItems` can break out the grid, if their content exceeds their width, as seen in the last column here:

![Screenshot from 2022-02-03 10-31-22](https://user-images.githubusercontent.com/2244375/152316384-cce082a5-14aa-44af-b5e0-a7a823fc0d3a.png)

Adding a `max-width: 100%` to each column ensures it's size in the grid. With that the columns falls in line with the others:

![Screenshot from 2022-02-03 10-35-44](https://user-images.githubusercontent.com/2244375/152317010-20de7e5f-cf52-4ea9-9dd2-810ed7376931.png)

