### PR TITLE
Fix popover repositioning

### DIFF
--- a/packages/strapi-design-system/src/Popover/Popover.js
+++ b/packages/strapi-design-system/src/Popover/Popover.js
@@ -87,7 +87,7 @@ const PopoverContent = ({ source, children, spacing, fullWidth, onReachEnd, inte
     position(source.current, popoverRef.current, fullWidth, centered, spacing),
   );
 
-  useResizeObserver(source, () =>
+  useResizeObserver([source, popoverRef], () =>
     setPosition(position(source.current, popoverRef.current, fullWidth, centered, spacing)),
   );
   useIntersection(popoverRef, onReachEnd, {

--- a/packages/strapi-design-system/src/helpers/useResizeObserver.js
+++ b/packages/strapi-design-system/src/helpers/useResizeObserver.js
@@ -1,9 +1,13 @@
 import { useEffect } from 'react';
 
-export const useResizeObserver = (source, onResize) => {
+export const useResizeObserver = (sources, onResize) => {
   useEffect(() => {
     const resizeObs = new ResizeObserver(onResize);
-    resizeObs.observe(source.current);
+    if (Array.isArray(sources)) {
+      sources.map((source) => resizeObs.observe(source.current));
+    } else {
+      resizeObs.observe(sources.current);
+    }
 
     return () => {
       resizeObs.disconnect();


### PR DESCRIPTION
Fix popover repositioning. Useful for the Combobox component.

| Before         | After     |
|--------------|-----------|
| ![before](https://user-images.githubusercontent.com/7756284/154098560-7275a522-433a-4e9c-910e-f19f0b78e71f.gif) | ![after](https://user-images.githubusercontent.com/7756284/154098552-ea5affae-4c46-456f-9e74-2efad846b0a2.gif) |