### PR TITLE
Tag: fix text color

### DIFF
--- a/packages/strapi-design-system/src/Tag/Tag.js
+++ b/packages/strapi-design-system/src/Tag/Tag.js
@@ -18,6 +18,7 @@ const TagWrapper = styled(Box)`
 
 const TagText = styled(Typography)`
   border-right: 1px solid ${({ theme, disabled }) => (disabled ? theme.colors.neutral300 : theme.colors.primary200)};
+  color: inherit;
   padding-right: ${({ theme }) => theme.spaces[2]};
 `;
 

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -15691,6 +15691,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
 
 .c56 {
   border-right: 1px solid #d9d8ff;
+  color: inherit;
   padding-right: 8px;
 }
 
@@ -36298,6 +36299,7 @@ exports[`Storyshots Design System/Components/Tag base 1`] = `
 
 .c5 {
   border-right: 1px solid #d9d8ff;
+  color: inherit;
   padding-right: 8px;
 }
 
@@ -36409,6 +36411,7 @@ exports[`Storyshots Design System/Components/Tag disabled 1`] = `
 
 .c5 {
   border-right: 1px solid #c0c0cf;
+  color: inherit;
   padding-right: 8px;
 }
 


### PR DESCRIPTION
This PR fixes the text color of the `Tag` component. The proper color was already set on the container, but not passed onto the text.

Disabled
![Screen Shot 2022-02-10 at 14 07 40](https://user-images.githubusercontent.com/2244375/153414520-9586d179-ae26-4b3e-a42c-21822fad38f7.png)

Enabled
![Screen Shot 2022-02-10 at 14 07 30](https://user-images.githubusercontent.com/2244375/153414524-5739c3d7-6ee8-4905-9bb2-bf5f29d9d74c.png)


Refs: https://strapi-inc.atlassian.net/browse/DS-2