### PR TITLE
MenuItem: Disable hover styles when aria-disabled is set

### DIFF
--- a/packages/strapi-design-system/src/SimpleMenu/SimpleMenu.stories.mdx
+++ b/packages/strapi-design-system/src/SimpleMenu/SimpleMenu.stories.mdx
@@ -31,6 +31,8 @@ import { SimpleMenu, MenuItem } from '@strapi/design-system/SimpleMenu';
 
 The label of the menu can be replaced by the option selected. For instance, in a Date picker component, the menu label will be replaced by the active month.
 
+By passing `aria-disabled` hover styles on `MenuItem`s can be disabled.
+
 <Canvas>
   <Story
     name="base"

--- a/packages/strapi-design-system/src/SimpleMenu/utils.js
+++ b/packages/strapi-design-system/src/SimpleMenu/utils.js
@@ -6,7 +6,7 @@ export const getOptionStyle = ({ theme }) => `
     &:focus {
         background-color: ${theme.colors.primary100};
     }
-    &:hover {
+    &:not([aria-disabled]):hover {
         background-color: ${theme.colors.primary100};
     }
 `;


### PR DESCRIPTION
When `aria-disabled` is passed into `MenuItem` hover styles should be disabled. The issue was discovered in https://github.com/strapi/strapi/pull/12213#discussion_r803889633.