### PR TITLE
Link: remove uppercase, improve typography size

### DIFF
--- a/packages/strapi-design-system/src/Link/Link.js
+++ b/packages/strapi-design-system/src/Link/Link.js
@@ -10,7 +10,6 @@ import { buttonFocusStyle } from '../themes/utils';
 const LinkWrapper = styled.a`
   display: inline-flex;
   align-items: center;
-  text-transform: uppercase;
   text-decoration: none;
   pointer-events: ${({ disabled }) => (disabled ? 'none' : undefined)};
 
@@ -55,7 +54,7 @@ export const Link = ({ href, to, children, disabled, startIcon, endIcon, ...prop
         </IconWrapper>
       )}
 
-      <Typography variant="sigma" textColor={disabled ? 'neutral600' : 'primary600'}>
+      <Typography variant="pi" textColor={disabled ? 'neutral600' : 'primary600'}>
         {children}
       </Typography>
 

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -670,10 +670,8 @@ exports[`Storyshots Design System/Components/Alert with action 1`] = `
 
 .c14 {
   color: #4945ff;
-  font-weight: 600;
-  font-size: 0.6875rem;
-  line-height: 1.45;
-  text-transform: uppercase;
+  font-size: 0.75rem;
+  line-height: 1.33;
 }
 
 .c3 {
@@ -784,7 +782,6 @@ exports[`Storyshots Design System/Components/Alert with action 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  text-transform: uppercase;
   -webkit-text-decoration: none;
   text-decoration: none;
   position: relative;
@@ -11922,10 +11919,8 @@ exports[`Storyshots Design System/Components/HeaderLayout base 1`] = `
 
 .c9 {
   color: #4945ff;
-  font-weight: 600;
-  font-size: 0.6875rem;
-  line-height: 1.45;
-  text-transform: uppercase;
+  font-size: 0.75rem;
+  line-height: 1.33;
 }
 
 .c12 {
@@ -11989,7 +11984,6 @@ exports[`Storyshots Design System/Components/HeaderLayout base 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  text-transform: uppercase;
   -webkit-text-decoration: none;
   text-decoration: none;
   position: relative;
@@ -12795,10 +12789,8 @@ exports[`Storyshots Design System/Components/HeaderLayout combined w/ scroll 1`]
 
 .c9 {
   color: #4945ff;
-  font-weight: 600;
-  font-size: 0.6875rem;
-  line-height: 1.45;
-  text-transform: uppercase;
+  font-size: 0.75rem;
+  line-height: 1.33;
 }
 
 .c12 {
@@ -12862,7 +12854,6 @@ exports[`Storyshots Design System/Components/HeaderLayout combined w/ scroll 1`]
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  text-transform: uppercase;
   -webkit-text-decoration: none;
   text-decoration: none;
   position: relative;
@@ -13293,10 +13284,8 @@ exports[`Storyshots Design System/Components/HeaderLayout sticky 1`] = `
 
 .c12 {
   color: #4945ff;
-  font-weight: 600;
-  font-size: 0.6875rem;
-  line-height: 1.45;
-  text-transform: uppercase;
+  font-size: 0.75rem;
+  line-height: 1.33;
 }
 
 .c13 {
@@ -13360,7 +13349,6 @@ exports[`Storyshots Design System/Components/HeaderLayout sticky 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  text-transform: uppercase;
   -webkit-text-decoration: none;
   text-decoration: none;
   position: relative;
@@ -19301,18 +19289,14 @@ exports[`Storyshots Design System/Components/Link base 1`] = `
 
 .c3 {
   color: #4945ff;
-  font-weight: 600;
-  font-size: 0.6875rem;
-  line-height: 1.45;
-  text-transform: uppercase;
+  font-size: 0.75rem;
+  line-height: 1.33;
 }
 
 .c7 {
   color: #666687;
-  font-weight: 600;
-  font-size: 0.6875rem;
-  line-height: 1.45;
-  text-transform: uppercase;
+  font-size: 0.75rem;
+  line-height: 1.33;
 }
 
 .c1 {
@@ -19343,7 +19327,6 @@ exports[`Storyshots Design System/Components/Link base 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  text-transform: uppercase;
   -webkit-text-decoration: none;
   text-decoration: none;
   position: relative;
@@ -19397,7 +19380,6 @@ exports[`Storyshots Design System/Components/Link base 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  text-transform: uppercase;
   -webkit-text-decoration: none;
   text-decoration: none;
   pointer-events: none;


### PR DESCRIPTION
Improves the styles of the `Link` component:

- remove text-transform
- update typography size

Refs: https://strapi-inc.atlassian.net/browse/DS-1