### PR TITLE
Docs: Replace default export with named imports everywhere

### DIFF
--- a/packages/strapi-design-system/src/Layout/GridLayout.stories.mdx
+++ b/packages/strapi-design-system/src/Layout/GridLayout.stories.mdx
@@ -13,7 +13,7 @@ import { Box } from '../Box';
 ## Imports
 
 ```js
-import GridLayout from '@strapi/design-system/Layout';
+import { GridLayout } from '@strapi/design-system/Layout';
 ```
 
 ## Usage

--- a/packages/strapi-design-system/src/Layout/Layout.stories.mdx
+++ b/packages/strapi-design-system/src/Layout/Layout.stories.mdx
@@ -39,7 +39,7 @@ This is the doc of the `Layout` component
 ## Imports
 
 ```js
-import Layout from '@strapi/design-system/Layout';
+import { Layout } from '@strapi/design-system/Layout';
 ```
 
 ## Usage

--- a/packages/strapi-design-system/src/Layout/TwoColsLayout.stories.mdx
+++ b/packages/strapi-design-system/src/Layout/TwoColsLayout.stories.mdx
@@ -16,7 +16,7 @@ import { Box } from '../Box';
 ## Imports
 
 ```js
-import TwoColsLayout from '@strapi/design-system/Layout';
+import { TwoColsLayout } from '@strapi/design-system/Layout';
 ```
 
 ## Usage


### PR DESCRIPTION
Some component documentation claimed that components should use default imports. All of them are using named exports and therefore should use named imports too.

Fixes: #504