### PR TITLE
Remove react-router-dom peer dependency + Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ Strapi Design System provides guidelines and tools to help anyone make Strapi's 
 Install Strapi Design System and its peer dependencies:
 
 ```sh
-$ yarn add @strapi/design-system @strapi/icons styled-components react-router-dom
+$ yarn add @strapi/design-system @strapi/icons styled-components
 
 # or
 
-$ npm i @strapi/design-system @strapi/icons styled-components react-router-dom
+$ npm i @strapi/design-system @strapi/icons styled-components
 ```
 
 ## Usage

--- a/packages/strapi-design-system/.storybook/preview.js
+++ b/packages/strapi-design-system/.storybook/preview.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
 import { ThemeProvider } from '../src/ThemeProvider';
 import { VisuallyHidden } from '../src/VisuallyHidden';
 import { lightTheme } from '../src/themes/light-theme';
@@ -15,7 +14,6 @@ export const parameters = {
 
 export const decorators = [
   (Story) => (
-    <MemoryRouter>
       <ThemeProvider theme={lightTheme}>
         <main>
           <VisuallyHidden>
@@ -26,6 +24,5 @@ export const decorators = [
           <Story />
         </main>
       </ThemeProvider>
-    </MemoryRouter>
   ),
 ];

--- a/packages/strapi-design-system/package.json
+++ b/packages/strapi-design-system/package.json
@@ -35,7 +35,6 @@
     "react": "^17.0.1",
     "react-copy-to-clipboard": "^5.0.4",
     "react-dom": "^17.0.1",
-    "react-router-dom": "^5.2.0",
     "styled-components": "^5.2.1",
     "webpack-bundle-analyzer": "^4.4.0",
     "webpack-cli": "^4.5.0"
@@ -44,7 +43,6 @@
     "@strapi/icons": "^0.0.1-alpha.73",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "react-router-dom": "^5.2.0",
     "styled-components": "^5.2.1"
   },
   "dependencies": {

--- a/packages/strapi-design-system/src/Accordion/Accordion.stories.mdx
+++ b/packages/strapi-design-system/src/Accordion/Accordion.stories.mdx
@@ -1,7 +1,7 @@
 <!--- Accordion.stories.mdx --->
 
 import { useState } from 'react';
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { Accordion } from './Accordion';
 import { AccordionToggle } from './AccordionToggle';

--- a/packages/strapi-design-system/src/Alert/Alert.stories.mdx
+++ b/packages/strapi-design-system/src/Alert/Alert.stories.mdx
@@ -1,7 +1,7 @@
 <!--- Alert.stories.mdx --->
 
 import { useState } from 'react';
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { Alert } from './Alert';
 import { Box } from '../Box';

--- a/packages/strapi-design-system/src/Avatar/Avatar.stories.mdx
+++ b/packages/strapi-design-system/src/Avatar/Avatar.stories.mdx
@@ -1,6 +1,6 @@
 <!--- Avatar.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { Avatar, Initials } from './Avatar';
 import { AvatarGroup } from './AvatarGroup';

--- a/packages/strapi-design-system/src/Badge/Badge.stories.mdx
+++ b/packages/strapi-design-system/src/Badge/Badge.stories.mdx
@@ -1,6 +1,6 @@
 <!--- Badge.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { Badge } from './Badge';
 import { Stack } from '../Stack';

--- a/packages/strapi-design-system/src/BaseButton/BaseButton.stories.mdx
+++ b/packages/strapi-design-system/src/BaseButton/BaseButton.stories.mdx
@@ -1,6 +1,6 @@
 <!--- BaseButton.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { BaseButton } from './BaseButton';
 

--- a/packages/strapi-design-system/src/BaseCheckbox/BaseCheckbox.stories.mdx
+++ b/packages/strapi-design-system/src/BaseCheckbox/BaseCheckbox.stories.mdx
@@ -1,7 +1,7 @@
 <!--- Button.stories.mdx --->
 
 import { useState } from 'react';
-import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs';
 import { BaseCheckbox } from './BaseCheckbox';
 
 <Meta title="Design System/Technical Components/BaseCheckbox" component={BaseCheckbox} />

--- a/packages/strapi-design-system/src/BaseLink/BaseLink.js
+++ b/packages/strapi-design-system/src/BaseLink/BaseLink.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+const A = styled.a`
+  cursor: pointer;
+`;
+
+export const BaseLink = ({ href, rel, target, disabled, ...props }) => {
+  return (
+    <A
+      target={href ? target : undefined}
+      rel={href ? rel : undefined}
+      href={disabled ? '#' : href}
+      disabled={disabled}
+      {...props}
+    />
+  );
+};
+
+BaseLink.displayName = 'BaseLink';
+
+BaseLink.defaultProps = {
+  disabled: false,
+  href: undefined,
+  rel: 'noreferrer noopener',
+  target: '_blank',
+};
+
+BaseLink.propTypes = {
+  disabled: PropTypes.bool,
+  href: PropTypes.string,
+  rel: PropTypes.string,
+  target: PropTypes.string,
+};

--- a/packages/strapi-design-system/src/BaseLink/BaseLink.js
+++ b/packages/strapi-design-system/src/BaseLink/BaseLink.js
@@ -6,30 +6,33 @@ const A = styled.a`
   cursor: pointer;
 `;
 
-export const BaseLink = ({ href, rel, target, disabled, ...props }) => {
+export const BaseLink = React.forwardRef(({ href, rel, target, disabled, isExternal, ...props }, ref) => {
   return (
     <A
-      target={href ? target : undefined}
-      rel={href ? rel : undefined}
+      ref={ref}
+      target={isExternal ? '_blank' : target}
+      rel={isExternal ? rel : undefined}
       href={disabled ? '#' : href}
       disabled={disabled}
       {...props}
     />
   );
-};
+});
 
 BaseLink.displayName = 'BaseLink';
 
 BaseLink.defaultProps = {
   disabled: false,
   href: undefined,
+  isExternal: false,
   rel: 'noreferrer noopener',
-  target: '_blank',
+  target: '_self',
 };
 
 BaseLink.propTypes = {
   disabled: PropTypes.bool,
   href: PropTypes.string,
+  isExternal: PropTypes.bool,
   rel: PropTypes.string,
   target: PropTypes.string,
 };

--- a/packages/strapi-design-system/src/BaseLink/BaseLink.stories.mdx
+++ b/packages/strapi-design-system/src/BaseLink/BaseLink.stories.mdx
@@ -1,0 +1,31 @@
+<!--- BaseLink.stories.mdx --->
+
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
+import { ArgsTable } from '@storybook/addon-docs';
+import { BaseLink } from './BaseLink';
+
+<Meta title="Design System/Technical Components/BaseLink" component={BaseLink} />
+
+# BaseLink
+
+BaseLink allow users to navigate to a different location. This is a very basic implementation of the native HTML anchor `<a />` element.
+
+[View source](https://github.com/strapi/design-system/tree/main/packages/strapi-design-system/src/BaseLink)
+
+## Imports
+
+```js
+import { BaseLink } from '@strapi/design-system/BaseLink';
+```
+
+## Usage
+
+<Canvas>
+  <Story name="base">
+    <BaseLink href="https://strapi.io">Base link</BaseLink>
+  </Story>
+</Canvas>
+
+## Props
+
+<ArgsTable of={BaseLink} />

--- a/packages/strapi-design-system/src/BaseLink/BaseLink.stories.mdx
+++ b/packages/strapi-design-system/src/BaseLink/BaseLink.stories.mdx
@@ -22,7 +22,7 @@ import { BaseLink } from '@strapi/design-system/BaseLink';
 
 <Canvas>
   <Story name="base">
-    <BaseLink href="https://strapi.io">Base link</BaseLink>
+    <BaseLink href="https://strapi.io" isExternal>Base link</BaseLink>
   </Story>
 </Canvas>
 

--- a/packages/strapi-design-system/src/BaseLink/__tests__/BaseLink.e2e.js
+++ b/packages/strapi-design-system/src/BaseLink/__tests__/BaseLink.e2e.js
@@ -1,0 +1,15 @@
+import { injectAxe, checkA11y } from 'axe-playwright';
+
+describe('BaseLink', () => {
+  beforeEach(async () => {
+    // This is the URL of the Storybook Iframe
+    await page.goto(
+      'http://localhost:6006/iframe.html?id=design-system-technical-components-baselink--base&viewMode=story',
+    );
+    await injectAxe(page);
+  });
+
+  it('triggers axe on the document', async () => {
+    await checkA11y(page);
+  });
+});

--- a/packages/strapi-design-system/src/BaseLink/__tests__/BaseLink.spec.js
+++ b/packages/strapi-design-system/src/BaseLink/__tests__/BaseLink.spec.js
@@ -19,6 +19,7 @@ describe('BaseLink', () => {
 
       <a
         class="c0"
+        target="_self"
       />
     `);
   });

--- a/packages/strapi-design-system/src/BaseLink/__tests__/BaseLink.spec.js
+++ b/packages/strapi-design-system/src/BaseLink/__tests__/BaseLink.spec.js
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { BaseLink } from '../BaseLink';
+import { ThemeProvider } from '../../ThemeProvider';
+import { lightTheme } from '../../themes';
+
+describe('BaseLink', () => {
+  it('snapshots the component', () => {
+    const { container } = render(
+      <ThemeProvider theme={lightTheme}>
+        <BaseLink />
+      </ThemeProvider>,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      .c0 {
+        cursor: pointer;
+      }
+
+      <a
+        class="c0"
+      />
+    `);
+  });
+});

--- a/packages/strapi-design-system/src/BaseLink/index.js
+++ b/packages/strapi-design-system/src/BaseLink/index.js
@@ -1,0 +1,1 @@
+export * from './BaseLink';

--- a/packages/strapi-design-system/src/BaseRadio/BaseRadio.stories.mdx
+++ b/packages/strapi-design-system/src/BaseRadio/BaseRadio.stories.mdx
@@ -1,7 +1,7 @@
 <!--- Radio.stories.mdx --->
 
 import { useState } from 'react';
-import { Meta, Story, Canvas, Source, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Source, ArgsTable } from '@storybook/addon-docs';
 import { BaseRadio } from './BaseRadio';
 import { RadioGroup } from './RadioGroup';
 

--- a/packages/strapi-design-system/src/Box/Box.stories.mdx
+++ b/packages/strapi-design-system/src/Box/Box.stories.mdx
@@ -1,6 +1,6 @@
 <!--- Button.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { Box } from './Box';
 import { BoxProps } from './BoxProps';

--- a/packages/strapi-design-system/src/Breadcrumbs/Breadcrumbs.stories.mdx
+++ b/packages/strapi-design-system/src/Breadcrumbs/Breadcrumbs.stories.mdx
@@ -1,6 +1,6 @@
 <!--- Breadcrumbs.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { Breadcrumbs, Crumb } from './Breadcrumbs';
 import { Stack } from '../Stack';

--- a/packages/strapi-design-system/src/Button/Button.stories.mdx
+++ b/packages/strapi-design-system/src/Button/Button.stories.mdx
@@ -1,6 +1,6 @@
 <!--- Button.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import Information from '@strapi/icons/Information';
 import Plus from '@strapi/icons/Plus';

--- a/packages/strapi-design-system/src/Card/Card.stories.mdx
+++ b/packages/strapi-design-system/src/Card/Card.stories.mdx
@@ -1,6 +1,6 @@
 <!--- Card.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import Pencil from '@strapi/icons/Pencil';
 import { Box } from '../Box';

--- a/packages/strapi-design-system/src/CarouselInput/Carousel.stories.mdx
+++ b/packages/strapi-design-system/src/CarouselInput/Carousel.stories.mdx
@@ -1,6 +1,6 @@
 <!--- CarouselInput.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { useState } from 'react';
 import Pencil from '@strapi/icons/Pencil';

--- a/packages/strapi-design-system/src/Checkbox/Checkbox.stories.mdx
+++ b/packages/strapi-design-system/src/Checkbox/Checkbox.stories.mdx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { ArgsTable } from '@storybook/addon-docs';
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { Checkbox } from './Checkbox';
 
 <Meta title="Design System/Components/Checkbox" component={Checkbox} />

--- a/packages/strapi-design-system/src/Combobox/Combobox.stories.mdx
+++ b/packages/strapi-design-system/src/Combobox/Combobox.stories.mdx
@@ -1,7 +1,7 @@
 <!--- Combobox.stories.mdx --->
 
 import { useState, useRef } from 'react';
-import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs';
 import Trash from '@strapi/icons/Trash';
 import { Combobox, CreatableCombobox } from './Combobox';
 import { ComboboxOption } from './ComboboxOption';

--- a/packages/strapi-design-system/src/DatePicker/DatePicker.stories.mdx
+++ b/packages/strapi-design-system/src/DatePicker/DatePicker.stories.mdx
@@ -1,7 +1,7 @@
 <!--- DatePicker.stories.mdx --->
 
 import { useState } from 'react';
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { DatePicker } from './DatePicker';
 

--- a/packages/strapi-design-system/src/Dialog/Dialog.stories.mdx
+++ b/packages/strapi-design-system/src/Dialog/Dialog.stories.mdx
@@ -1,7 +1,7 @@
 <!--- Dialog.stories.mdx --->
 
 import { useState } from 'react';
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { Typography } from '../Typography';
 import { Stack } from '../Stack';

--- a/packages/strapi-design-system/src/Divider/Divider.stories.mdx
+++ b/packages/strapi-design-system/src/Divider/Divider.stories.mdx
@@ -1,6 +1,6 @@
 <!--- Divider.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { Divider } from './Divider';
 import { Box } from '../Box';

--- a/packages/strapi-design-system/src/EmptyStateLayout/EmptyStateLayout.stories.mdx
+++ b/packages/strapi-design-system/src/EmptyStateLayout/EmptyStateLayout.stories.mdx
@@ -1,6 +1,6 @@
 <!--- EmptyStateLayout.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import Plus from '@strapi/icons/Plus';
 import { Illo } from './story-assets/Illo';

--- a/packages/strapi-design-system/src/Field/Field.stories.mdx
+++ b/packages/strapi-design-system/src/Field/Field.stories.mdx
@@ -1,7 +1,7 @@
 <!--- Field.stories.mdx --->
 
 import { useState } from 'react';
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import Password from '@strapi/icons/Password';
 import Information from '@strapi/icons/Information';

--- a/packages/strapi-design-system/src/Flex/Flex.stories.mdx
+++ b/packages/strapi-design-system/src/Flex/Flex.stories.mdx
@@ -1,6 +1,6 @@
 <!--- Flex.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { Flex } from './Flex';
 import { FlexProps } from './FlexProps';

--- a/packages/strapi-design-system/src/FocusTrap/FocusTrap.stories.mdx
+++ b/packages/strapi-design-system/src/FocusTrap/FocusTrap.stories.mdx
@@ -1,6 +1,6 @@
 <!--- FocusTrap.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { FocusTrap } from './FocusTrap';
 import { ExampleComponent } from './ExampleComponent';

--- a/packages/strapi-design-system/src/Grid/Grid.stories.mdx
+++ b/packages/strapi-design-system/src/Grid/Grid.stories.mdx
@@ -1,6 +1,6 @@
 <!--- Grid.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { Grid } from './Grid';
 import { GridItem } from './GridItem';

--- a/packages/strapi-design-system/src/IconButton/IconButton.stories.mdx
+++ b/packages/strapi-design-system/src/IconButton/IconButton.stories.mdx
@@ -1,6 +1,6 @@
 <!--- IconButton.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import Pencil from '@strapi/icons/Pencil';
 import Play from '@strapi/icons/Play';

--- a/packages/strapi-design-system/src/Layout/GridLayout.stories.mdx
+++ b/packages/strapi-design-system/src/Layout/GridLayout.stories.mdx
@@ -1,6 +1,6 @@
 <!--- GridLayout.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { GridLayout } from './GridLayout';
 import { Box } from '../Box';
 

--- a/packages/strapi-design-system/src/Layout/HeaderLayout.stories.mdx
+++ b/packages/strapi-design-system/src/Layout/HeaderLayout.stories.mdx
@@ -1,7 +1,7 @@
 <!--- HeaderLayout.stories.mdx --->
 
 import { useState } from 'react';
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import ArrowLeft from '@strapi/icons/ArrowLeft';
 import Pencil from '@strapi/icons/Pencil';

--- a/packages/strapi-design-system/src/Layout/Layout.stories.mdx
+++ b/packages/strapi-design-system/src/Layout/Layout.stories.mdx
@@ -1,6 +1,6 @@
 <!--- Layout.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import Apps from '@strapi/icons/Apps';
 import Key from '@strapi/icons/Key';
@@ -10,7 +10,6 @@ import Plus from '@strapi/icons/Plus';
 import Pencil from '@strapi/icons/Pencil';
 import ArrowLeft from '@strapi/icons/ArrowLeft';
 import Trash from '@strapi/icons/Trash';
-import { MemoryRouter } from 'react-router-dom';
 import { SubNav, SubNavHeader, SubNavSection, SubNavSections, SubNavLink, SubNavLinkSection } from '../SubNav';
 import { Link } from '../Link';
 import { Layout } from './Layout';

--- a/packages/strapi-design-system/src/Layout/TwoColsLayout.stories.mdx
+++ b/packages/strapi-design-system/src/Layout/TwoColsLayout.stories.mdx
@@ -1,6 +1,6 @@
 <!--- TwoColsLayout.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { TwoColsLayout } from './TwoColsLayout';
 import { Box } from '../Box';

--- a/packages/strapi-design-system/src/Link/Link.js
+++ b/packages/strapi-design-system/src/Link/Link.js
@@ -2,12 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import ExternalLink from '@strapi/icons/ExternalLink';
-import { NavLink } from 'react-router-dom';
 import { Typography } from '../Typography';
 import { Box } from '../Box';
 import { buttonFocusStyle } from '../themes/utils';
+import { BaseLink } from '../BaseLink';
 
-const LinkWrapper = styled.a`
+const LinkWrapper = styled(BaseLink)`
   display: inline-flex;
   align-items: center;
   text-decoration: none;
@@ -33,21 +33,9 @@ const IconWrapper = styled(Box)`
   display: flex;
 `;
 
-// TODO: make sure to use the link from the router library chosen
-export const Link = ({ href, to, children, disabled, startIcon, endIcon, ...props }) => {
-  const target = href ? '_blank' : undefined;
-  const rel = href ? 'noreferrer noopener' : undefined;
-
+export const Link = ({ children, href, disabled, startIcon, endIcon, ...props }) => {
   return (
-    <LinkWrapper
-      as={to && !disabled ? NavLink : 'a'}
-      target={target}
-      rel={rel}
-      to={disabled ? undefined : to}
-      href={disabled ? '#' : href}
-      disabled={disabled}
-      {...props}
-    >
+    <LinkWrapper href={href} disabled={disabled} {...props}>
       {startIcon && (
         <IconWrapper as="span" aria-hidden={true} paddingRight={2}>
           {startIcon}
@@ -58,13 +46,13 @@ export const Link = ({ href, to, children, disabled, startIcon, endIcon, ...prop
         {children}
       </Typography>
 
-      {endIcon && !href && (
+      {endIcon && (
         <IconWrapper as="span" aria-hidden={true} paddingLeft={2}>
           {endIcon}
         </IconWrapper>
       )}
 
-      {href && (
+      {href && !endIcon && (
         <IconWrapper as="span" aria-hidden={true} paddingLeft={2}>
           <ExternalLink />
         </IconWrapper>
@@ -76,24 +64,18 @@ export const Link = ({ href, to, children, disabled, startIcon, endIcon, ...prop
 Link.displayName = 'Link';
 
 Link.defaultProps = {
+  as: undefined,
   href: undefined,
-  to: undefined,
   disabled: false,
+  startIcon: undefined,
+  endIcon: undefined,
 };
 
 Link.propTypes = {
+  as: PropTypes.elementType,
   children: PropTypes.node.isRequired,
   disabled: PropTypes.bool,
   endIcon: PropTypes.element,
-  href: (props) => {
-    if (!props.disabled && !props.to && !props.href) {
-      return new Error('href must be defined');
-    }
-  },
+  href: PropTypes.string,
   startIcon: PropTypes.element,
-  to: (props) => {
-    if (!props.disabled && !props.href && !props.to) {
-      return new Error('to must be defined');
-    }
-  },
 };

--- a/packages/strapi-design-system/src/Link/Link.js
+++ b/packages/strapi-design-system/src/Link/Link.js
@@ -33,9 +33,9 @@ const IconWrapper = styled(Box)`
   display: flex;
 `;
 
-export const Link = ({ children, href, disabled, startIcon, endIcon, ...props }) => {
+export const Link = React.forwardRef(({ children, href, disabled, startIcon, endIcon, ...props }, ref) => {
   return (
-    <LinkWrapper href={href} disabled={disabled} {...props}>
+    <LinkWrapper ref={ref} href={href} disabled={disabled} {...props}>
       {startIcon && (
         <IconWrapper as="span" aria-hidden={true} paddingRight={2}>
           {startIcon}
@@ -59,7 +59,7 @@ export const Link = ({ children, href, disabled, startIcon, endIcon, ...props })
       )}
     </LinkWrapper>
   );
-};
+});
 
 Link.displayName = 'Link';
 

--- a/packages/strapi-design-system/src/Link/Link.stories.mdx
+++ b/packages/strapi-design-system/src/Link/Link.stories.mdx
@@ -1,11 +1,12 @@
 <!--- Link.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import ChevronRight from '@strapi/icons/ChevronRight';
 import ArrowLeft from '@strapi/icons/ArrowLeft';
 import { Link } from './Link';
 import { Stack } from '../Stack';
+import Strapi from '@strapi/icons/Strapi';
 
 <Meta title="Design System/Components/Link" component={Link} />
 
@@ -40,24 +41,7 @@ The simplest representation of the Link component.
 <Canvas>
   <Story name="base">
     <Stack size={5}>
-      <div>
-        <Link to="https://strapi.io/">External link</Link>
-      </div>
-      <div>
-        <Link to="/somewhere-internal" startIcon={<ArrowLeft />}>
-          Internal link
-        </Link>
-      </div>
-      <div>
-        <Link to="https://strapi.io/" disabled>
-          External disabled link
-        </Link>
-      </div>
-      <div>
-        <Link to="/somewhere-internal" disabled startIcon={<ArrowLeft />} endIcon={<ChevronRight />}>
-          Internal disabled link
-        </Link>
-      </div>
+      <Link href="https://strapi.io/">External link</Link>
     </Stack>
   </Story>
 </Canvas>
@@ -65,6 +49,64 @@ The simplest representation of the Link component.
 ### Disabled link
 
 Depending on the permissions a user have or the status of an action, a link can be unreachable or unavailable yet.
+
+<Canvas>
+  <Story name="disabled">
+    <Stack size={5}>
+      <Link href="https://strapi.io/" disabled>
+        Disabled link
+      </Link>
+    </Stack>
+  </Story>
+</Canvas>
+
+### Start & end icons
+
+Display icons on the left or right side.
+
+<Canvas>
+  <Story name="icons">
+    <Stack size={5}>
+      <div>
+        <Link href="https://strapi.io/" startIcon={<Strapi />}>
+          Strapi
+        </Link>
+      </div>
+      <div>
+        <Link href="https://strapi.io/" endIcon={<Strapi />}>
+          Strapi
+        </Link>
+      </div>
+    </Stack>
+  </Story>
+</Canvas>
+
+### Usage with other routing libraries
+
+To use the Link component with a routing library (e.g. react-router-dom), you'll need to pass the `NavLink` component to the `as` prop in order to replace the default HTML anchor `<a />`.
+You'll now be able to pass all `NavLink` props.
+
+```jsx
+import { Link } from '@strapi/design-system/Link';
+import { NavLink } from 'react-router-dom';
+
+<Link as={NavLink} to="/home">
+  Home
+</Link>;
+```
+
+#### NextJS usage
+
+For NextJS, you'll need to wrap the `Link` with the `NextLink` component
+
+```jsx
+import { Link } from '@strapi/design-system/Link';
+import NextLink from 'next/link';
+
+<NextLink href="/home" passHref>
+  <Link>Home</Link>
+</NextLink>;
+```
 
 ## Props
 

--- a/packages/strapi-design-system/src/Link/Link.stories.mdx
+++ b/packages/strapi-design-system/src/Link/Link.stories.mdx
@@ -41,7 +41,9 @@ The simplest representation of the Link component.
 <Canvas>
   <Story name="base">
     <Stack size={5}>
-      <Link href="https://strapi.io/">External link</Link>
+      <Link isExternal href="https://strapi.io/">
+        External link
+      </Link>
     </Stack>
   </Story>
 </Canvas>
@@ -53,7 +55,7 @@ Depending on the permissions a user have or the status of an action, a link can 
 <Canvas>
   <Story name="disabled">
     <Stack size={5}>
-      <Link href="https://strapi.io/" disabled>
+      <Link isExternal href="https://strapi.io/" disabled>
         Disabled link
       </Link>
     </Stack>
@@ -68,12 +70,12 @@ Display icons on the left or right side.
   <Story name="icons">
     <Stack size={5}>
       <div>
-        <Link href="https://strapi.io/" startIcon={<Strapi />}>
+        <Link isExternal href="https://strapi.io/" startIcon={<Strapi />}>
           Strapi
         </Link>
       </div>
       <div>
-        <Link href="https://strapi.io/" endIcon={<Strapi />}>
+        <Link isExternal href="https://strapi.io/" endIcon={<Strapi />}>
           Strapi
         </Link>
       </div>

--- a/packages/strapi-design-system/src/LinkButton/LinkButton.js
+++ b/packages/strapi-design-system/src/LinkButton/LinkButton.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { NavLink } from 'react-router-dom';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { Typography } from '../Typography';
@@ -7,6 +6,7 @@ import { Box } from '../Box';
 import { getDisabledStyle, getHoverStyle, getActiveStyle, getVariantStyle } from '../Button/utils';
 import { VARIANTS, BUTTON_SIZES } from '../Button/constants';
 import { BaseButtonWrapper } from '../BaseButton';
+import { BaseLink } from '../BaseLink';
 
 const LinkWrapper = styled(BaseButtonWrapper)`
   padding: ${({ theme, size }) => `${size === 'S' ? theme.spaces[2] : '10px'} ${theme.spaces[4]}`};
@@ -43,23 +43,9 @@ const LinkWrapper = styled(BaseButtonWrapper)`
 `;
 
 export const LinkButton = React.forwardRef(
-  ({ variant, startIcon, endIcon, disabled, children, size, href, to, ...props }, ref) => {
-    const target = href ? '_blank' : undefined;
-    const rel = href ? 'noreferrer noopener' : undefined;
-
+  ({ variant, startIcon, endIcon, disabled, children, size, as, ...props }, ref) => {
     return (
-      <LinkWrapper
-        ref={ref}
-        aria-disabled={disabled}
-        size={size}
-        variant={variant}
-        target={target}
-        rel={rel}
-        to={disabled ? undefined : to}
-        href={disabled ? '#' : href}
-        {...props}
-        as={to && !disabled ? NavLink : 'a'}
-      >
+      <LinkWrapper ref={ref} aria-disabled={disabled} size={size} variant={variant} {...props} as={as || BaseLink}>
         {startIcon && (
           <Box aria-hidden={true} paddingRight={2}>
             {startIcon}
@@ -87,6 +73,7 @@ export const LinkButton = React.forwardRef(
 LinkButton.displayName = 'LinkButton';
 
 LinkButton.defaultProps = {
+  as: BaseLink,
   disabled: false,
   startIcon: undefined,
   endIcon: undefined,
@@ -97,6 +84,7 @@ LinkButton.defaultProps = {
   to: undefined,
 };
 LinkButton.propTypes = {
+  as: PropTypes.elementType,
   children: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   endIcon: PropTypes.element,

--- a/packages/strapi-design-system/src/LinkButton/LinkButton.stories.mdx
+++ b/packages/strapi-design-system/src/LinkButton/LinkButton.stories.mdx
@@ -1,6 +1,6 @@
 <!--- LinkButton.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import Information from '@strapi/icons/Information';
 import Write from '@strapi/icons/Write';
@@ -42,7 +42,7 @@ Use the `to` parameter to redirect using the router's routes, `href` parameter f
 <Canvas>
   <Story name="base">
     <Box paddingBottom={2}>
-      <LinkButton variant="default" to="/">
+      <LinkButton variant="default" href="https://strapi.io/">
         Default
       </LinkButton>
     </Box>
@@ -120,6 +120,33 @@ For all actions that cannot be performed yet, you can use the disabled state.
     </Box>
   </Story>
 </Canvas>
+
+### Usage with other routing libraries
+
+To use the LinkButton component with a routing library (e.g. react-router-dom), you'll need to pass the `NavLink` component to the `as` prop in order to replace the default HTML anchor `<a />`.
+You'll now be able to pass all `NavLink` props.
+
+```jsx
+import { LinkButton } from '@strapi/design-system/LinkButton';
+import { NavLink } from 'react-router-dom';
+
+<LinkButton as={NavLink} to="/home">
+  Home
+</LinkButton>;
+```
+
+#### NextJS usage
+
+For NextJS, you'll need to wrap the `LinkButton` with the `NextLink` component
+
+```jsx
+import { LinkButton } from '@strapi/design-system/LinkButton';
+import NextLink from 'next/link';
+
+<NextLink href="/home" passHref>
+  <LinkButton>Home</LinkButton>
+</NextLink>;
+```
 
 ## Props
 

--- a/packages/strapi-design-system/src/LiveRegions/LiveRegions.stories.mdx
+++ b/packages/strapi-design-system/src/LiveRegions/LiveRegions.stories.mdx
@@ -1,7 +1,7 @@
 <!--- LiveRegions.stories.mdx --->
 
 import { useState } from 'react';
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { LiveRegions } from './LiveRegions';
 import { StoryComponent } from './StoryComponent';
 import { Stack } from '../Stack';

--- a/packages/strapi-design-system/src/Loader/Loader.stories.mdx
+++ b/packages/strapi-design-system/src/Loader/Loader.stories.mdx
@@ -1,6 +1,6 @@
 <!--- Loader.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { Loader } from './Loader';
 

--- a/packages/strapi-design-system/src/MainNav/MainNav.stories.mdx
+++ b/packages/strapi-design-system/src/MainNav/MainNav.stories.mdx
@@ -1,7 +1,7 @@
 <!--- MainNav.stories.mdx --->
 
 import { useState } from 'react';
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import Write from '@strapi/icons/Write';
 import Layer from '@strapi/icons/Layer';
@@ -167,6 +167,33 @@ Exception made for core plugins (i.e. Content Manager, Content-types Builder, Me
     }}
   </Story>
 </Canvas>
+
+### Usage with other routing libraries
+
+To use the Strapi design system NavLink/NavBrand component with a routing library (e.g. react-router-dom), you'll need to pass the react-router-dom `NavLink` component to the `as` prop in order to replace the default HTML anchor `<a />`.
+You'll now be able to pass all the react-router-dom `NavLink` props.
+
+```jsx
+import { NavLink } from '@strapi/design-system/NavLink';
+import { NavLink as RouterNavLink } from 'react-router-dom';
+
+<NavLink as={RouterNavLink} to="/home">
+  Home
+</NavLink>;
+```
+
+#### NextJS usage
+
+For NextJS, you'll need to wrap the `NavLink` with the `NextLink` component
+
+```jsx
+import { NavLink } from '@strapi/design-system/NavLink';
+import NextLink from 'next/link';
+
+<NextLink href="/home" passHref>
+  <NavLink>Home</NavLink>
+</NextLink>;
+```
 
 ## Props
 

--- a/packages/strapi-design-system/src/MainNav/NavBrand.js
+++ b/packages/strapi-design-system/src/MainNav/NavBrand.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { NavLink } from 'react-router-dom';
 import { Box } from '../Box';
 import { Typography } from '../Typography';
 import { Flex } from '../Flex';
 import { useMainNav } from './MainNavContext';
 import { VisuallyHidden } from '../VisuallyHidden';
+import { BaseLink } from '../BaseLink';
 
 const BrandIconWrapper = styled.div`
   border-radius: ${({ theme }) => theme.borderRadius};
@@ -18,50 +18,50 @@ const BrandIconWrapper = styled.div`
   }
 `;
 
-const NavLinkWrapper = styled(NavLink)`
+const NavLinkWrapper = styled(BaseLink)`
   text-decoration: unset;
   color: inherit;
 `;
 
-export const NavBrand = ({ workplace, title, icon, to }) => {
+export const NavBrand = ({ workplace, title, icon, ...props }) => {
   const condensed = useMainNav();
 
   if (condensed) {
     return (
-      <Box paddingLeft={3} paddingRight={3} paddingTop={4} paddingBottom={4}>
-        <BrandIconWrapper condensed={true}>
-          <NavLink to={to}>
+      <BaseLink {...props}>
+        <Box paddingLeft={3} paddingRight={3} paddingTop={4} paddingBottom={4}>
+          <BrandIconWrapper condensed={true}>
             {icon}
             <VisuallyHidden>
               <span>{title}</span>
               <span>{workplace}</span>
             </VisuallyHidden>
-          </NavLink>
-        </BrandIconWrapper>
-      </Box>
+          </BrandIconWrapper>
+        </Box>
+      </BaseLink>
     );
   }
 
   return (
-    <Box paddingLeft={3} paddingRight={3} paddingTop={4} paddingBottom={4}>
-      <Flex>
-        <BrandIconWrapper as={NavLink} to={to} aria-hidden tabIndex={-1}>
-          {icon}
-        </BrandIconWrapper>
+    <NavLinkWrapper {...props}>
+      <Box paddingLeft={3} paddingRight={3} paddingTop={4} paddingBottom={4}>
+        <Flex>
+          <BrandIconWrapper aria-hidden tabIndex={-1}>
+            {icon}
+          </BrandIconWrapper>
 
-        <Box paddingLeft={2}>
-          <Typography fontWeight="bold" textColor="neutral800" as="span">
-            <NavLinkWrapper to={to}>
+          <Box paddingLeft={2}>
+            <Typography fontWeight="bold" textColor="neutral800" as="span">
               {title}
               <VisuallyHidden as="span">{workplace}</VisuallyHidden>
-            </NavLinkWrapper>
-          </Typography>
-          <Typography variant="pi" as="p" textColor="neutral600" aria-hidden>
-            {workplace}
-          </Typography>
-        </Box>
-      </Flex>
-    </Box>
+            </Typography>
+            <Typography variant="pi" as="p" textColor="neutral600" aria-hidden>
+              {workplace}
+            </Typography>
+          </Box>
+        </Flex>
+      </Box>
+    </NavLinkWrapper>
   );
 };
 

--- a/packages/strapi-design-system/src/MainNav/NavBrand.js
+++ b/packages/strapi-design-system/src/MainNav/NavBrand.js
@@ -23,12 +23,12 @@ const NavLinkWrapper = styled(BaseLink)`
   color: inherit;
 `;
 
-export const NavBrand = ({ workplace, title, icon, ...props }) => {
+export const NavBrand = React.forwardRef(({ workplace, title, icon, ...props }, ref) => {
   const condensed = useMainNav();
 
   if (condensed) {
     return (
-      <BaseLink {...props}>
+      <BaseLink ref={ref} {...props}>
         <Box paddingLeft={3} paddingRight={3} paddingTop={4} paddingBottom={4}>
           <BrandIconWrapper condensed={true}>
             {icon}
@@ -43,7 +43,7 @@ export const NavBrand = ({ workplace, title, icon, ...props }) => {
   }
 
   return (
-    <NavLinkWrapper {...props}>
+    <NavLinkWrapper ref={ref} {...props}>
       <Box paddingLeft={3} paddingRight={3} paddingTop={4} paddingBottom={4}>
         <Flex>
           <BrandIconWrapper aria-hidden tabIndex={-1}>
@@ -63,7 +63,9 @@ export const NavBrand = ({ workplace, title, icon, ...props }) => {
       </Box>
     </NavLinkWrapper>
   );
-};
+});
+
+NavBrand.displayName = 'NavBrand';
 
 NavBrand.defaultProps = {
   to: '/',

--- a/packages/strapi-design-system/src/MainNav/NavLink.js
+++ b/packages/strapi-design-system/src/MainNav/NavLink.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import { NavLink as RouterLink } from 'react-router-dom';
 import { Box } from '../Box';
 import { Flex } from '../Flex';
 import { Typography } from '../Typography';
 import { useMainNav } from './MainNavContext';
 import { Tooltip } from '../Tooltip';
 import { Badge } from '../Badge';
+import { BaseLink } from '../BaseLink';
 
 const IconBox = styled(Box)`
   svg {
@@ -16,8 +16,7 @@ const IconBox = styled(Box)`
   }
 `;
 
-// TODO: make sure to use the Link component associated with the router we want to use
-const MainNavLinkWrapper = styled(RouterLink)`
+const MainNavLinkWrapper = styled(BaseLink)`
   position: relative;
   text-decoration: none;
   display: block;
@@ -93,43 +92,39 @@ export const NavLink = ({ children, icon, badgeContent, badgeAriaLabel, ...props
 
   if (condensed) {
     return (
-      <li>
+      <MainNavLinkWrapper {...props}>
         <Tooltip position="right" label={children}>
-          <MainNavLinkWrapper {...props}>
-            <MainNavRow as="span">
-              <IconBox aria-hidden paddingRight={0} as="span">
-                {icon}
-              </IconBox>
-              {badgeContent && (
-                <CustomBadge condensed aria-label={badgeAriaLabel}>
-                  {badgeContent}
-                </CustomBadge>
-              )}
-            </MainNavRow>
-          </MainNavLinkWrapper>
+          <MainNavRow as="span" justifyContent="center">
+            <IconBox aria-hidden paddingRight={0} as="span">
+              {icon}
+            </IconBox>
+            {badgeContent && (
+              <CustomBadge condensed aria-label={badgeAriaLabel}>
+                {badgeContent}
+              </CustomBadge>
+            )}
+          </MainNavRow>
         </Tooltip>
-      </li>
+      </MainNavLinkWrapper>
     );
   }
 
   return (
-    <li>
-      <MainNavLinkWrapper {...props}>
-        <MainNavRow as="span" justifyContent="space-between">
-          <Flex>
-            <IconBox aria-hidden paddingRight={3} as="span">
-              {icon}
-            </IconBox>
-            <Typography>{children}</Typography>
-          </Flex>
-          {badgeContent && (
-            <CustomBadge justifyContent="center" aria-label={badgeAriaLabel}>
-              {badgeContent}
-            </CustomBadge>
-          )}
-        </MainNavRow>
-      </MainNavLinkWrapper>
-    </li>
+    <MainNavLinkWrapper {...props}>
+      <MainNavRow as="span" justifyContent="space-between">
+        <Flex>
+          <IconBox aria-hidden paddingRight={3} as="span">
+            {icon}
+          </IconBox>
+          <Typography>{children}</Typography>
+        </Flex>
+        {badgeContent && (
+          <CustomBadge justifyContent="center" aria-label={badgeAriaLabel}>
+            {badgeContent}
+          </CustomBadge>
+        )}
+      </MainNavRow>
+    </MainNavLinkWrapper>
   );
 };
 

--- a/packages/strapi-design-system/src/MainNav/NavLink.js
+++ b/packages/strapi-design-system/src/MainNav/NavLink.js
@@ -87,12 +87,12 @@ const CustomBadge = styled(Badge)`
   background: ${({ theme }) => theme.colors.primary600};
 `;
 
-export const NavLink = ({ children, icon, badgeContent, badgeAriaLabel, ...props }) => {
+export const NavLink = React.forwardRef(({ children, icon, badgeContent, badgeAriaLabel, ...props }, ref) => {
   const condensed = useMainNav();
 
   if (condensed) {
     return (
-      <MainNavLinkWrapper {...props}>
+      <MainNavLinkWrapper ref={ref} {...props}>
         <Tooltip position="right" label={children}>
           <MainNavRow as="span" justifyContent="center">
             <IconBox aria-hidden paddingRight={0} as="span">
@@ -110,7 +110,7 @@ export const NavLink = ({ children, icon, badgeContent, badgeAriaLabel, ...props
   }
 
   return (
-    <MainNavLinkWrapper {...props}>
+    <MainNavLinkWrapper ref={ref} {...props}>
       <MainNavRow as="span" justifyContent="space-between">
         <Flex>
           <IconBox aria-hidden paddingRight={3} as="span">
@@ -126,7 +126,9 @@ export const NavLink = ({ children, icon, badgeContent, badgeAriaLabel, ...props
       </MainNavRow>
     </MainNavLinkWrapper>
   );
-};
+});
+
+NavLink.displayName = 'NavLink';
 
 NavLink.defaultProps = {
   badgeContent: undefined,

--- a/packages/strapi-design-system/src/MainNav/NavSection.js
+++ b/packages/strapi-design-system/src/MainNav/NavSection.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Children } from 'react';
 import PropTypes from 'prop-types';
 import { Box } from '../Box';
 import { Typography } from '../Typography';
@@ -7,50 +7,47 @@ import { useMainNav } from './MainNavContext';
 import { VisuallyHidden } from '../VisuallyHidden';
 import { Divider } from '../Divider';
 
-export const NavSection = ({ label, ...props }) => {
+export const NavSection = ({ label, children, ...props }) => {
   const condensed = useMainNav();
 
   if (condensed) {
     return (
-      <Box as="li">
-        <Stack size={2}>
-          <Box paddingTop={1} paddingBottom={1} background="neutral0" hasRadius as="span">
-            <Divider />
+      <Stack size={2}>
+        <Box paddingTop={1} paddingBottom={1} background="neutral0" hasRadius as="span">
+          <Divider />
 
-            <VisuallyHidden>
-              <span>{label}</span>
-            </VisuallyHidden>
-          </Box>
+          <VisuallyHidden>
+            <span>{label}</span>
+          </VisuallyHidden>
+        </Box>
 
-          <Stack as="ul" size={2} {...props}></Stack>
+        <Stack as="ul" size={2} {...props}>
+          {Children.map(children, (child, index) => {
+            return <li key={index}>{child}</li>;
+          })}
         </Stack>
-      </Box>
+      </Stack>
     );
   }
 
   return (
-    <Box as="li">
-      <Stack size={2}>
-        <Box
-          paddingTop={1}
-          paddingBottom={1}
-          background="neutral0"
-          paddingRight={3}
-          paddingLeft={3}
-          hasRadius
-          as="span"
-        >
-          <Typography variant="sigma" textColor="neutral600">
-            {label}
-          </Typography>
-        </Box>
+    <Stack size={2}>
+      <Box paddingTop={1} paddingBottom={1} background="neutral0" paddingRight={3} paddingLeft={3} hasRadius as="span">
+        <Typography variant="sigma" textColor="neutral600">
+          {label}
+        </Typography>
+      </Box>
 
-        <Stack as="ul" size={2} {...props}></Stack>
+      <Stack as="ul" size={2} {...props}>
+        {Children.map(children, (child, index) => {
+          return <li key={index}>{child}</li>;
+        })}
       </Stack>
-    </Box>
+    </Stack>
   );
 };
 
 NavSection.propTypes = {
+  children: PropTypes.node.isRequired,
   label: PropTypes.string.isRequired,
 };

--- a/packages/strapi-design-system/src/MainNav/NavSections.js
+++ b/packages/strapi-design-system/src/MainNav/NavSections.js
@@ -1,11 +1,20 @@
-import React from 'react';
+import React, { Children } from 'react';
+import PropTypes from 'prop-types';
 import { Stack } from '../Stack';
 import { Box } from '../Box';
 
-export const NavSections = (props) => {
+export const NavSections = ({ children, ...props }) => {
   return (
     <Box paddingLeft={3} paddingRight={2} paddingTop={3}>
-      <Stack as="ul" size={4} {...props}></Stack>
+      <Stack as="ul" size={4} {...props}>
+        {Children.map(children, (child, index) => {
+          return <li key={index}>{child}</li>;
+        })}
+      </Stack>
     </Box>
   );
+};
+
+NavSections.propTypes = {
+  children: PropTypes.node.isRequired,
 };

--- a/packages/strapi-design-system/src/ModalLayout/ModalLayout.stories.mdx
+++ b/packages/strapi-design-system/src/ModalLayout/ModalLayout.stories.mdx
@@ -1,7 +1,7 @@
 <!--- ModalLayout.stories.mdx --->
 
 import { useState } from 'react';
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { ModalLayout } from './ModalLayout';
 import { ModalHeader } from './ModalHeader';

--- a/packages/strapi-design-system/src/NumberInput/NumberInput.stories.mdx
+++ b/packages/strapi-design-system/src/NumberInput/NumberInput.stories.mdx
@@ -1,7 +1,7 @@
 <!--- NumberInput.stories.mdx --->
 
 import { useState } from 'react';
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import Information from '@strapi/icons/Information';
 import { NumberInput } from './NumberInput';

--- a/packages/strapi-design-system/src/Pagination/Pagination.js
+++ b/packages/strapi-design-system/src/Pagination/Pagination.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Children } from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { Flex } from '../Flex';
@@ -15,7 +15,11 @@ export const Pagination = ({ children, label, activePage, pageCount }) => {
   return (
     <PaginationContext.Provider value={{ activePage, pageCount }}>
       <PaginationWrapper aria-label={label}>
-        <PaginationList as="ul">{children}</PaginationList>
+        <PaginationList as="ul">
+          {Children.map(children, (child, index) => {
+            return <li key={index}>{child}</li>;
+          })}
+        </PaginationList>
       </PaginationWrapper>
     </PaginationContext.Provider>
   );

--- a/packages/strapi-design-system/src/Pagination/Pagination.stories.mdx
+++ b/packages/strapi-design-system/src/Pagination/Pagination.stories.mdx
@@ -1,6 +1,6 @@
 <!--- Pagination.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { Pagination } from './Pagination';
 import { PreviousLink, NextLink, PageLink, Dots } from './components';
@@ -24,25 +24,73 @@ import { Dots, NextLink, PageLink, Pagination, PreviousLink } from '@strapi/desi
 <Canvas>
   <Story name="base">
     <Pagination activePage={1} pageCount={26}>
-      <PreviousLink to="/1">Go to previous page</PreviousLink>
-      <PageLink number={1} to="/1">
+      <PreviousLink href="/1">Go to previous page</PreviousLink>
+      <PageLink number={1} href="/1">
         Go to page 1
       </PageLink>
-      <PageLink number={2} to="/2">
+      <PageLink number={2} href="/2">
         Go to page 2
       </PageLink>
       <Dots>And 23 other links</Dots>
-      <PageLink number={25} to="/25">
+      <PageLink number={25} href="/25">
         Go to page 3
       </PageLink>
-      <PageLink number={26} to="/26">
+      <PageLink number={26} href="/26">
         Go to page 26
       </PageLink>
-      <NextLink to="/3">Go to next page</NextLink>
+      <NextLink href="/3">Go to next page</NextLink>
     </Pagination>
   </Story>
 </Canvas>
 
+### Usage with routing libraries
+
+To use the PreviousLink/PageLink/NextLink component with a routing library (e.g. react-router-dom), you'll need to pass the `NavLink` component to the `as` prop in order to replace the default HTML anchor `<a />`.
+You'll now be able to pass all `NavLink` props.
+
+```jsx
+import { PreviousLink, PageLink, NextLink } from '@strapi/design-system/Pagination';
+import { NavLink } from 'react-router-dom';
+
+<Pagination>
+  <PreviousLink as={NavLink} to="/1">
+    Previous
+  </PreviousLink>
+  <PageLink as={NavLink} to="/1">
+    1
+  </PageLink>
+  <PageLink as={NavLink} to="/2">
+    2
+  </PageLink>
+  <NextLink as={NavLink} to="/2">
+    Next page
+  </NextLink>
+</Pagination>;
+```
+
+#### Usage with NextJS
+
+For NextJS, you'll need to wrap the `Link` with the `NextLink` component
+
+```jsx
+import { PreviousLink, PageLink, NextLink } from '@strapi/design-system/Pagination';
+import NextLink from 'next/link';
+
+<Pagination>
+  <NextLink href="/home" passHref>
+    <PreviousLink>Previous</PreviousLink>
+  </NextLink>
+  <NextLink href="/1" passHref>
+    <PageLink>1</PageLink>
+  </NextLink>
+  <NextLink href="/2" passHref>
+    <PageLink>2</PageLink>
+  </NextLink>
+  <NextLink href="/2" passHref>
+    <NextLink>Next page</NextLink>
+  </NextLink>
+</Pagination>;
+```
 
 ## Props
 

--- a/packages/strapi-design-system/src/Pagination/components.js
+++ b/packages/strapi-design-system/src/Pagination/components.js
@@ -3,11 +3,11 @@ import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import ChevronLeft from '@strapi/icons/ChevronLeft';
 import ChevronRight from '@strapi/icons/ChevronRight';
-import { NavLink } from 'react-router-dom';
 import { VisuallyHidden } from '../VisuallyHidden';
 import { usePagination } from './PaginationContext';
 import { Typography } from '../Typography';
 import { buttonFocusStyle } from '../themes/utils';
+import { BaseLink } from '../BaseLink';
 
 const PaginationText = styled(Typography)`
   line-height: revert;
@@ -17,8 +17,7 @@ const transientProps = {
   active: true,
 };
 
-// TODO: make sure to use the Link exposed by the chosen router
-const LinkWrapper = styled(NavLink).withConfig({
+const LinkWrapper = styled(BaseLink).withConfig({
   shouldForwardProp: (prop, defPropValFN) => !transientProps[prop] && defPropValFN(prop),
 })`
   padding: ${({ theme }) => theme.spaces[3]};
@@ -64,43 +63,29 @@ const DotsWrapper = styled(LinkWrapper)`
   color: ${({ theme }) => theme.colors.neutral800};
 `;
 
-export const PreviousLink = ({ children, to, ...props }) => {
+export const PreviousLink = ({ children, ...props }) => {
   const { activePage } = usePagination();
 
   const disabled = activePage === 1;
 
   return (
-    <li>
-      <ActionLinkWrapper
-        to={disabled ? '#' : to}
-        aria-disabled={disabled}
-        tabIndex={disabled ? -1 : undefined}
-        {...props}
-      >
-        <VisuallyHidden>{children}</VisuallyHidden>
-        <ChevronLeft aria-hidden={true} />
-      </ActionLinkWrapper>
-    </li>
+    <ActionLinkWrapper aria-disabled={disabled} tabIndex={disabled ? -1 : undefined} {...props}>
+      <VisuallyHidden>{children}</VisuallyHidden>
+      <ChevronLeft aria-hidden={true} />
+    </ActionLinkWrapper>
   );
 };
 
-export const NextLink = ({ children, to, ...props }) => {
+export const NextLink = ({ children, ...props }) => {
   const { activePage, pageCount } = usePagination();
 
   const disabled = activePage === pageCount;
 
   return (
-    <li>
-      <ActionLinkWrapper
-        to={disabled ? '#' : to}
-        aria-disabled={disabled}
-        tabIndex={disabled ? -1 : undefined}
-        {...props}
-      >
-        <VisuallyHidden>{children}</VisuallyHidden>
-        <ChevronRight aria-hidden={true} />
-      </ActionLinkWrapper>
-    </li>
+    <ActionLinkWrapper aria-disabled={disabled} tabIndex={disabled ? -1 : undefined} {...props}>
+      <VisuallyHidden>{children}</VisuallyHidden>
+      <ChevronRight aria-hidden={true} />
+    </ActionLinkWrapper>
   );
 };
 
@@ -110,26 +95,22 @@ export const PageLink = ({ number, children, ...props }) => {
   const isActive = activePage === number;
 
   return (
-    <li>
-      <PageLinkWrapper {...props} active={isActive}>
-        <VisuallyHidden>{children}</VisuallyHidden>
-        <PaginationText aria-hidden={true} variant="pi" fontWeight={isActive ? 'bold' : null}>
-          {number}
-        </PaginationText>
-      </PageLinkWrapper>
-    </li>
+    <PageLinkWrapper {...props} active={isActive}>
+      <VisuallyHidden>{children}</VisuallyHidden>
+      <PaginationText aria-hidden={true} variant="pi" fontWeight={isActive ? 'bold' : null}>
+        {number}
+      </PaginationText>
+    </PageLinkWrapper>
   );
 };
 
 export const Dots = ({ children, ...props }) => (
-  <li>
-    <DotsWrapper {...props} as="div">
-      <VisuallyHidden>{children}</VisuallyHidden>
-      <PaginationText aria-hidden={true} variant="pi">
-        …
-      </PaginationText>
-    </DotsWrapper>
-  </li>
+  <DotsWrapper {...props} as="div">
+    <VisuallyHidden>{children}</VisuallyHidden>
+    <PaginationText aria-hidden={true} variant="pi">
+      …
+    </PaginationText>
+  </DotsWrapper>
 );
 
 PageLink.propTypes = {
@@ -139,7 +120,6 @@ PageLink.propTypes = {
 
 const sharedPropTypes = {
   children: PropTypes.node.isRequired,
-  to: PropTypes.string.isRequired,
 };
 
 NextLink.propTypes = sharedPropTypes;

--- a/packages/strapi-design-system/src/Pagination/components.js
+++ b/packages/strapi-design-system/src/Pagination/components.js
@@ -63,46 +63,52 @@ const DotsWrapper = styled(LinkWrapper)`
   color: ${({ theme }) => theme.colors.neutral800};
 `;
 
-export const PreviousLink = ({ children, ...props }) => {
+export const PreviousLink = React.forwardRef(({ children, ...props }, ref) => {
   const { activePage } = usePagination();
 
   const disabled = activePage === 1;
 
   return (
-    <ActionLinkWrapper aria-disabled={disabled} tabIndex={disabled ? -1 : undefined} {...props}>
+    <ActionLinkWrapper ref={ref} aria-disabled={disabled} tabIndex={disabled ? -1 : undefined} {...props}>
       <VisuallyHidden>{children}</VisuallyHidden>
       <ChevronLeft aria-hidden={true} />
     </ActionLinkWrapper>
   );
-};
+});
 
-export const NextLink = ({ children, ...props }) => {
+PreviousLink.displayName = 'PreviousLink';
+
+export const NextLink = React.forwardRef(({ children, ...props }, ref) => {
   const { activePage, pageCount } = usePagination();
 
   const disabled = activePage === pageCount;
 
   return (
-    <ActionLinkWrapper aria-disabled={disabled} tabIndex={disabled ? -1 : undefined} {...props}>
+    <ActionLinkWrapper ref={ref} aria-disabled={disabled} tabIndex={disabled ? -1 : undefined} {...props}>
       <VisuallyHidden>{children}</VisuallyHidden>
       <ChevronRight aria-hidden={true} />
     </ActionLinkWrapper>
   );
-};
+});
 
-export const PageLink = ({ number, children, ...props }) => {
+NextLink.displayName = 'NextLink';
+
+export const PageLink = React.forwardRef(({ number, children, ...props }, ref) => {
   const { activePage } = usePagination();
 
   const isActive = activePage === number;
 
   return (
-    <PageLinkWrapper {...props} active={isActive}>
+    <PageLinkWrapper ref={ref} {...props} active={isActive}>
       <VisuallyHidden>{children}</VisuallyHidden>
       <PaginationText aria-hidden={true} variant="pi" fontWeight={isActive ? 'bold' : null}>
         {number}
       </PaginationText>
     </PageLinkWrapper>
   );
-};
+});
+
+PageLink.displayName = 'PageLink';
 
 export const Dots = ({ children, ...props }) => (
   <DotsWrapper {...props} as="div">

--- a/packages/strapi-design-system/src/Popover/Popover.stories.mdx
+++ b/packages/strapi-design-system/src/Popover/Popover.stories.mdx
@@ -1,7 +1,7 @@
 <!--- Popover.stories.mdx --->
 
 import { useRef, useState } from 'react';
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { Popover } from './Popover';
 import { PopoverContentProps } from './PopoverProps';

--- a/packages/strapi-design-system/src/Portal/Portal.stories.mdx
+++ b/packages/strapi-design-system/src/Portal/Portal.stories.mdx
@@ -1,6 +1,6 @@
 <!--- Portal.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { Portal } from './Portal';
 
 <Meta title="Design System/Technical Components/Portal" component={Portal} />

--- a/packages/strapi-design-system/src/ProgressBar/ProgressBar.stories.mdx
+++ b/packages/strapi-design-system/src/ProgressBar/ProgressBar.stories.mdx
@@ -1,6 +1,6 @@
 <!--- ProgressBar.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { ProgressBar } from './ProgressBar';
 

--- a/packages/strapi-design-system/src/Radio/Radio.stories.mdx
+++ b/packages/strapi-design-system/src/Radio/Radio.stories.mdx
@@ -1,7 +1,7 @@
 <!--- Radio.stories.mdx --->
 
 import { useState } from 'react';
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { Radio, RadioGroup } from './';
 

--- a/packages/strapi-design-system/src/RawTable/RawTable.stories.mdx
+++ b/packages/strapi-design-system/src/RawTable/RawTable.stories.mdx
@@ -1,6 +1,6 @@
 <!--- RawTable.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { RawTable } from './RawTable';
 import { RawTh, RawTd } from './RawCell';

--- a/packages/strapi-design-system/src/Searchbar/Searchbar.stories.mdx
+++ b/packages/strapi-design-system/src/Searchbar/Searchbar.stories.mdx
@@ -1,7 +1,7 @@
 <!--- Searchbar.stories.mdx --->
 
 import { useState } from 'react';
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { Searchbar } from './Searchbar';
 import { SearchForm } from './SearchForm';

--- a/packages/strapi-design-system/src/Select/Select.stories.mdx
+++ b/packages/strapi-design-system/src/Select/Select.stories.mdx
@@ -1,7 +1,7 @@
 <!--- Select.stories.mdx --->
 
 import { useState } from 'react';
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import Plus from '@strapi/icons/Plus';
 import { Select } from './Select';

--- a/packages/strapi-design-system/src/SimpleMenu/SimpleMenu.js
+++ b/packages/strapi-design-system/src/SimpleMenu/SimpleMenu.js
@@ -2,11 +2,11 @@ import React, { useRef, useState, Children, cloneElement, useEffect } from 'reac
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import CarretDown from '@strapi/icons/CarretDown';
-import { NavLink } from 'react-router-dom';
 import { Typography } from '../Typography';
 import { Box } from '../Box';
 import { Flex } from '../Flex';
 import { Button } from '../Button';
+import { BaseLink } from '../BaseLink';
 import { Popover } from '../Popover';
 import { getOptionStyle } from './utils';
 import { useId } from '../helpers/useId';
@@ -20,7 +20,7 @@ const OptionButton = styled.button`
   ${getOptionStyle}
 `;
 
-const OptionLink = styled(NavLink)`
+const OptionLink = styled(BaseLink)`
   text-decoration: none;
   ${getOptionStyle}
 `;
@@ -34,7 +34,7 @@ const IconWrapper = styled.span`
   }
 `;
 
-export const MenuItem = ({ children, onClick, to, isFocused, ...props }) => {
+export const MenuItem = ({ as, children, onClick, isFocused, isLink, ...props }) => {
   const menuItemRef = useRef();
 
   useEffect(() => {
@@ -56,36 +56,33 @@ export const MenuItem = ({ children, onClick, to, isFocused, ...props }) => {
     }
   };
 
-  return (
-    <Flex as="li" justifyContent="center" role="menuitem">
-      {to ? (
-        <OptionLink to={to} {...menuItemProps}>
-          <Box padding={2}>
-            <Typography>{children}</Typography>
-          </Box>
-        </OptionLink>
-      ) : (
-        <OptionButton onKeyDown={handleKeyDown} onMouseDown={onClick} type="button" {...menuItemProps}>
-          <Box padding={2}>
-            <Typography>{children}</Typography>
-          </Box>
-        </OptionButton>
-      )}
-    </Flex>
+  return isLink ? (
+    <OptionLink as={as} {...menuItemProps}>
+      <Box padding={2}>
+        <Typography>{children}</Typography>
+      </Box>
+    </OptionLink>
+  ) : (
+    <OptionButton onKeyDown={handleKeyDown} onMouseDown={onClick} type="button" {...menuItemProps}>
+      <Box padding={2}>
+        <Typography>{children}</Typography>
+      </Box>
+    </OptionButton>
   );
 };
 
 MenuItem.defaultProps = {
   onClick: () => {},
-  to: undefined,
   isFocused: false,
+  isLink: false,
 };
 
 MenuItem.propTypes = {
+  as: PropTypes.elementType,
   children: PropTypes.node.isRequired,
   isFocused: PropTypes.bool,
+  isLink: PropTypes.bool,
   onClick: PropTypes.func,
-  to: PropTypes.string,
 };
 
 export const SimpleMenu = ({ label, children, id, as: asComp, ...props }) => {
@@ -150,16 +147,18 @@ export const SimpleMenu = ({ label, children, id, as: asComp, ...props }) => {
     setVisible((prevVisible) => !prevVisible);
   };
 
-  const childrenClone = childrenArray.map((child, index) =>
-    cloneElement(child, {
-      onClick: () => {
-        child.props.onClick();
-        setVisible(false);
-        menuButtonRef.current.focus();
-      },
-      isFocused: focusedItemIndex === index,
-    }),
-  );
+  const childrenClone = childrenArray.map((child, index) => (
+    <Flex as="li" key={index} justifyContent="center" role="menuitem">
+      {cloneElement(child, {
+        onClick: () => {
+          child.props.onClick();
+          setVisible(false);
+          menuButtonRef.current.focus();
+        },
+        isFocused: focusedItemIndex === index,
+      })}
+    </Flex>
+  ));
 
   return (
     <div onKeyDown={handleWrapperKeyDown}>

--- a/packages/strapi-design-system/src/SimpleMenu/SimpleMenu.stories.mdx
+++ b/packages/strapi-design-system/src/SimpleMenu/SimpleMenu.stories.mdx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { ArgsTable } from '@storybook/addon-docs';
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import CarretDown from '@strapi/icons/CarretDown';
 import { SimpleMenu, MenuItem } from './SimpleMenu';
 import { IconButton } from '../IconButton';
@@ -134,9 +134,13 @@ return (
         },
       },
     }}
-    >
+  >
     {() => {
-      const Label = <><span>2</span> special items</>;
+      const Label = (
+        <>
+          <span>2</span> special items
+        </>
+      );
       return (
         <SimpleMenu label={Label}>
           <MenuItem>Home</MenuItem>
@@ -146,6 +150,37 @@ return (
     }}
   </Story>
 </Canvas>
+
+### with other routing libraries
+
+To use the SimpleMenu/MenuItem components with a routing library (e.g. react-router-dom), you'll need to pass the `NavLink` component to the `as` prop in order to replace the default HTML anchor `<a />`.
+You'll also need to pass the `isLink` props to the `MenuItem` component.
+
+```jsx
+import { SimpleMenu, MenuItem } from '@strapi/design-system/SimpleMenu';
+import { NavLink as RouterNavLink } from 'react-router-dom';
+
+<SimpleMenu label={Label}>
+  <MenuItem as={RouterNavLink} to="/">
+    Home
+  </MenuItem>
+</SimpleMenu>;
+```
+
+#### with NextJS
+
+For NextJS, you'll need to wrap the `NavLink` with the `NextLink` component
+
+```jsx
+import { SimpleMenu, MenuItem } from '@strapi/design-system/SimpleMenu';
+import NextLink from 'next/link';
+
+<SimpleMenu label={Label}>
+  <NextLink href="/home" passHref>
+    <MenuItem>Home</MenuItem>
+  </NextLink>
+</SimpleMenu>;
+```
 
 ## Accessibility
 

--- a/packages/strapi-design-system/src/Stack/Stack.stories.mdx
+++ b/packages/strapi-design-system/src/Stack/Stack.stories.mdx
@@ -1,6 +1,6 @@
 <!--- Stack.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { Stack } from './Stack';
 import { Box } from '../Box';

--- a/packages/strapi-design-system/src/Status/Status.stories.mdx
+++ b/packages/strapi-design-system/src/Status/Status.stories.mdx
@@ -1,6 +1,6 @@
 <!--- Status.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { Status } from './Status';
 import { Typography } from '../Typography';

--- a/packages/strapi-design-system/src/SubNav/SubNav.stories.mdx
+++ b/packages/strapi-design-system/src/SubNav/SubNav.stories.mdx
@@ -1,7 +1,7 @@
 <!--- SubNav.stories.mdx --->
 
 import { useState } from 'react';
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import Apps from '@strapi/icons/Apps';
 import Plus from '@strapi/icons/Plus';
@@ -109,7 +109,7 @@ import {
                     </SubNavLink>
                   ))}
                 </SubNavSection>
-                <Box as="li" paddingLeft={7}>
+                <Box paddingLeft={7}>
                   <TextButton startIcon={<Plus />}>Click on me</TextButton>
                 </Box>
                 <SubNavSection label="Single Type" collapsable badgeLabel={links.length.toString()}>
@@ -121,7 +121,7 @@ import {
                     ))}
                   </SubNavLinkSection>
                 </SubNavSection>
-                <Box as="li" paddingLeft={7}>
+                <Box paddingLeft={7}>
                   <TextButton startIcon={<Plus />}>Click on me</TextButton>
                 </Box>
               </SubNavSections>
@@ -188,6 +188,33 @@ import {
     }}
   </Story>
 </Canvas>
+
+### Usage with other routing libraries
+
+To use the Strapi design system SubNavLink component with a routing library (e.g. react-router-dom), you'll need to pass the react-router-dom `NavLink` component to the `as` prop in order to replace the default HTML anchor `<a />`.
+You'll now be able to pass all `NavLink` props.
+
+```jsx
+import { SubNavLink } from '@strapi/design-system/SubNavLink';
+import { NavLink } from 'react-router-dom';
+
+<SubNavLink as={NavLink} to="/home">
+  Home
+</SubNavLink>;
+```
+
+#### NextJS usage
+
+For NextJS, you'll need to wrap the `NavLink` with the `NextLink` component
+
+```jsx
+import { SubNavLink } from '@strapi/design-system/SubNavLink';
+import NextLink from 'next/link';
+
+<NextLink href="/home" passHref>
+  <SubNavLink>Home</SubNavLink>
+</NextLink>;
+```
 
 ## SubNav Props
 

--- a/packages/strapi-design-system/src/SubNav/SubNavLink.js
+++ b/packages/strapi-design-system/src/SubNav/SubNavLink.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import Dot from '@strapi/icons/Dot';
-import { NavLink } from 'react-router-dom';
 import { Box } from '../Box';
 import { Typography } from '../Typography';
 import { Flex } from '../Flex';
@@ -53,29 +52,19 @@ const IconWrapper = styled.div`
 
 export const SubNavLink = ({ children, icon, withBullet, ...props }) => {
   return (
-    <li>
-      <SubNavLinkWrapper
-        as={NavLink}
-        icon={icon}
-        background="neutral100"
-        paddingLeft={7}
-        paddingBottom={2}
-        paddingTop={2}
-        {...props}
-      >
-        <Flex>
-          {icon ? <IconWrapper>{icon}</IconWrapper> : <CustomBullet />}
-          <Box paddingLeft={2}>
-            <Typography as="span">{children}</Typography>
-          </Box>
-        </Flex>
-        {withBullet && (
-          <Box as={Flex} paddingRight={4}>
-            <CustomBullet $active={true} />
-          </Box>
-        )}
-      </SubNavLinkWrapper>
-    </li>
+    <SubNavLinkWrapper icon={icon} background="neutral100" paddingLeft={7} paddingBottom={2} paddingTop={2} {...props}>
+      <Flex>
+        {icon ? <IconWrapper>{icon}</IconWrapper> : <CustomBullet />}
+        <Box paddingLeft={2}>
+          <Typography as="span">{children}</Typography>
+        </Box>
+      </Flex>
+      {withBullet && (
+        <Box as={Flex} paddingRight={4}>
+          <CustomBullet $active={true} />
+        </Box>
+      )}
+    </SubNavLinkWrapper>
   );
 };
 

--- a/packages/strapi-design-system/src/SubNav/SubNavLink.js
+++ b/packages/strapi-design-system/src/SubNav/SubNavLink.js
@@ -5,6 +5,7 @@ import Dot from '@strapi/icons/Dot';
 import { Box } from '../Box';
 import { Typography } from '../Typography';
 import { Flex } from '../Flex';
+import { BaseLink } from '../BaseLink';
 
 const SubNavLinkWrapper = styled(Box)`
   display: flex;
@@ -50,9 +51,18 @@ const IconWrapper = styled.div`
   }
 `;
 
-export const SubNavLink = ({ children, icon, withBullet, ...props }) => {
+export const SubNavLink = React.forwardRef(({ children, icon, withBullet, as, ...props }, ref) => {
   return (
-    <SubNavLinkWrapper icon={icon} background="neutral100" paddingLeft={7} paddingBottom={2} paddingTop={2} {...props}>
+    <SubNavLinkWrapper
+      as={as}
+      icon={icon}
+      background="neutral100"
+      paddingLeft={7}
+      paddingBottom={2}
+      paddingTop={2}
+      ref={ref}
+      {...props}
+    >
       <Flex>
         {icon ? <IconWrapper>{icon}</IconWrapper> : <CustomBullet />}
         <Box paddingLeft={2}>
@@ -66,13 +76,16 @@ export const SubNavLink = ({ children, icon, withBullet, ...props }) => {
       )}
     </SubNavLinkWrapper>
   );
-};
+});
 
+SubNavLink.displayName = 'SubNavLink';
 SubNavLink.defaultProps = {
+  as: BaseLink,
   icon: null,
   withBullet: false,
 };
 SubNavLink.propTypes = {
+  as: PropTypes.elementType,
   children: PropTypes.node,
   icon: PropTypes.element,
   link: PropTypes.element,

--- a/packages/strapi-design-system/src/SubNav/SubNavLinkSection.js
+++ b/packages/strapi-design-system/src/SubNav/SubNavLinkSection.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { Children, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import CarretDown from '@strapi/icons/CarretDown';
@@ -39,7 +39,7 @@ export const SubNavLinkSection = ({ label, children, id }) => {
   };
 
   return (
-    <li>
+    <Box>
       <SubNavLinkSectionWrapper paddingLeft={7} paddingTop={2} paddingBottom={2} paddingRight={4}>
         <Flex justifyContent="space-between">
           <SubNavLinkSectionButton onClick={handleClick} aria-expanded={isOpen} aria-controls={listId}>
@@ -54,8 +54,14 @@ export const SubNavLinkSection = ({ label, children, id }) => {
           </SubNavLinkSectionButton>
         </Flex>
       </SubNavLinkSectionWrapper>
-      {isOpen && <ul id={listId}>{children}</ul>}
-    </li>
+      {isOpen && (
+        <ul id={listId}>
+          {Children.map(children, (child, index) => {
+            return <li key={index}>{child}</li>;
+          })}
+        </ul>
+      )}
+    </Box>
   );
 };
 

--- a/packages/strapi-design-system/src/SubNav/SubNavSection.js
+++ b/packages/strapi-design-system/src/SubNav/SubNavSection.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { Children, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Box } from '../Box';
@@ -30,7 +30,7 @@ export const SubNavSection = ({ collapsable, label, badgeLabel, children, id }) 
   };
 
   return (
-    <li>
+    <Box>
       <SubNavSectionWrapper paddingLeft={6} paddingTop={2} paddingBottom={2} paddingRight={4}>
         <Flex justifyContent="space-between">
           <SubNavSectionLabel
@@ -47,8 +47,14 @@ export const SubNavSection = ({ collapsable, label, badgeLabel, children, id }) 
           )}
         </Flex>
       </SubNavSectionWrapper>
-      {(!collapsable || isOpen) && <ul id={listId}>{children}</ul>}
-    </li>
+      {(!collapsable || isOpen) && (
+        <ul id={listId}>
+          {Children.map(children, (child, index) => {
+            return <li key={index}>{child}</li>;
+          })}
+        </ul>
+      )}
+    </Box>
   );
 };
 

--- a/packages/strapi-design-system/src/SubNav/SubNavSections.js
+++ b/packages/strapi-design-system/src/SubNav/SubNavSections.js
@@ -1,11 +1,20 @@
-import React from 'react';
+import React, { Children } from 'react';
+import PropTypes from 'prop-types';
 import { Stack } from '../Stack';
 import { Box } from '../Box';
 
-export const SubNavSections = (props) => {
+export const SubNavSections = ({ children, ...props }) => {
   return (
     <Box paddingTop={2} paddingBottom={4}>
-      <Stack as="ul" size={2} {...props}></Stack>
+      <Stack as="ul" size={2} {...props}>
+        {Children.map(children, (child, index) => {
+          return <li key={index}>{child}</li>;
+        })}
+      </Stack>
     </Box>
   );
+};
+
+SubNavSections.propTypes = {
+  children: PropTypes.node.isRequired,
 };

--- a/packages/strapi-design-system/src/Switch/Switch.stories.mdx
+++ b/packages/strapi-design-system/src/Switch/Switch.stories.mdx
@@ -1,7 +1,7 @@
 <!--- Switch.stories.mdx --->
 
 import { useState } from 'react';
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { Switch } from './Switch';
 

--- a/packages/strapi-design-system/src/Table/Table.stories.mdx
+++ b/packages/strapi-design-system/src/Table/Table.stories.mdx
@@ -1,6 +1,6 @@
 <!--- Table.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import Pencil from '@strapi/icons/Pencil';
 import Trash from '@strapi/icons/Trash';

--- a/packages/strapi-design-system/src/Tabs/Tabs.stories.mdx
+++ b/packages/strapi-design-system/src/Tabs/Tabs.stories.mdx
@@ -1,6 +1,6 @@
 <!--- Tabs.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { Tabs, Tab } from './Tabs';
 import { TabGroup } from './TabGroup';

--- a/packages/strapi-design-system/src/Tag/Tag.stories.mdx
+++ b/packages/strapi-design-system/src/Tag/Tag.stories.mdx
@@ -1,6 +1,6 @@
 <!--- Tag.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import Information from '@strapi/icons/Information';
 import { Tag } from './Tag';

--- a/packages/strapi-design-system/src/TextButton/TextButton.stories.mdx
+++ b/packages/strapi-design-system/src/TextButton/TextButton.stories.mdx
@@ -1,6 +1,6 @@
 <!--- TextButton.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import ArrowLeft from '@strapi/icons/ArrowLeft';
 import ArrowRight from '@strapi/icons/ArrowRight';

--- a/packages/strapi-design-system/src/TextInput/TextInput.stories.mdx
+++ b/packages/strapi-design-system/src/TextInput/TextInput.stories.mdx
@@ -1,7 +1,7 @@
 <!--- TextInput.stories.mdx --->
 
 import { useState } from 'react';
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import Information from '@strapi/icons/Information';
 import { TextInput } from './TextInput';

--- a/packages/strapi-design-system/src/Textarea/Textarea.stories.mdx
+++ b/packages/strapi-design-system/src/Textarea/Textarea.stories.mdx
@@ -1,7 +1,7 @@
 <!--- Textarea.stories.mdx --->
 
 import { useState } from 'react';
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import Information from '@strapi/icons/Information';
 import { Textarea } from './Textarea';

--- a/packages/strapi-design-system/src/TimePicker/TimePicker.stories.mdx
+++ b/packages/strapi-design-system/src/TimePicker/TimePicker.stories.mdx
@@ -1,7 +1,7 @@
 <!--- TimePicker.stories.mdx --->
 
 import { useState } from 'react';
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { TimePicker } from './TimePicker';
 import { Box } from '../Box';

--- a/packages/strapi-design-system/src/ToggleCheckbox/ToggleCheckbox.stories.mdx
+++ b/packages/strapi-design-system/src/ToggleCheckbox/ToggleCheckbox.stories.mdx
@@ -1,7 +1,7 @@
 <!--- ToggleCheckbox.stories.mdx --->
 
 import { useState } from 'react';
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { ToggleCheckbox } from './ToggleCheckbox';
 

--- a/packages/strapi-design-system/src/ToggleInput/ToggleInput.stories.mdx
+++ b/packages/strapi-design-system/src/ToggleInput/ToggleInput.stories.mdx
@@ -1,6 +1,6 @@
 <!--- ToggleInput.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { ToggleInput } from './ToggleInput';
 import { Tooltip } from '../Tooltip';

--- a/packages/strapi-design-system/src/Tooltip/Tooltip.stories.mdx
+++ b/packages/strapi-design-system/src/Tooltip/Tooltip.stories.mdx
@@ -1,6 +1,6 @@
 <!--- Tooltip.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { Tooltip } from './Tooltip';
 import { Box } from '../Box';

--- a/packages/strapi-design-system/src/Typography/Typography.stories.mdx
+++ b/packages/strapi-design-system/src/Typography/Typography.stories.mdx
@@ -1,6 +1,6 @@
 <!--- Typography.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { Typography } from './Typography';
 import { Box } from '../Box';

--- a/packages/strapi-design-system/src/index.js
+++ b/packages/strapi-design-system/src/index.js
@@ -4,6 +4,7 @@ export * from './Avatar';
 export * from './Badge';
 export * from './BaseButton';
 export * from './BaseCheckbox';
+export * from './BaseLink';
 export * from './BaseRadio';
 export * from './Box';
 export * from './Breadcrumbs';

--- a/packages/strapi-design-system/src/themes/Theme.stories.mdx
+++ b/packages/strapi-design-system/src/themes/Theme.stories.mdx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import * as Icons from '@strapi/icons';
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { Box } from '../Box';
 import { Flex } from '../Flex';

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -3470,6 +3470,7 @@ exports[`Storyshots Design System/Components/Alert with action 1`] = `
           >
             <a
               class="c13 c14"
+              target="_self"
               to="/somewhere"
             >
               <span
@@ -14984,6 +14985,7 @@ exports[`Storyshots Design System/Components/HeaderLayout base 1`] = `
       >
         <a
           class="c5 c6"
+          target="_self"
           to="/"
         >
           <span
@@ -15861,6 +15863,7 @@ exports[`Storyshots Design System/Components/HeaderLayout combined w/ scroll 1`]
         >
           <a
             class="c5 c6"
+            target="_self"
             to="/"
           >
             <span
@@ -16370,6 +16373,7 @@ exports[`Storyshots Design System/Components/HeaderLayout sticky 1`] = `
           >
             <a
               class="c8 c9"
+              target="_self"
               to="/"
             >
               <span
@@ -17422,47 +17426,47 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   text-transform: uppercase;
 }
 
-.c32 {
+.c33 {
   color: #32324d;
   font-size: 0.875rem;
   line-height: 1.43;
 }
 
-.c37 {
+.c38 {
   font-weight: 500;
   color: #32324d;
   font-size: 0.875rem;
   line-height: 1.43;
 }
 
-.c41 {
+.c42 {
   color: #32324d;
   font-weight: 600;
   font-size: 2rem;
   line-height: 1.25;
 }
 
-.c46 {
+.c47 {
   font-weight: 600;
   color: #32324d;
   font-size: 0.75rem;
   line-height: 1.33;
 }
 
-.c48 {
+.c49 {
   color: #666687;
   font-size: 1rem;
   line-height: 1.5;
 }
 
-.c60 {
+.c61 {
   font-weight: 600;
   color: #32324d;
   font-size: 0.875rem;
   line-height: 1.43;
 }
 
-.c72 {
+.c73 {
   color: #32324d;
   font-weight: 600;
   font-size: 0.6875rem;
@@ -17470,7 +17474,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   text-transform: uppercase;
 }
 
-.c82 {
+.c83 {
   font-weight: 600;
   color: #4945ff;
   font-size: 0.75rem;
@@ -17519,29 +17523,29 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   min-width: 20px;
 }
 
-.c28 {
+.c29 {
   background: #f6f6f9;
   padding-top: 8px;
   padding-bottom: 8px;
   padding-left: 32px;
 }
 
-.c31 {
+.c32 {
   padding-left: 8px;
 }
 
-.c33 {
+.c34 {
   padding-top: 8px;
   padding-right: 16px;
   padding-bottom: 8px;
   padding-left: 32px;
 }
 
-.c38 {
+.c39 {
   padding-bottom: 56px;
 }
 
-.c40 {
+.c41 {
   background: #f6f6f9;
   padding-top: 40px;
   padding-right: 56px;
@@ -17549,28 +17553,28 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   padding-left: 56px;
 }
 
-.c42 {
+.c43 {
   padding-left: 16px;
 }
 
-.c44 {
+.c45 {
   padding-right: 8px;
 }
 
-.c49 {
+.c50 {
   padding-right: 56px;
   padding-left: 56px;
 }
 
-.c50 {
+.c51 {
   padding-bottom: 16px;
 }
 
-.c53 {
+.c54 {
   padding-top: 8px;
 }
 
-.c54 {
+.c55 {
   background: #f0f0ff;
   color: #4945ff;
   padding-right: 12px;
@@ -17582,31 +17586,31 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   height: 2rem;
 }
 
-.c61 {
+.c62 {
   background: #ffffff;
   border-radius: 4px;
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
 }
 
-.c64 {
+.c65 {
   padding-right: 24px;
   padding-left: 24px;
 }
 
-.c76 {
+.c77 {
   padding-left: 4px;
 }
 
-.c77 {
+.c78 {
   background: #f0f0ff;
   padding: 20px;
 }
 
-.c79 {
+.c80 {
   background: #d9d8ff;
 }
 
-.c81 {
+.c82 {
   padding-left: 12px;
 }
 
@@ -17678,7 +17682,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   align-items: center;
 }
 
-.c51 {
+.c52 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -17812,19 +17816,23 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   fill: #666687;
 }
 
-.c75 {
+.c28 {
+  cursor: pointer;
+}
+
+.c76 {
   border-radius: 50%;
   display: block;
   position: relative;
 }
 
-.c74 {
+.c75 {
   position: relative;
   width: 26px;
   height: 26px;
 }
 
-.c70 {
+.c71 {
   margin: 0;
   height: 18px;
   min-width: 18px;
@@ -17835,12 +17843,12 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   cursor: pointer;
 }
 
-.c70:checked {
+.c71:checked {
   background-color: #4945ff;
   border: 1px solid #4945ff;
 }
 
-.c70:checked:after {
+.c71:checked:after {
   content: '';
   display: block;
   position: relative;
@@ -17854,21 +17862,21 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   transform: translateX(-50%) translateY(-50%);
 }
 
-.c70:checked:disabled:after {
+.c71:checked:disabled:after {
   background: url(test-file-stub) no-repeat no-repeat center center;
 }
 
-.c70:disabled {
+.c71:disabled {
   background-color: #dcdce4;
   border: 1px solid #c0c0cf;
 }
 
-.c70:indeterminate {
+.c71:indeterminate {
   background-color: #4945ff;
   border: 1px solid #4945ff;
 }
 
-.c70:indeterminate:after {
+.c71:indeterminate:after {
   content: '';
   display: block;
   position: relative;
@@ -17883,20 +17891,20 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   transform: translateX(-50%) translateY(-50%);
 }
 
-.c70:indeterminate:disabled {
+.c71:indeterminate:disabled {
   background-color: #dcdce4;
   border: 1px solid #c0c0cf;
 }
 
-.c70:indeterminate:disabled:after {
+.c71:indeterminate:disabled:after {
   background-color: #8e8ea9;
 }
 
-.c45 {
+.c46 {
   height: 100%;
 }
 
-.c43 {
+.c44 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -17908,7 +17916,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   background: #ffffff;
 }
 
-.c43 .c1 {
+.c44 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -17919,56 +17927,56 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   align-items: center;
 }
 
-.c43 .c7 {
+.c44 .c7 {
   color: #ffffff;
 }
 
-.c43[aria-disabled='true'] {
+.c44[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c43[aria-disabled='true'] .c7 {
+.c44[aria-disabled='true'] .c7 {
   color: #666687;
 }
 
-.c43[aria-disabled='true'] svg > g,
-.c43[aria-disabled='true'] svg path {
+.c44[aria-disabled='true'] svg > g,
+.c44[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c43[aria-disabled='true']:active {
+.c44[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c43[aria-disabled='true']:active .c7 {
+.c44[aria-disabled='true']:active .c7 {
   color: #666687;
 }
 
-.c43[aria-disabled='true']:active svg > g,
-.c43[aria-disabled='true']:active svg path {
+.c44[aria-disabled='true']:active svg > g,
+.c44[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c43:hover {
+.c44:hover {
   background-color: #f6f6f9;
 }
 
-.c43:active {
+.c44:active {
   background-color: #eaeaef;
 }
 
-.c43 .c7 {
+.c44 .c7 {
   color: #32324d;
 }
 
-.c43 svg > g,
-.c43 svg path {
+.c44 svg > g,
+.c44 svg path {
   fill: #32324d;
 }
 
-.c47 {
+.c48 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -17980,7 +17988,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   background: #4945ff;
 }
 
-.c47 .c1 {
+.c48 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -17991,49 +17999,49 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   align-items: center;
 }
 
-.c47 .c7 {
+.c48 .c7 {
   color: #ffffff;
 }
 
-.c47[aria-disabled='true'] {
+.c48[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c47[aria-disabled='true'] .c7 {
+.c48[aria-disabled='true'] .c7 {
   color: #666687;
 }
 
-.c47[aria-disabled='true'] svg > g,
-.c47[aria-disabled='true'] svg path {
+.c48[aria-disabled='true'] svg > g,
+.c48[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c47[aria-disabled='true']:active {
+.c48[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c47[aria-disabled='true']:active .c7 {
+.c48[aria-disabled='true']:active .c7 {
   color: #666687;
 }
 
-.c47[aria-disabled='true']:active svg > g,
-.c47[aria-disabled='true']:active svg path {
+.c48[aria-disabled='true']:active svg > g,
+.c48[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c47:hover {
+.c48:hover {
   border: 1px solid #7b79ff;
   background: #7b79ff;
 }
 
-.c47:active {
+.c48:active {
   border: 1px solid #4945ff;
   background: #4945ff;
 }
 
-.c59 {
+.c60 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -18045,7 +18053,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   background: #ffffff;
 }
 
-.c59 .c1 {
+.c60 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -18056,52 +18064,52 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   align-items: center;
 }
 
-.c59 .c7 {
+.c60 .c7 {
   color: #ffffff;
 }
 
-.c59[aria-disabled='true'] {
+.c60[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c59[aria-disabled='true'] .c7 {
+.c60[aria-disabled='true'] .c7 {
   color: #666687;
 }
 
-.c59[aria-disabled='true'] svg > g,
-.c59[aria-disabled='true'] svg path {
+.c60[aria-disabled='true'] svg > g,
+.c60[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c59[aria-disabled='true']:active {
+.c60[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c59[aria-disabled='true']:active .c7 {
+.c60[aria-disabled='true']:active .c7 {
   color: #666687;
 }
 
-.c59[aria-disabled='true']:active svg > g,
-.c59[aria-disabled='true']:active svg path {
+.c60[aria-disabled='true']:active svg > g,
+.c60[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c59:hover {
+.c60:hover {
   background-color: #f6f6f9;
 }
 
-.c59:active {
+.c60:active {
   background-color: #eaeaef;
 }
 
-.c59 .c7 {
+.c60 .c7 {
   color: #32324d;
 }
 
-.c59 svg > g,
-.c59 svg path {
+.c60 svg > g,
+.c60 svg path {
   fill: #32324d;
 }
 
@@ -18128,7 +18136,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   background-color: #dcdce4;
 }
 
-.c29 {
+.c30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -18146,50 +18154,50 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   color: #32324d;
 }
 
-.c29 svg > * {
+.c30 svg > * {
   fill: #666687;
 }
 
-.c29.active {
+.c30.active {
   background-color: #f0f0ff;
   border-right: 2px solid #4945ff;
 }
 
-.c29.active svg > * {
+.c30.active svg > * {
   fill: #271fe0;
 }
 
-.c29.active .c7 {
+.c30.active .c7 {
   color: #271fe0;
   font-weight: 500;
 }
 
-.c29:focus-visible {
+.c30:focus-visible {
   outline-offset: -2px;
 }
 
-.c30 {
+.c31 {
   width: 0.75rem;
   height: 0.25rem;
 }
 
-.c30 * {
+.c31 * {
   fill: #666687;
 }
 
-.c34 {
+.c35 {
   max-height: 2rem;
 }
 
-.c34 svg {
+.c35 svg {
   height: 0.25rem;
 }
 
-.c34 svg path {
+.c35 svg path {
   fill: #4a4a6a;
 }
 
-.c35 {
+.c36 {
   border: none;
   padding: 0;
   background: transparent;
@@ -18203,7 +18211,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   align-items: center;
 }
 
-.c36 {
+.c37 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -18266,42 +18274,42 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   grid-template-columns: auto 1fr;
 }
 
-.c39 {
+.c40 {
   overflow-x: hidden;
 }
 
-.c52 > * + * {
-  margin-left: 8px;
-}
-
-.c57 {
-  margin-left: auto;
-}
-
-.c57 > * + * {
+.c53 > * + * {
   margin-left: 8px;
 }
 
 .c58 {
+  margin-left: auto;
+}
+
+.c58 > * + * {
+  margin-left: 8px;
+}
+
+.c59 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c62 {
+.c63 {
   overflow: hidden;
 }
 
-.c66 {
+.c67 {
   width: 100%;
   white-space: nowrap;
 }
 
-.c63 {
+.c64 {
   position: relative;
 }
 
-.c63:before {
+.c64:before {
   background: linear-gradient(90deg,#c0c0cf 0%,rgba(0,0,0,0) 100%);
   opacity: 0.2;
   position: absolute;
@@ -18311,7 +18319,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   left: 0;
 }
 
-.c63:after {
+.c64:after {
   background: linear-gradient(270deg,#c0c0cf 0%,rgba(0,0,0,0) 100%);
   opacity: 0.2;
   position: absolute;
@@ -18322,54 +18330,54 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   top: 0;
 }
 
-.c65 {
+.c66 {
   overflow-x: auto;
 }
 
-.c73 tr:last-of-type {
+.c74 tr:last-of-type {
   border-bottom: none;
-}
-
-.c67 {
-  border-bottom: 1px solid #eaeaef;
 }
 
 .c68 {
   border-bottom: 1px solid #eaeaef;
 }
 
-.c68 td,
-.c68 th {
+.c69 {
+  border-bottom: 1px solid #eaeaef;
+}
+
+.c69 td,
+.c69 th {
   padding: 16px;
 }
 
-.c68 td:first-of-type,
-.c68 th:first-of-type {
+.c69 td:first-of-type,
+.c69 th:first-of-type {
   padding: 0 4px;
 }
 
-.c68 th {
+.c69 th {
   padding-top: 0;
   padding-bottom: 0;
   height: 3.5rem;
 }
 
-.c69 {
+.c70 {
   vertical-align: middle;
   text-align: left;
   color: #666687;
   outline-offset: -4px;
 }
 
-.c69 input {
+.c70 input {
   vertical-align: sub;
 }
 
-.c71 svg {
+.c72 svg {
   height: 0.25rem;
 }
 
-.c80 {
+.c81 {
   height: 1.5rem;
   width: 1.5rem;
   border-radius: 50%;
@@ -18387,32 +18395,32 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   align-items: center;
 }
 
-.c80 svg {
+.c81 svg {
   height: 0.625rem;
   width: 0.625rem;
 }
 
-.c80 svg path {
+.c81 svg path {
   fill: #4945ff;
 }
 
-.c78 {
+.c79 {
   border-radius: 0 0 4px 4px;
   display: block;
   width: 100%;
   border: none;
 }
 
-.c55 svg {
+.c56 svg {
   height: 0.5rem;
   width: 0.5rem;
 }
 
-.c55 svg path {
+.c56 svg path {
   fill: #4945ff;
 }
 
-.c56 {
+.c57 {
   border-right: 1px solid #d9d8ff;
   color: inherit;
   padding-right: 8px;
@@ -18545,15 +18553,16 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                   id="subnav-list-86"
                 >
                   <li>
-                    <div
-                      class="c1 c28 c29"
+                    <a
+                      class="c28 c1 c29 c30"
+                      target="_self"
                       to="/address"
                     >
                       <div
                         class="c1 c20"
                       >
                         <svg
-                          class="c30"
+                          class="c31"
                           fill="none"
                           height="1em"
                           viewBox="0 0 4 4"
@@ -18568,27 +18577,28 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           />
                         </svg>
                         <div
-                          class="c1 c31"
+                          class="c1 c32"
                         >
                           <span
-                            class="c7 c32"
+                            class="c7 c33"
                           >
                             Addresses
                           </span>
                         </div>
                       </div>
-                    </div>
+                    </a>
                   </li>
                   <li>
-                    <div
-                      class="c1 c28 c29"
+                    <a
+                      class="c28 c1 c29 c30"
+                      target="_self"
                       to="/category"
                     >
                       <div
                         class="c1 c20"
                       >
                         <svg
-                          class="c30"
+                          class="c31"
                           fill="none"
                           height="1em"
                           viewBox="0 0 4 4"
@@ -18603,27 +18613,28 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           />
                         </svg>
                         <div
-                          class="c1 c31"
+                          class="c1 c32"
                         >
                           <span
-                            class="c7 c32"
+                            class="c7 c33"
                           >
                             Categories
                           </span>
                         </div>
                       </div>
-                    </div>
+                    </a>
                   </li>
                   <li>
-                    <div
-                      class="c1 c28 c29"
+                    <a
+                      class="c28 c1 c29 c30"
+                      target="_self"
                       to="/city"
                     >
                       <div
                         class="c1 c20"
                       >
                         <svg
-                          class="c30"
+                          class="c31"
                           fill="none"
                           height="1em"
                           viewBox="0 0 4 4"
@@ -18638,27 +18649,28 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           />
                         </svg>
                         <div
-                          class="c1 c31"
+                          class="c1 c32"
                         >
                           <span
-                            class="c7 c32"
+                            class="c7 c33"
                           >
                             Cities
                           </span>
                         </div>
                       </div>
-                    </div>
+                    </a>
                   </li>
                   <li>
-                    <div
-                      class="c1 c28 c29"
+                    <a
+                      class="c28 c1 c29 c30"
+                      target="_self"
                       to="/country"
                     >
                       <div
                         class="c1 c20"
                       >
                         <svg
-                          class="c30"
+                          class="c31"
                           fill="none"
                           height="1em"
                           viewBox="0 0 4 4"
@@ -18673,16 +18685,16 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           />
                         </svg>
                         <div
-                          class="c1 c31"
+                          class="c1 c32"
                         >
                           <span
-                            class="c7 c32"
+                            class="c7 c33"
                           >
                             Countries
                           </span>
                         </div>
                       </div>
-                    </div>
+                    </a>
                   </li>
                 </ul>
               </div>
@@ -18750,7 +18762,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       class="c1 "
                     >
                       <div
-                        class="c1 c33 c34"
+                        class="c1 c34 c35"
                       >
                         <div
                           class="c1 c19"
@@ -18758,10 +18770,10 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           <button
                             aria-controls="subnav-list-88"
                             aria-expanded="true"
-                            class="c35"
+                            class="c36"
                           >
                             <div
-                              class="c36"
+                              class="c37"
                             >
                               <svg
                                 aria-hidden="true"
@@ -18780,10 +18792,10 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c1 c31"
+                              class="c1 c32"
                             >
                               <span
-                                class="c7 c37"
+                                class="c7 c38"
                               >
                                 Default
                               </span>
@@ -18795,15 +18807,16 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                         id="subnav-list-88"
                       >
                         <li>
-                          <div
-                            class="c1 c28 c29"
+                          <a
+                            class="c28 c1 c29 c30"
+                            target="_self"
                             to="/address"
                           >
                             <div
                               class="c1 c20"
                             >
                               <svg
-                                class="c30"
+                                class="c31"
                                 fill="none"
                                 height="1em"
                                 viewBox="0 0 4 4"
@@ -18818,27 +18831,28 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                                 />
                               </svg>
                               <div
-                                class="c1 c31"
+                                class="c1 c32"
                               >
                                 <span
-                                  class="c7 c32"
+                                  class="c7 c33"
                                 >
                                   Addresses
                                 </span>
                               </div>
                             </div>
-                          </div>
+                          </a>
                         </li>
                         <li>
-                          <div
-                            class="c1 c28 c29"
+                          <a
+                            class="c28 c1 c29 c30"
+                            target="_self"
                             to="/category"
                           >
                             <div
                               class="c1 c20"
                             >
                               <svg
-                                class="c30"
+                                class="c31"
                                 fill="none"
                                 height="1em"
                                 viewBox="0 0 4 4"
@@ -18853,27 +18867,28 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                                 />
                               </svg>
                               <div
-                                class="c1 c31"
+                                class="c1 c32"
                               >
                                 <span
-                                  class="c7 c32"
+                                  class="c7 c33"
                                 >
                                   Categories
                                 </span>
                               </div>
                             </div>
-                          </div>
+                          </a>
                         </li>
                         <li>
-                          <div
-                            class="c1 c28 c29"
+                          <a
+                            class="c28 c1 c29 c30"
+                            target="_self"
                             to="/city"
                           >
                             <div
                               class="c1 c20"
                             >
                               <svg
-                                class="c30"
+                                class="c31"
                                 fill="none"
                                 height="1em"
                                 viewBox="0 0 4 4"
@@ -18888,27 +18903,28 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                                 />
                               </svg>
                               <div
-                                class="c1 c31"
+                                class="c1 c32"
                               >
                                 <span
-                                  class="c7 c32"
+                                  class="c7 c33"
                                 >
                                   Cities
                                 </span>
                               </div>
                             </div>
-                          </div>
+                          </a>
                         </li>
                         <li>
-                          <div
-                            class="c1 c28 c29"
+                          <a
+                            class="c28 c1 c29 c30"
+                            target="_self"
                             to="/country"
                           >
                             <div
                               class="c1 c20"
                             >
                               <svg
-                                class="c30"
+                                class="c31"
                                 fill="none"
                                 height="1em"
                                 viewBox="0 0 4 4"
@@ -18923,16 +18939,16 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                                 />
                               </svg>
                               <div
-                                class="c1 c31"
+                                class="c1 c32"
                               >
                                 <span
-                                  class="c7 c32"
+                                  class="c7 c33"
                                 >
                                   Countries
                                 </span>
                               </div>
                             </div>
-                          </div>
+                          </a>
                         </li>
                       </ul>
                     </div>
@@ -18944,13 +18960,13 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
         </div>
       </nav>
       <div
-        class="c1 c38 c39"
+        class="c1 c39 c40"
       >
         <div
           style="height: 0px;"
         >
           <div
-            class="c1 c40"
+            class="c1 c41"
             data-strapi-header="true"
           >
             <div
@@ -18960,21 +18976,21 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                 class="c1 c20"
               >
                 <h2
-                  class="c7 c41"
+                  class="c7 c42"
                 >
                   Other CT
                 </h2>
                 <div
-                  class="c1 c42"
+                  class="c1 c43"
                 >
                   <button
                     aria-disabled="false"
-                    class="c9 c43"
+                    class="c9 c44"
                     type="button"
                   >
                     <div
                       aria-hidden="true"
-                      class="c1 c44 c45"
+                      class="c1 c45 c46"
                     >
                       <svg
                         fill="none"
@@ -18992,7 +19008,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </svg>
                     </div>
                     <span
-                      class="c7 c46"
+                      class="c7 c47"
                     >
                       Edit
                     </span>
@@ -19001,12 +19017,12 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
               </div>
               <button
                 aria-disabled="false"
-                class="c9 c47"
+                class="c9 c48"
                 type="button"
               >
                 <div
                   aria-hidden="true"
-                  class="c1 c44 c45"
+                  class="c1 c45 c46"
                 >
                   <svg
                     fill="none"
@@ -19022,51 +19038,51 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                   </svg>
                 </div>
                 <span
-                  class="c7 c46"
+                  class="c7 c47"
                 >
                   Add an entry
                 </span>
               </button>
             </div>
             <p
-              class="c7 c48"
+              class="c7 c49"
             >
               36 entries found
             </p>
           </div>
         </div>
         <div
-          class="c1 c49"
+          class="c1 c50"
         >
           <div
-            class="c1 c50"
+            class="c1 c51"
           >
             <div
               class="c1 c6"
             >
               <div
-                class="c1 c51 c52"
+                class="c1 c52 c53"
                 wrap="wrap"
               >
                 <div
-                  class="c1 c53"
+                  class="c1 c54"
                 >
                   <button
                     aria-disabled="false"
-                    class="c1 c54 c55"
+                    class="c1 c55 c56"
                     height="2rem"
                   >
                     <div
                       class="c1 c20"
                     >
                       <span
-                        class="c7 c46 c56"
+                        class="c7 c47 c57"
                       >
                         Hello world 
                         0
                       </span>
                       <div
-                        class="c1 c31"
+                        class="c1 c32"
                       >
                         <div
                           class="c1 c20"
@@ -19090,24 +19106,24 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                   </button>
                 </div>
                 <div
-                  class="c1 c53"
+                  class="c1 c54"
                 >
                   <button
                     aria-disabled="false"
-                    class="c1 c54 c55"
+                    class="c1 c55 c56"
                     height="2rem"
                   >
                     <div
                       class="c1 c20"
                     >
                       <span
-                        class="c7 c46 c56"
+                        class="c7 c47 c57"
                       >
                         Hello world 
                         1
                       </span>
                       <div
-                        class="c1 c31"
+                        class="c1 c32"
                       >
                         <div
                           class="c1 c20"
@@ -19131,24 +19147,24 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                   </button>
                 </div>
                 <div
-                  class="c1 c53"
+                  class="c1 c54"
                 >
                   <button
                     aria-disabled="false"
-                    class="c1 c54 c55"
+                    class="c1 c55 c56"
                     height="2rem"
                   >
                     <div
                       class="c1 c20"
                     >
                       <span
-                        class="c7 c46 c56"
+                        class="c7 c47 c57"
                       >
                         Hello world 
                         2
                       </span>
                       <div
-                        class="c1 c31"
+                        class="c1 c32"
                       >
                         <div
                           class="c1 c20"
@@ -19172,24 +19188,24 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                   </button>
                 </div>
                 <div
-                  class="c1 c53"
+                  class="c1 c54"
                 >
                   <button
                     aria-disabled="false"
-                    class="c1 c54 c55"
+                    class="c1 c55 c56"
                     height="2rem"
                   >
                     <div
                       class="c1 c20"
                     >
                       <span
-                        class="c7 c46 c56"
+                        class="c7 c47 c57"
                       >
                         Hello world 
                         3
                       </span>
                       <div
-                        class="c1 c31"
+                        class="c1 c32"
                       >
                         <div
                           class="c1 c20"
@@ -19213,24 +19229,24 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                   </button>
                 </div>
                 <div
-                  class="c1 c53"
+                  class="c1 c54"
                 >
                   <button
                     aria-disabled="false"
-                    class="c1 c54 c55"
+                    class="c1 c55 c56"
                     height="2rem"
                   >
                     <div
                       class="c1 c20"
                     >
                       <span
-                        class="c7 c46 c56"
+                        class="c7 c47 c57"
                       >
                         Hello world 
                         4
                       </span>
                       <div
-                        class="c1 c31"
+                        class="c1 c32"
                       >
                         <div
                           class="c1 c20"
@@ -19254,24 +19270,24 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                   </button>
                 </div>
                 <div
-                  class="c1 c53"
+                  class="c1 c54"
                 >
                   <button
                     aria-disabled="false"
-                    class="c1 c54 c55"
+                    class="c1 c55 c56"
                     height="2rem"
                   >
                     <div
                       class="c1 c20"
                     >
                       <span
-                        class="c7 c46 c56"
+                        class="c7 c47 c57"
                       >
                         Hello world 
                         5
                       </span>
                       <div
-                        class="c1 c31"
+                        class="c1 c32"
                       >
                         <div
                           class="c1 c20"
@@ -19295,24 +19311,24 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                   </button>
                 </div>
                 <div
-                  class="c1 c53"
+                  class="c1 c54"
                 >
                   <button
                     aria-disabled="false"
-                    class="c1 c54 c55"
+                    class="c1 c55 c56"
                     height="2rem"
                   >
                     <div
                       class="c1 c20"
                     >
                       <span
-                        class="c7 c46 c56"
+                        class="c7 c47 c57"
                       >
                         Hello world 
                         6
                       </span>
                       <div
-                        class="c1 c31"
+                        class="c1 c32"
                       >
                         <div
                           class="c1 c20"
@@ -19336,24 +19352,24 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                   </button>
                 </div>
                 <div
-                  class="c1 c53"
+                  class="c1 c54"
                 >
                   <button
                     aria-disabled="false"
-                    class="c1 c54 c55"
+                    class="c1 c55 c56"
                     height="2rem"
                   >
                     <div
                       class="c1 c20"
                     >
                       <span
-                        class="c7 c46 c56"
+                        class="c7 c47 c57"
                       >
                         Hello world 
                         7
                       </span>
                       <div
-                        class="c1 c31"
+                        class="c1 c32"
                       >
                         <div
                           class="c1 c20"
@@ -19377,24 +19393,24 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                   </button>
                 </div>
                 <div
-                  class="c1 c53"
+                  class="c1 c54"
                 >
                   <button
                     aria-disabled="false"
-                    class="c1 c54 c55"
+                    class="c1 c55 c56"
                     height="2rem"
                   >
                     <div
                       class="c1 c20"
                     >
                       <span
-                        class="c7 c46 c56"
+                        class="c7 c47 c57"
                       >
                         Hello world 
                         8
                       </span>
                       <div
-                        class="c1 c31"
+                        class="c1 c32"
                       >
                         <div
                           class="c1 c20"
@@ -19418,24 +19434,24 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                   </button>
                 </div>
                 <div
-                  class="c1 c53"
+                  class="c1 c54"
                 >
                   <button
                     aria-disabled="false"
-                    class="c1 c54 c55"
+                    class="c1 c55 c56"
                     height="2rem"
                   >
                     <div
                       class="c1 c20"
                     >
                       <span
-                        class="c7 c46 c56"
+                        class="c7 c47 c57"
                       >
                         Hello world 
                         9
                       </span>
                       <div
-                        class="c1 c31"
+                        class="c1 c32"
                       >
                         <div
                           class="c1 c20"
@@ -19459,24 +19475,24 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                   </button>
                 </div>
                 <div
-                  class="c1 c53"
+                  class="c1 c54"
                 >
                   <button
                     aria-disabled="false"
-                    class="c1 c54 c55"
+                    class="c1 c55 c56"
                     height="2rem"
                   >
                     <div
                       class="c1 c20"
                     >
                       <span
-                        class="c7 c46 c56"
+                        class="c7 c47 c57"
                       >
                         Hello world 
                         10
                       </span>
                       <div
-                        class="c1 c31"
+                        class="c1 c32"
                       >
                         <div
                           class="c1 c20"
@@ -19500,24 +19516,24 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                   </button>
                 </div>
                 <div
-                  class="c1 c53"
+                  class="c1 c54"
                 >
                   <button
                     aria-disabled="false"
-                    class="c1 c54 c55"
+                    class="c1 c55 c56"
                     height="2rem"
                   >
                     <div
                       class="c1 c20"
                     >
                       <span
-                        class="c7 c46 c56"
+                        class="c7 c47 c57"
                       >
                         Hello world 
                         11
                       </span>
                       <div
-                        class="c1 c31"
+                        class="c1 c32"
                       >
                         <div
                           class="c1 c20"
@@ -19541,24 +19557,24 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                   </button>
                 </div>
                 <div
-                  class="c1 c53"
+                  class="c1 c54"
                 >
                   <button
                     aria-disabled="false"
-                    class="c1 c54 c55"
+                    class="c1 c55 c56"
                     height="2rem"
                   >
                     <div
                       class="c1 c20"
                     >
                       <span
-                        class="c7 c46 c56"
+                        class="c7 c47 c57"
                       >
                         Hello world 
                         12
                       </span>
                       <div
-                        class="c1 c31"
+                        class="c1 c32"
                       >
                         <div
                           class="c1 c20"
@@ -19582,24 +19598,24 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                   </button>
                 </div>
                 <div
-                  class="c1 c53"
+                  class="c1 c54"
                 >
                   <button
                     aria-disabled="false"
-                    class="c1 c54 c55"
+                    class="c1 c55 c56"
                     height="2rem"
                   >
                     <div
                       class="c1 c20"
                     >
                       <span
-                        class="c7 c46 c56"
+                        class="c7 c47 c57"
                       >
                         Hello world 
                         13
                       </span>
                       <div
-                        class="c1 c31"
+                        class="c1 c32"
                       >
                         <div
                           class="c1 c20"
@@ -19623,24 +19639,24 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                   </button>
                 </div>
                 <div
-                  class="c1 c53"
+                  class="c1 c54"
                 >
                   <button
                     aria-disabled="false"
-                    class="c1 c54 c55"
+                    class="c1 c55 c56"
                     height="2rem"
                   >
                     <div
                       class="c1 c20"
                     >
                       <span
-                        class="c7 c46 c56"
+                        class="c7 c47 c57"
                       >
                         Hello world 
                         14
                       </span>
                       <div
-                        class="c1 c31"
+                        class="c1 c32"
                       >
                         <div
                           class="c1 c20"
@@ -19664,24 +19680,24 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                   </button>
                 </div>
                 <div
-                  class="c1 c53"
+                  class="c1 c54"
                 >
                   <button
                     aria-disabled="false"
-                    class="c1 c54 c55"
+                    class="c1 c55 c56"
                     height="2rem"
                   >
                     <div
                       class="c1 c20"
                     >
                       <span
-                        class="c7 c46 c56"
+                        class="c7 c47 c57"
                       >
                         Hello world 
                         15
                       </span>
                       <div
-                        class="c1 c31"
+                        class="c1 c32"
                       >
                         <div
                           class="c1 c20"
@@ -19705,24 +19721,24 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                   </button>
                 </div>
                 <div
-                  class="c1 c53"
+                  class="c1 c54"
                 >
                   <button
                     aria-disabled="false"
-                    class="c1 c54 c55"
+                    class="c1 c55 c56"
                     height="2rem"
                   >
                     <div
                       class="c1 c20"
                     >
                       <span
-                        class="c7 c46 c56"
+                        class="c7 c47 c57"
                       >
                         Hello world 
                         16
                       </span>
                       <div
-                        class="c1 c31"
+                        class="c1 c32"
                       >
                         <div
                           class="c1 c20"
@@ -19746,24 +19762,24 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                   </button>
                 </div>
                 <div
-                  class="c1 c53"
+                  class="c1 c54"
                 >
                   <button
                     aria-disabled="false"
-                    class="c1 c54 c55"
+                    class="c1 c55 c56"
                     height="2rem"
                   >
                     <div
                       class="c1 c20"
                     >
                       <span
-                        class="c7 c46 c56"
+                        class="c7 c47 c57"
                       >
                         Hello world 
                         17
                       </span>
                       <div
-                        class="c1 c31"
+                        class="c1 c32"
                       >
                         <div
                           class="c1 c20"
@@ -19787,24 +19803,24 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                   </button>
                 </div>
                 <div
-                  class="c1 c53"
+                  class="c1 c54"
                 >
                   <button
                     aria-disabled="false"
-                    class="c1 c54 c55"
+                    class="c1 c55 c56"
                     height="2rem"
                   >
                     <div
                       class="c1 c20"
                     >
                       <span
-                        class="c7 c46 c56"
+                        class="c7 c47 c57"
                       >
                         Hello world 
                         18
                       </span>
                       <div
-                        class="c1 c31"
+                        class="c1 c32"
                       >
                         <div
                           class="c1 c20"
@@ -19828,24 +19844,24 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                   </button>
                 </div>
                 <div
-                  class="c1 c53"
+                  class="c1 c54"
                 >
                   <button
                     aria-disabled="false"
-                    class="c1 c54 c55"
+                    class="c1 c55 c56"
                     height="2rem"
                   >
                     <div
                       class="c1 c20"
                     >
                       <span
-                        class="c7 c46 c56"
+                        class="c7 c47 c57"
                       >
                         Hello world 
                         19
                       </span>
                       <div
-                        class="c1 c31"
+                        class="c1 c32"
                       >
                         <div
                           class="c1 c20"
@@ -19870,26 +19886,26 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                 </div>
               </div>
               <div
-                class="c1 c20 c57 c58"
+                class="c1 c20 c58 c59"
               >
                 <button
                   aria-disabled="false"
-                  class="c9 c59"
+                  class="c9 c60"
                   type="button"
                 >
                   <span
-                    class="c7 c60"
+                    class="c7 c61"
                   >
                     Settings
                   </span>
                 </button>
                 <button
                   aria-disabled="false"
-                  class="c9 c59"
+                  class="c9 c60"
                   type="button"
                 >
                   <span
-                    class="c7 c60"
+                    class="c7 c61"
                   >
                     Settings
                   </span>
@@ -19899,140 +19915,140 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
           </div>
         </div>
         <div
-          class="c1 c49"
+          class="c1 c50"
         >
           <div
-            class="c1 c61 c62"
+            class="c1 c62 c63"
           >
             <div
-              class="c1 c63"
+              class="c1 c64"
             >
               <div
-                class="c1 c64 c65"
+                class="c1 c65 c66"
               >
                 <table
                   aria-colcount="10"
                   aria-rowcount="6"
-                  class="c66"
+                  class="c67"
                 >
                   <thead
-                    class="c67"
+                    class="c68"
                   >
                     <tr
                       aria-rowindex="1"
-                      class="c1 c68"
+                      class="c1 c69"
                     >
                       <th
                         aria-colindex="1"
-                        class="c1 c69"
+                        class="c1 c70"
                       >
                         <div
                           class="c1 c20"
                         >
                           <input
                             aria-label="Select all entries"
-                            class="c70"
+                            class="c71"
                             tabindex="0"
                             type="checkbox"
                           />
                           <span
-                            class="c71"
+                            class="c72"
                           />
                         </div>
                       </th>
                       <th
                         aria-colindex="2"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <div
                           class="c1 c20"
                         >
                           <span
-                            class="c7 c72"
+                            class="c7 c73"
                           >
                             ID
                           </span>
                           <span
-                            class="c71"
+                            class="c72"
                           />
                         </div>
                       </th>
                       <th
                         aria-colindex="3"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <div
                           class="c1 c20"
                         >
                           <span
-                            class="c7 c72"
+                            class="c7 c73"
                           >
                             Cover
                           </span>
                           <span
-                            class="c71"
+                            class="c72"
                           />
                         </div>
                       </th>
                       <th
                         aria-colindex="4"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <div
                           class="c1 c20"
                         >
                           <span
-                            class="c7 c72"
+                            class="c7 c73"
                           >
                             Description
                           </span>
                           <span
-                            class="c71"
+                            class="c72"
                           />
                         </div>
                       </th>
                       <th
                         aria-colindex="5"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <div
                           class="c1 c20"
                         >
                           <span
-                            class="c7 c72"
+                            class="c7 c73"
                           >
                             Categories
                           </span>
                           <span
-                            class="c71"
+                            class="c72"
                           />
                         </div>
                       </th>
                       <th
                         aria-colindex="6"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <div
                           class="c1 c20"
                         >
                           <span
-                            class="c7 c72"
+                            class="c7 c73"
                           >
                             Contact
                           </span>
                           <span
-                            class="c71"
+                            class="c72"
                           />
                         </div>
                       </th>
                       <th
                         aria-colindex="7"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <div
@@ -20040,13 +20056,13 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                         >
                           More
                           <span
-                            class="c71"
+                            class="c72"
                           />
                         </div>
                       </th>
                       <th
                         aria-colindex="8"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <div
@@ -20054,13 +20070,13 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                         >
                           More
                           <span
-                            class="c71"
+                            class="c72"
                           />
                         </div>
                       </th>
                       <th
                         aria-colindex="9"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <div
@@ -20068,13 +20084,13 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                         >
                           More
                           <span
-                            class="c71"
+                            class="c72"
                           />
                         </div>
                       </th>
                       <th
                         aria-colindex="10"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <div
@@ -20086,53 +20102,53 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                             Actions
                           </div>
                           <span
-                            class="c71"
+                            class="c72"
                           />
                         </div>
                       </th>
                     </tr>
                   </thead>
                   <tbody
-                    class="c73"
+                    class="c74"
                   >
                     <tr
                       aria-rowindex="2"
-                      class="c1 c68"
+                      class="c1 c69"
                     >
                       <td
                         aria-colindex="1"
-                        class="c1 c69"
+                        class="c1 c70"
                       >
                         <input
                           aria-label="Select Leon Lafrite"
-                          class="c70"
+                          class="c71"
                           tabindex="-1"
                           type="checkbox"
                         />
                       </td>
                       <td
                         aria-colindex="2"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           0
                         </span>
                       </td>
                       <td
                         aria-colindex="3"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span>
                           <div
-                            class="c74"
+                            class="c75"
                           >
                             <img
                               alt="Leon Lafrite"
-                              class="c75"
+                              class="c76"
                               height="26px"
                               src="https://avatars.githubusercontent.com/u/3874873?v=4"
                               width="26px"
@@ -20142,73 +20158,73 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </td>
                       <td
                         aria-colindex="4"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           Chez Léon is a human sized Parisian
                         </span>
                       </td>
                       <td
                         aria-colindex="5"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           French cuisine
                         </span>
                       </td>
                       <td
                         aria-colindex="6"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           Leon Lafrite
                         </span>
                       </td>
                       <td
                         aria-colindex="7"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           Chez Léon is a human sized Parisian
                         </span>
                       </td>
                       <td
                         aria-colindex="8"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           Chez Léon is a human sized Parisian
                         </span>
                       </td>
                       <td
                         aria-colindex="9"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           Chez Léon is a human sized Parisian
                         </span>
                       </td>
                       <td
                         aria-colindex="10"
-                        class="c1 c69"
+                        class="c1 c70"
                       >
                         <div
                           class="c1 c20"
@@ -20238,7 +20254,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                             </button>
                           </span>
                           <div
-                            class="c1 c76"
+                            class="c1 c77"
                           >
                             <span>
                               <button
@@ -20268,42 +20284,42 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                     </tr>
                     <tr
                       aria-rowindex="3"
-                      class="c1 c68"
+                      class="c1 c69"
                     >
                       <td
                         aria-colindex="1"
-                        class="c1 c69"
+                        class="c1 c70"
                       >
                         <input
                           aria-label="Select Leon Lafrite"
-                          class="c70"
+                          class="c71"
                           tabindex="-1"
                           type="checkbox"
                         />
                       </td>
                       <td
                         aria-colindex="2"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           1
                         </span>
                       </td>
                       <td
                         aria-colindex="3"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span>
                           <div
-                            class="c74"
+                            class="c75"
                           >
                             <img
                               alt="Leon Lafrite"
-                              class="c75"
+                              class="c76"
                               height="26px"
                               src="https://avatars.githubusercontent.com/u/3874873?v=4"
                               width="26px"
@@ -20313,73 +20329,73 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </td>
                       <td
                         aria-colindex="4"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           Chez Léon is a human sized Parisian
                         </span>
                       </td>
                       <td
                         aria-colindex="5"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           French cuisine
                         </span>
                       </td>
                       <td
                         aria-colindex="6"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           Leon Lafrite
                         </span>
                       </td>
                       <td
                         aria-colindex="7"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           Chez Léon is a human sized Parisian
                         </span>
                       </td>
                       <td
                         aria-colindex="8"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           Chez Léon is a human sized Parisian
                         </span>
                       </td>
                       <td
                         aria-colindex="9"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           Chez Léon is a human sized Parisian
                         </span>
                       </td>
                       <td
                         aria-colindex="10"
-                        class="c1 c69"
+                        class="c1 c70"
                       >
                         <div
                           class="c1 c20"
@@ -20409,7 +20425,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                             </button>
                           </span>
                           <div
-                            class="c1 c76"
+                            class="c1 c77"
                           >
                             <span>
                               <button
@@ -20439,42 +20455,42 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                     </tr>
                     <tr
                       aria-rowindex="4"
-                      class="c1 c68"
+                      class="c1 c69"
                     >
                       <td
                         aria-colindex="1"
-                        class="c1 c69"
+                        class="c1 c70"
                       >
                         <input
                           aria-label="Select Leon Lafrite"
-                          class="c70"
+                          class="c71"
                           tabindex="-1"
                           type="checkbox"
                         />
                       </td>
                       <td
                         aria-colindex="2"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           2
                         </span>
                       </td>
                       <td
                         aria-colindex="3"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span>
                           <div
-                            class="c74"
+                            class="c75"
                           >
                             <img
                               alt="Leon Lafrite"
-                              class="c75"
+                              class="c76"
                               height="26px"
                               src="https://avatars.githubusercontent.com/u/3874873?v=4"
                               width="26px"
@@ -20484,73 +20500,73 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </td>
                       <td
                         aria-colindex="4"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           Chez Léon is a human sized Parisian
                         </span>
                       </td>
                       <td
                         aria-colindex="5"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           French cuisine
                         </span>
                       </td>
                       <td
                         aria-colindex="6"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           Leon Lafrite
                         </span>
                       </td>
                       <td
                         aria-colindex="7"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           Chez Léon is a human sized Parisian
                         </span>
                       </td>
                       <td
                         aria-colindex="8"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           Chez Léon is a human sized Parisian
                         </span>
                       </td>
                       <td
                         aria-colindex="9"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           Chez Léon is a human sized Parisian
                         </span>
                       </td>
                       <td
                         aria-colindex="10"
-                        class="c1 c69"
+                        class="c1 c70"
                       >
                         <div
                           class="c1 c20"
@@ -20580,7 +20596,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                             </button>
                           </span>
                           <div
-                            class="c1 c76"
+                            class="c1 c77"
                           >
                             <span>
                               <button
@@ -20610,42 +20626,42 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                     </tr>
                     <tr
                       aria-rowindex="5"
-                      class="c1 c68"
+                      class="c1 c69"
                     >
                       <td
                         aria-colindex="1"
-                        class="c1 c69"
+                        class="c1 c70"
                       >
                         <input
                           aria-label="Select Leon Lafrite"
-                          class="c70"
+                          class="c71"
                           tabindex="-1"
                           type="checkbox"
                         />
                       </td>
                       <td
                         aria-colindex="2"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           3
                         </span>
                       </td>
                       <td
                         aria-colindex="3"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span>
                           <div
-                            class="c74"
+                            class="c75"
                           >
                             <img
                               alt="Leon Lafrite"
-                              class="c75"
+                              class="c76"
                               height="26px"
                               src="https://avatars.githubusercontent.com/u/3874873?v=4"
                               width="26px"
@@ -20655,73 +20671,73 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </td>
                       <td
                         aria-colindex="4"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           Chez Léon is a human sized Parisian
                         </span>
                       </td>
                       <td
                         aria-colindex="5"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           French cuisine
                         </span>
                       </td>
                       <td
                         aria-colindex="6"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           Leon Lafrite
                         </span>
                       </td>
                       <td
                         aria-colindex="7"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           Chez Léon is a human sized Parisian
                         </span>
                       </td>
                       <td
                         aria-colindex="8"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           Chez Léon is a human sized Parisian
                         </span>
                       </td>
                       <td
                         aria-colindex="9"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           Chez Léon is a human sized Parisian
                         </span>
                       </td>
                       <td
                         aria-colindex="10"
-                        class="c1 c69"
+                        class="c1 c70"
                       >
                         <div
                           class="c1 c20"
@@ -20751,7 +20767,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                             </button>
                           </span>
                           <div
-                            class="c1 c76"
+                            class="c1 c77"
                           >
                             <span>
                               <button
@@ -20781,42 +20797,42 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                     </tr>
                     <tr
                       aria-rowindex="6"
-                      class="c1 c68"
+                      class="c1 c69"
                     >
                       <td
                         aria-colindex="1"
-                        class="c1 c69"
+                        class="c1 c70"
                       >
                         <input
                           aria-label="Select Leon Lafrite"
-                          class="c70"
+                          class="c71"
                           tabindex="-1"
                           type="checkbox"
                         />
                       </td>
                       <td
                         aria-colindex="2"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           4
                         </span>
                       </td>
                       <td
                         aria-colindex="3"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span>
                           <div
-                            class="c74"
+                            class="c75"
                           >
                             <img
                               alt="Leon Lafrite"
-                              class="c75"
+                              class="c76"
                               height="26px"
                               src="https://avatars.githubusercontent.com/u/3874873?v=4"
                               width="26px"
@@ -20826,73 +20842,73 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </td>
                       <td
                         aria-colindex="4"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           Chez Léon is a human sized Parisian
                         </span>
                       </td>
                       <td
                         aria-colindex="5"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           French cuisine
                         </span>
                       </td>
                       <td
                         aria-colindex="6"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           Leon Lafrite
                         </span>
                       </td>
                       <td
                         aria-colindex="7"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           Chez Léon is a human sized Parisian
                         </span>
                       </td>
                       <td
                         aria-colindex="8"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           Chez Léon is a human sized Parisian
                         </span>
                       </td>
                       <td
                         aria-colindex="9"
-                        class="c1 c69"
+                        class="c1 c70"
                         tabindex="-1"
                       >
                         <span
-                          class="c7 c32"
+                          class="c7 c33"
                         >
                           Chez Léon is a human sized Parisian
                         </span>
                       </td>
                       <td
                         aria-colindex="10"
-                        class="c1 c69"
+                        class="c1 c70"
                       >
                         <div
                           class="c1 c20"
@@ -20922,7 +20938,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                             </button>
                           </span>
                           <div
-                            class="c1 c76"
+                            class="c1 c77"
                           >
                             <span>
                               <button
@@ -20959,14 +20975,14 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                 class="c1 c12 c13"
               />
               <button
-                class="c1 c77 c78"
+                class="c1 c78 c79"
               >
                 <div
                   class="c1 c20"
                 >
                   <div
                     aria-hidden="true"
-                    class="c1 c79 c80"
+                    class="c1 c80 c81"
                   >
                     <svg
                       fill="none"
@@ -20982,10 +20998,10 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                     </svg>
                   </div>
                   <div
-                    class="c1 c81"
+                    class="c1 c82"
                   >
                     <span
-                      class="c7 c82"
+                      class="c7 c83"
                     >
                       Add another field to this collection type
                     </span>
@@ -22718,8 +22734,7 @@ exports[`Storyshots Design System/Components/LinkButton base 1`] = `
       aria-disabled="false"
       class="c3 c4 c5"
       href="https://strapi.io/"
-      rel="noreferrer noopener"
-      target="_blank"
+      target="_self"
     >
       <span
         class="c6 c7"
@@ -22903,6 +22918,7 @@ exports[`Storyshots Design System/Components/LinkButton disabled 1`] = `
     <a
       aria-disabled="true"
       class="c3 c4 c5"
+      target="_self"
       to="/"
     >
       <div
@@ -23210,6 +23226,7 @@ exports[`Storyshots Design System/Components/LinkButton icons 1`] = `
       <a
         aria-disabled="false"
         class="c4 c5 c6"
+        target="_self"
         to="/"
       >
         <div
@@ -23239,6 +23256,7 @@ exports[`Storyshots Design System/Components/LinkButton icons 1`] = `
     <a
       aria-disabled="false"
       class="c4 c5 c10"
+      target="_self"
       to="/"
     >
       <span
@@ -23530,6 +23548,7 @@ exports[`Storyshots Design System/Components/LinkButton sizes 1`] = `
       <a
         aria-disabled="false"
         class="c4 c5 c6"
+        target="_self"
         to="/"
       >
         <span
@@ -23542,6 +23561,7 @@ exports[`Storyshots Design System/Components/LinkButton sizes 1`] = `
     <a
       aria-disabled="false"
       class="c4 c5 c9"
+      target="_self"
       to="/"
     >
       <span
@@ -24205,6 +24225,7 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
       <a
         aria-disabled="false"
         class="c4 c5 c6"
+        target="_self"
         to="/"
       >
         <span
@@ -24220,6 +24241,7 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
       <a
         aria-disabled="false"
         class="c4 c5 c9"
+        target="_self"
         to="/"
       >
         <span
@@ -24235,6 +24257,7 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
       <a
         aria-disabled="false"
         class="c4 c5 c10"
+        target="_self"
         to="/"
       >
         <span
@@ -24250,6 +24273,7 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
       <a
         aria-disabled="false"
         class="c4 c5 c11"
+        target="_self"
         to="/"
       >
         <span
@@ -24265,6 +24289,7 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
       <a
         aria-disabled="false"
         class="c4 c5 c12"
+        target="_self"
         to="/"
       >
         <span
@@ -24280,6 +24305,7 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
       <a
         aria-disabled="false"
         class="c4 c5 c13"
+        target="_self"
         to="/"
       >
         <span
@@ -24295,6 +24321,7 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
       <a
         aria-disabled="false"
         class="c4 c5 c14"
+        target="_self"
         to="/"
       >
         <span
@@ -25286,6 +25313,7 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
     >
       <a
         class="c3 c4"
+        target="_self"
         to="/"
       >
         <div
@@ -25339,6 +25367,7 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
           <li>
             <a
               class="c3 c16 active"
+              target="_self"
               to="/cm"
             >
               <span
@@ -25394,6 +25423,7 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
                 <li>
                   <a
                     class="c3 c16"
+                    target="_self"
                     to="/builder"
                   >
                     <span
@@ -25431,6 +25461,7 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
                 <li>
                   <a
                     class="c3 c16"
+                    target="_self"
                     to="/content"
                   >
                     <span
@@ -25470,6 +25501,7 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
                 <li>
                   <a
                     class="c3 c16"
+                    target="_self"
                     to="/content"
                   >
                     <span
@@ -25526,6 +25558,7 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
                 <li>
                   <a
                     class="c3 c16"
+                    target="_self"
                     to="/builder"
                   >
                     <span
@@ -25565,6 +25598,7 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
                 <li>
                   <a
                     class="c3 c16"
+                    target="_self"
                     to="/content"
                   >
                     <span
@@ -25604,6 +25638,7 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
                 <li>
                   <a
                     class="c3 c16"
+                    target="_self"
                     to="/content"
                   >
                     <span
@@ -26115,6 +26150,7 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
     >
       <a
         class="c3 c4"
+        target="_self"
         to="/"
       >
         <div
@@ -26168,6 +26204,7 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
           <li>
             <a
               class="c3 c16 active"
+              target="_self"
               to="/cm"
             >
               <span
@@ -26223,6 +26260,7 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
                 <li>
                   <a
                     class="c3 c16"
+                    target="_self"
                     to="/builder"
                   >
                     <span
@@ -26260,6 +26298,7 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
                 <li>
                   <a
                     class="c3 c16"
+                    target="_self"
                     to="/content"
                   >
                     <span
@@ -26299,6 +26338,7 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
                 <li>
                   <a
                     class="c3 c16"
+                    target="_self"
                     to="/content"
                   >
                     <span
@@ -26355,6 +26395,7 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
                 <li>
                   <a
                     class="c3 c16"
+                    target="_self"
                     to="/builder"
                   >
                     <span
@@ -26394,6 +26435,7 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
                 <li>
                   <a
                     class="c3 c16"
+                    target="_self"
                     to="/content"
                   >
                     <span
@@ -26443,6 +26485,7 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
                 <li>
                   <a
                     class="c3 c16"
+                    target="_self"
                     to="/content"
                   >
                     <span
@@ -28844,8 +28887,9 @@ exports[`Storyshots Design System/Components/Pagination base 1`] = `
         <a
           aria-disabled="true"
           class="c3 c4 c5"
+          href="/1"
           tabindex="-1"
-          to="#"
+          target="_self"
         >
           <div
             class="c0"
@@ -28870,7 +28914,8 @@ exports[`Storyshots Design System/Components/Pagination base 1`] = `
       <li>
         <a
           class="c3 c6 c7"
-          to="/1"
+          href="/1"
+          target="_self"
         >
           <div
             class="c0"
@@ -28888,7 +28933,8 @@ exports[`Storyshots Design System/Components/Pagination base 1`] = `
       <li>
         <a
           class="c3 c4 c10"
-          to="/2"
+          href="/2"
+          target="_self"
         >
           <div
             class="c0"
@@ -28923,7 +28969,8 @@ exports[`Storyshots Design System/Components/Pagination base 1`] = `
       <li>
         <a
           class="c3 c4 c10"
-          to="/25"
+          href="/25"
+          target="_self"
         >
           <div
             class="c0"
@@ -28941,7 +28988,8 @@ exports[`Storyshots Design System/Components/Pagination base 1`] = `
       <li>
         <a
           class="c3 c4 c10"
-          to="/26"
+          href="/26"
+          target="_self"
         >
           <div
             class="c0"
@@ -28960,7 +29008,8 @@ exports[`Storyshots Design System/Components/Pagination base 1`] = `
         <a
           aria-disabled="false"
           class="c3 c4 c13"
-          to="/3"
+          href="/3"
+          target="_self"
         >
           <div
             class="c0"
@@ -32837,19 +32886,19 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   text-transform: uppercase;
 }
 
-.c30 {
+.c31 {
   color: #32324d;
   font-size: 0.875rem;
   line-height: 1.43;
 }
 
-.c34 {
+.c35 {
   color: #4945ff;
   font-size: 0.75rem;
   line-height: 1.33;
 }
 
-.c39 {
+.c40 {
   font-weight: 500;
   color: #32324d;
   font-size: 0.875rem;
@@ -32898,33 +32947,33 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   min-width: 20px;
 }
 
-.c26 {
+.c27 {
   background: #f6f6f9;
   padding-top: 8px;
   padding-bottom: 8px;
   padding-left: 32px;
 }
 
-.c29 {
+.c30 {
   padding-left: 8px;
 }
 
-.c31 {
+.c32 {
   padding-left: 32px;
 }
 
-.c33 {
+.c34 {
   padding-right: 8px;
 }
 
-.c35 {
+.c36 {
   padding-top: 8px;
   padding-right: 16px;
   padding-bottom: 8px;
   padding-left: 32px;
 }
 
-.c41 {
+.c42 {
   padding-right: 16px;
 }
 
@@ -32996,22 +33045,22 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   align-items: center;
 }
 
-.c32 {
+.c33 {
   background: transparent;
   border: none;
   position: relative;
   outline: none;
 }
 
-.c32[aria-disabled='true'] {
+.c33[aria-disabled='true'] {
   pointer-events: none;
 }
 
-.c32[aria-disabled='true'] svg path {
+.c33[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c32 svg {
+.c33 svg {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -33019,11 +33068,11 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   font-size: 0.625rem;
 }
 
-.c32 svg path {
+.c33 svg path {
   fill: #4945ff;
 }
 
-.c32:after {
+.c33:after {
   -webkit-transition-property: all;
   transition-property: all;
   -webkit-transition-duration: 0.2s;
@@ -33038,11 +33087,11 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   border: 2px solid transparent;
 }
 
-.c32:focus-visible {
+.c33:focus-visible {
   outline: none;
 }
 
-.c32:focus-visible:after {
+.c33:focus-visible:after {
   border-radius: 8px;
   content: '';
   position: absolute;
@@ -33170,6 +33219,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   fill: #666687;
 }
 
+.c26 {
+  cursor: pointer;
+}
+
 .c12 {
   height: 1px;
   border: none;
@@ -33193,7 +33246,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   background-color: #dcdce4;
 }
 
-.c27 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -33211,64 +33264,64 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   color: #32324d;
 }
 
-.c27 svg > * {
+.c28 svg > * {
   fill: #666687;
 }
 
-.c27.active {
+.c28.active {
   background-color: #f0f0ff;
   border-right: 2px solid #4945ff;
 }
 
-.c27.active svg > * {
+.c28.active svg > * {
   fill: #271fe0;
 }
 
-.c27.active .c6 {
+.c28.active .c6 {
   color: #271fe0;
   font-weight: 500;
 }
 
-.c27:focus-visible {
+.c28:focus-visible {
   outline-offset: -2px;
 }
 
-.c28 {
+.c29 {
   width: 0.75rem;
   height: 0.25rem;
 }
 
-.c28 * {
+.c29 * {
   fill: #666687;
 }
 
-.c42 {
+.c43 {
   width: 0.75rem;
   height: 0.25rem;
 }
 
-.c42 * {
+.c43 * {
   fill: #4945ff;
 }
 
-.c40 svg {
+.c41 svg {
   height: 0.75rem;
   width: 0.75rem;
 }
 
-.c36 {
+.c37 {
   max-height: 2rem;
 }
 
-.c36 svg {
+.c37 svg {
   height: 0.25rem;
 }
 
-.c36 svg path {
+.c37 svg path {
   fill: #4a4a6a;
 }
 
-.c37 {
+.c38 {
   border: none;
   padding: 0;
   background: transparent;
@@ -33282,7 +33335,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   align-items: center;
 }
 
-.c38 {
+.c39 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -33468,15 +33521,16 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                   id="subnav-list-132"
                 >
                   <li>
-                    <div
-                      class="c26 c27"
+                    <a
+                      class="c26 c27 c28"
+                      target="_self"
                       to="/address"
                     >
                       <div
                         class="c1"
                       >
                         <svg
-                          class="c28"
+                          class="c29"
                           fill="none"
                           height="1em"
                           viewBox="0 0 4 4"
@@ -33491,27 +33545,28 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           />
                         </svg>
                         <div
-                          class="c29"
+                          class="c30"
                         >
                           <span
-                            class="c6 c30"
+                            class="c6 c31"
                           >
                             Addresses
                           </span>
                         </div>
                       </div>
-                    </div>
+                    </a>
                   </li>
                   <li>
-                    <div
-                      class="c26 c27"
+                    <a
+                      class="c26 c27 c28"
+                      target="_self"
                       to="/category"
                     >
                       <div
                         class="c1"
                       >
                         <svg
-                          class="c28"
+                          class="c29"
                           fill="none"
                           height="1em"
                           viewBox="0 0 4 4"
@@ -33526,27 +33581,28 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           />
                         </svg>
                         <div
-                          class="c29"
+                          class="c30"
                         >
                           <span
-                            class="c6 c30"
+                            class="c6 c31"
                           >
                             Categories
                           </span>
                         </div>
                       </div>
-                    </div>
+                    </a>
                   </li>
                   <li>
-                    <div
-                      class="c26 c27"
+                    <a
+                      class="c26 c27 c28"
+                      target="_self"
                       to="/city"
                     >
                       <div
                         class="c1"
                       >
                         <svg
-                          class="c28"
+                          class="c29"
                           fill="none"
                           height="1em"
                           viewBox="0 0 4 4"
@@ -33561,27 +33617,28 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           />
                         </svg>
                         <div
-                          class="c29"
+                          class="c30"
                         >
                           <span
-                            class="c6 c30"
+                            class="c6 c31"
                           >
                             Cities
                           </span>
                         </div>
                       </div>
-                    </div>
+                    </a>
                   </li>
                   <li>
-                    <div
-                      class="c26 c27"
+                    <a
+                      class="c26 c27 c28"
+                      target="_self"
                       to="/country"
                     >
                       <div
                         class="c1"
                       >
                         <svg
-                          class="c28"
+                          class="c29"
                           fill="none"
                           height="1em"
                           viewBox="0 0 4 4"
@@ -33596,32 +33653,32 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           />
                         </svg>
                         <div
-                          class="c29"
+                          class="c30"
                         >
                           <span
-                            class="c6 c30"
+                            class="c6 c31"
                           >
                             Countries
                           </span>
                         </div>
                       </div>
-                    </div>
+                    </a>
                   </li>
                 </ul>
               </div>
             </li>
             <li>
               <div
-                class="c31"
+                class="c32"
               >
                 <button
                   aria-disabled="false"
-                  class="c1 c32"
+                  class="c1 c33"
                   type="button"
                 >
                   <span
                     aria-hidden="true"
-                    class="c33"
+                    class="c34"
                   >
                     <svg
                       fill="none"
@@ -33637,7 +33694,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                     </svg>
                   </span>
                   <span
-                    class="c6 c34"
+                    class="c6 c35"
                   >
                     Click on me
                   </span>
@@ -33707,7 +33764,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       class=""
                     >
                       <div
-                        class="c35 c36"
+                        class="c36 c37"
                       >
                         <div
                           class="c18"
@@ -33715,10 +33772,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           <button
                             aria-controls="subnav-list-134"
                             aria-expanded="true"
-                            class="c37"
+                            class="c38"
                           >
                             <div
-                              class="c38"
+                              class="c39"
                             >
                               <svg
                                 aria-hidden="true"
@@ -33737,10 +33794,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c29"
+                              class="c30"
                             >
                               <span
-                                class="c6 c39"
+                                class="c6 c40"
                               >
                                 Default
                               </span>
@@ -33752,15 +33809,16 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                         id="subnav-list-134"
                       >
                         <li>
-                          <div
-                            class="c26 c27"
+                          <a
+                            class="c26 c27 c28"
+                            target="_self"
                             to="/address"
                           >
                             <div
                               class="c1"
                             >
                               <svg
-                                class="c28"
+                                class="c29"
                                 fill="none"
                                 height="1em"
                                 viewBox="0 0 4 4"
@@ -33775,27 +33833,28 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                                 />
                               </svg>
                               <div
-                                class="c29"
+                                class="c30"
                               >
                                 <span
-                                  class="c6 c30"
+                                  class="c6 c31"
                                 >
                                   Addresses
                                 </span>
                               </div>
                             </div>
-                          </div>
+                          </a>
                         </li>
                         <li>
-                          <div
-                            class="c26 c27"
+                          <a
+                            class="c26 c27 c28"
+                            target="_self"
                             to="/category"
                           >
                             <div
                               class="c1"
                             >
                               <svg
-                                class="c28"
+                                class="c29"
                                 fill="none"
                                 height="1em"
                                 viewBox="0 0 4 4"
@@ -33810,27 +33869,28 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                                 />
                               </svg>
                               <div
-                                class="c29"
+                                class="c30"
                               >
                                 <span
-                                  class="c6 c30"
+                                  class="c6 c31"
                                 >
                                   Categories
                                 </span>
                               </div>
                             </div>
-                          </div>
+                          </a>
                         </li>
                         <li>
-                          <div
-                            class="c26 c27"
+                          <a
+                            class="c26 c27 c28"
+                            target="_self"
                             to="/city"
                           >
                             <div
                               class="c1"
                             >
                               <svg
-                                class="c28"
+                                class="c29"
                                 fill="none"
                                 height="1em"
                                 viewBox="0 0 4 4"
@@ -33845,27 +33905,28 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                                 />
                               </svg>
                               <div
-                                class="c29"
+                                class="c30"
                               >
                                 <span
-                                  class="c6 c30"
+                                  class="c6 c31"
                                 >
                                   Cities
                                 </span>
                               </div>
                             </div>
-                          </div>
+                          </a>
                         </li>
                         <li>
-                          <div
-                            class="c26 c27"
+                          <a
+                            class="c26 c27 c28"
+                            target="_self"
                             to="/country"
                           >
                             <div
                               class="c1"
                             >
                               <svg
-                                class="c28"
+                                class="c29"
                                 fill="none"
                                 height="1em"
                                 viewBox="0 0 4 4"
@@ -33880,16 +33941,16 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                                 />
                               </svg>
                               <div
-                                class="c29"
+                                class="c30"
                               >
                                 <span
-                                  class="c6 c30"
+                                  class="c6 c31"
                                 >
                                   Countries
                                 </span>
                               </div>
                             </div>
-                          </div>
+                          </a>
                         </li>
                       </ul>
                     </div>
@@ -33899,16 +33960,16 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
             </li>
             <li>
               <div
-                class="c31"
+                class="c32"
               >
                 <button
                   aria-disabled="false"
-                  class="c1 c32"
+                  class="c1 c33"
                   type="button"
                 >
                   <span
                     aria-hidden="true"
-                    class="c33"
+                    class="c34"
                   >
                     <svg
                       fill="none"
@@ -33924,7 +33985,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                     </svg>
                   </span>
                   <span
-                    class="c6 c34"
+                    class="c6 c35"
                   >
                     Click on me
                   </span>
@@ -33970,15 +34031,16 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
             class="c15"
           >
             <li>
-              <div
-                class="c26 c27 active"
+              <a
+                class="c26 c27 c28 active"
+                target="_self"
                 to="/blabla"
               >
                 <div
                   class="c1"
                 >
                   <div
-                    class="c40"
+                    class="c41"
                   >
                     <svg
                       fill="none"
@@ -33994,20 +34056,20 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                     </svg>
                   </div>
                   <div
-                    class="c29"
+                    class="c30"
                   >
                     <span
-                      class="c6 c30"
+                      class="c6 c31"
                     >
                       Application
                     </span>
                   </div>
                 </div>
                 <div
-                  class="c1 sc-dkPtRN c41"
+                  class="c1 sc-dkPtRN c42"
                 >
                   <svg
-                    class="c42"
+                    class="c43"
                     fill="none"
                     height="1em"
                     viewBox="0 0 4 4"
@@ -34022,7 +34084,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                     />
                   </svg>
                 </div>
-              </div>
+              </a>
             </li>
             <li>
               <div
@@ -34053,15 +34115,16 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                   id="subnav-list-136"
                 >
                   <li>
-                    <div
-                      class="c26 c27"
+                    <a
+                      class="c26 c27 c28"
+                      target="_self"
                       to="/address"
                     >
                       <div
                         class="c1"
                       >
                         <div
-                          class="c40"
+                          class="c41"
                         >
                           <svg
                             fill="none"
@@ -34077,28 +34140,29 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="c29"
+                          class="c30"
                         >
                           <span
-                            class="c6 c30"
+                            class="c6 c31"
                           >
                             Addresses
                           </span>
                         </div>
                       </div>
-                    </div>
+                    </a>
                   </li>
                   <li />
                   <li>
-                    <div
-                      class="c26 c27"
+                    <a
+                      class="c26 c27 c28"
+                      target="_self"
                       to="/city"
                     >
                       <div
                         class="c1"
                       >
                         <div
-                          class="c40"
+                          class="c41"
                         >
                           <svg
                             fill="none"
@@ -34114,16 +34178,16 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="c29"
+                          class="c30"
                         >
                           <span
-                            class="c6 c30"
+                            class="c6 c31"
                           >
                             Cities
                           </span>
                         </div>
                       </div>
-                    </div>
+                    </a>
                   </li>
                   <li />
                 </ul>
@@ -34158,15 +34222,16 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                   id="subnav-list-137"
                 >
                   <li>
-                    <div
-                      class="c26 c27"
+                    <a
+                      class="c26 c27 c28"
+                      target="_self"
                       to="/address"
                     >
                       <div
                         class="c1"
                       >
                         <div
-                          class="c40"
+                          class="c41"
                         >
                           <svg
                             fill="none"
@@ -34182,28 +34247,29 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="c29"
+                          class="c30"
                         >
                           <span
-                            class="c6 c30"
+                            class="c6 c31"
                           >
                             Addresses
                           </span>
                         </div>
                       </div>
-                    </div>
+                    </a>
                   </li>
                   <li />
                   <li>
-                    <div
-                      class="c26 c27"
+                    <a
+                      class="c26 c27 c28"
+                      target="_self"
                       to="/city"
                     >
                       <div
                         class="c1"
                       >
                         <div
-                          class="c40"
+                          class="c41"
                         >
                           <svg
                             fill="none"
@@ -34219,16 +34285,16 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="c29"
+                          class="c30"
                         >
                           <span
-                            class="c6 c30"
+                            class="c6 c31"
                           >
                             Cities
                           </span>
                         </div>
                       </div>
-                    </div>
+                    </a>
                   </li>
                   <li />
                 </ul>
@@ -34273,15 +34339,16 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
             class="c15"
           >
             <li>
-              <div
-                class="c26 c27"
+              <a
+                class="c26 c27 c28"
+                target="_self"
                 to="/blabla"
               >
                 <div
                   class="c1"
                 >
                   <div
-                    class="c40"
+                    class="c41"
                   >
                     <svg
                       fill="none"
@@ -34297,20 +34364,20 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                     </svg>
                   </div>
                   <div
-                    class="c29"
+                    class="c30"
                   >
                     <span
-                      class="c6 c30"
+                      class="c6 c31"
                     >
                       Application
                     </span>
                   </div>
                 </div>
                 <div
-                  class="c1 sc-dkPtRN c41"
+                  class="c1 sc-dkPtRN c42"
                 >
                   <svg
-                    class="c42"
+                    class="c43"
                     fill="none"
                     height="1em"
                     viewBox="0 0 4 4"
@@ -34325,7 +34392,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                     />
                   </svg>
                 </div>
-              </div>
+              </a>
             </li>
             <li>
               <div
@@ -34360,7 +34427,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       class=""
                     >
                       <div
-                        class="c35 c36"
+                        class="c36 c37"
                       >
                         <div
                           class="c18"
@@ -34368,10 +34435,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           <button
                             aria-controls="subnav-list-140"
                             aria-expanded="true"
-                            class="c37"
+                            class="c38"
                           >
                             <div
-                              class="c38"
+                              class="c39"
                             >
                               <svg
                                 aria-hidden="true"
@@ -34390,10 +34457,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c29"
+                              class="c30"
                             >
                               <span
-                                class="c6 c39"
+                                class="c6 c40"
                               >
                                 Sub section
                               </span>
@@ -34405,15 +34472,16 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                         id="subnav-list-140"
                       >
                         <li>
-                          <div
-                            class="c26 c27"
+                          <a
+                            class="c26 c27 c28"
+                            target="_self"
                             to="/address"
                           >
                             <div
                               class="c1"
                             >
                               <div
-                                class="c40"
+                                class="c41"
                               >
                                 <svg
                                   fill="none"
@@ -34429,27 +34497,28 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                                 </svg>
                               </div>
                               <div
-                                class="c29"
+                                class="c30"
                               >
                                 <span
-                                  class="c6 c30"
+                                  class="c6 c31"
                                 >
                                   Addresses
                                 </span>
                               </div>
                             </div>
-                          </div>
+                          </a>
                         </li>
                         <li>
-                          <div
-                            class="c26 c27"
+                          <a
+                            class="c26 c27 c28"
+                            target="_self"
                             to="/category"
                           >
                             <div
                               class="c1"
                             >
                               <svg
-                                class="c28"
+                                class="c29"
                                 fill="none"
                                 height="1em"
                                 viewBox="0 0 4 4"
@@ -34464,27 +34533,28 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                                 />
                               </svg>
                               <div
-                                class="c29"
+                                class="c30"
                               >
                                 <span
-                                  class="c6 c30"
+                                  class="c6 c31"
                                 >
                                   Categories
                                 </span>
                               </div>
                             </div>
-                          </div>
+                          </a>
                         </li>
                         <li>
-                          <div
-                            class="c26 c27"
+                          <a
+                            class="c26 c27 c28"
+                            target="_self"
                             to="/city"
                           >
                             <div
                               class="c1"
                             >
                               <div
-                                class="c40"
+                                class="c41"
                               >
                                 <svg
                                   fill="none"
@@ -34500,27 +34570,28 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                                 </svg>
                               </div>
                               <div
-                                class="c29"
+                                class="c30"
                               >
                                 <span
-                                  class="c6 c30"
+                                  class="c6 c31"
                                 >
                                   Cities
                                 </span>
                               </div>
                             </div>
-                          </div>
+                          </a>
                         </li>
                         <li>
-                          <div
-                            class="c26 c27"
+                          <a
+                            class="c26 c27 c28"
+                            target="_self"
                             to="/country"
                           >
                             <div
                               class="c1"
                             >
                               <svg
-                                class="c28"
+                                class="c29"
                                 fill="none"
                                 height="1em"
                                 viewBox="0 0 4 4"
@@ -34535,16 +34606,16 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                                 />
                               </svg>
                               <div
-                                class="c29"
+                                class="c30"
                               >
                                 <span
-                                  class="c6 c30"
+                                  class="c6 c31"
                                 >
                                   Countries
                                 </span>
                               </div>
                             </div>
-                          </div>
+                          </a>
                         </li>
                       </ul>
                     </div>
@@ -34581,15 +34652,16 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                   id="subnav-list-141"
                 >
                   <li>
-                    <div
-                      class="c26 c27"
+                    <a
+                      class="c26 c27 c28"
+                      target="_self"
                       to="/address"
                     >
                       <div
                         class="c1"
                       >
                         <div
-                          class="c40"
+                          class="c41"
                         >
                           <svg
                             fill="none"
@@ -34605,27 +34677,28 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="c29"
+                          class="c30"
                         >
                           <span
-                            class="c6 c30"
+                            class="c6 c31"
                           >
                             Addresses
                           </span>
                         </div>
                       </div>
-                    </div>
+                    </a>
                   </li>
                   <li>
-                    <div
-                      class="c26 c27"
+                    <a
+                      class="c26 c27 c28"
+                      target="_self"
                       to="/category"
                     >
                       <div
                         class="c1"
                       >
                         <svg
-                          class="c28"
+                          class="c29"
                           fill="none"
                           height="1em"
                           viewBox="0 0 4 4"
@@ -34640,27 +34713,28 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           />
                         </svg>
                         <div
-                          class="c29"
+                          class="c30"
                         >
                           <span
-                            class="c6 c30"
+                            class="c6 c31"
                           >
                             Categories
                           </span>
                         </div>
                       </div>
-                    </div>
+                    </a>
                   </li>
                   <li>
-                    <div
-                      class="c26 c27"
+                    <a
+                      class="c26 c27 c28"
+                      target="_self"
                       to="/city"
                     >
                       <div
                         class="c1"
                       >
                         <div
-                          class="c40"
+                          class="c41"
                         >
                           <svg
                             fill="none"
@@ -34676,27 +34750,28 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           </svg>
                         </div>
                         <div
-                          class="c29"
+                          class="c30"
                         >
                           <span
-                            class="c6 c30"
+                            class="c6 c31"
                           >
                             Cities
                           </span>
                         </div>
                       </div>
-                    </div>
+                    </a>
                   </li>
                   <li>
-                    <div
-                      class="c26 c27"
+                    <a
+                      class="c26 c27 c28"
+                      target="_self"
                       to="/country"
                     >
                       <div
                         class="c1"
                       >
                         <svg
-                          class="c28"
+                          class="c29"
                           fill="none"
                           height="1em"
                           viewBox="0 0 4 4"
@@ -34711,16 +34786,16 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           />
                         </svg>
                         <div
-                          class="c29"
+                          class="c30"
                         >
                           <span
-                            class="c6 c30"
+                            class="c6 c31"
                           >
                             Countries
                           </span>
                         </div>
                       </div>
-                    </div>
+                    </a>
                   </li>
                 </ul>
               </div>

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -1,5 +1,2583 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storyshots Design System/Components/Accordion accordion-group 1`] = `
+.c0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c6 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c24 {
+  color: #4945ff;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c25 {
+  font-weight: 600;
+  color: #4a4a6a;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
+.c32 {
+  color: #666687;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c34 {
+  color: #d02b20;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c1 {
+  background: #ffffff;
+  padding: 40px;
+}
+
+.c3 {
+  padding-bottom: 4px;
+}
+
+.c7 {
+  padding-left: 4px;
+}
+
+.c10 {
+  border-radius: 4px;
+}
+
+.c12 {
+  background: #ffffff;
+  padding-right: 16px;
+  padding-left: 16px;
+}
+
+.c15 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.c17 {
+  background: #dcdce4;
+  border-radius: 50%;
+  cursor: pointer;
+  width: 1.5rem;
+  height: 1.5rem;
+  cursor: pointer;
+}
+
+.c19 {
+  color: #666687;
+  width: 0.5rem;
+}
+
+.c23 {
+  padding-right: 8px;
+}
+
+.c31 {
+  background: #eaeaef;
+  height: 48px;
+}
+
+.c33 {
+  padding-top: 4px;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c11 {
+  border: 1px solid #d02b20 !important;
+}
+
+.c11:hover:not([aria-disabled='true']) {
+  border: 1px solid #4945ff;
+}
+
+.c11:hover:not([aria-disabled='true']) .c5 {
+  color: #4945ff;
+}
+
+.c11:hover:not([aria-disabled='true']) > .c2 {
+  background: #f0f0ff;
+}
+
+.c11:hover:not([aria-disabled='true']) [data-strapi-dropdown='true'] {
+  background: #d9d8ff;
+}
+
+.c29 {
+  border: 1px solid #ffffff;
+}
+
+.c29:hover:not([aria-disabled='true']) {
+  border: 1px solid #4945ff;
+}
+
+.c29:hover:not([aria-disabled='true']) .c5 {
+  color: #4945ff;
+}
+
+.c29:hover:not([aria-disabled='true']) > .c2 {
+  background: #f0f0ff;
+}
+
+.c29:hover:not([aria-disabled='true']) [data-strapi-dropdown='true'] {
+  background: #d9d8ff;
+}
+
+.c21 {
+  background: transparent;
+  border: none;
+  position: relative;
+  outline: none;
+}
+
+.c21[aria-disabled='true'] {
+  pointer-events: none;
+}
+
+.c21[aria-disabled='true'] svg path {
+  fill: #666687;
+}
+
+.c21 svg {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 0.625rem;
+}
+
+.c21 svg path {
+  fill: #4945ff;
+}
+
+.c21:after {
+  -webkit-transition-property: all;
+  transition-property: all;
+  -webkit-transition-duration: 0.2s;
+  transition-duration: 0.2s;
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  left: -4px;
+  right: -4px;
+  border: 2px solid transparent;
+}
+
+.c21:focus-visible {
+  outline: none;
+}
+
+.c21:focus-visible:after {
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -5px;
+  bottom: -5px;
+  left: -5px;
+  right: -5px;
+  border: 2px solid #4945ff;
+}
+
+.c16 > * {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.c16 > * + * {
+  margin-left: 12px;
+}
+
+.c26 > * {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.c26 > * + * {
+  margin-left: 0px;
+}
+
+.c20 path {
+  fill: #666687;
+}
+
+.c22 {
+  text-align: left;
+}
+
+.c22 svg {
+  width: 0.875rem;
+  height: 0.875rem;
+}
+
+.c22 svg path {
+  fill: #8e8ea9;
+}
+
+.c14 {
+  height: 3rem;
+  border-radius: 4px;
+}
+
+.c14:hover svg path {
+  fill: #4945ff;
+}
+
+.c30 {
+  border-bottom: 1px solid #dcdce4;
+  border-right: 1px solid #dcdce4;
+  border-left: 1px solid #dcdce4;
+  border-radius: 0 0 4px 4px;
+}
+
+.c9 > * > * {
+  border-radius: unset;
+}
+
+.c9 > * {
+  border-radius: unset;
+  border-right: 1px solid #dcdce4;
+  border-left: 1px solid #dcdce4;
+  border-bottom: 1px solid #dcdce4;
+}
+
+.c9 > *:first-of-type {
+  border-top: 1px solid #dcdce4;
+  border-radius: 4px 4px 0 0;
+}
+
+.c9 > *:first-of-type > * {
+  border-radius: 4px 4px 0 0;
+}
+
+.c9 > *:first-of-type:hover {
+  border-top: 1px solid #4945ff;
+}
+
+.c9 [data-strapi-expanded='true'] {
+  border: 1px solid #4945ff;
+}
+
+.c9:not([object Object]) > *:last-of-type {
+  border-radius: 0 0 4px 4px;
+}
+
+.c8 svg path {
+  fill: #8e8ea9;
+}
+
+.c27 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 4px;
+  background: #ffffff;
+  border: 1px solid #dcdce4;
+  position: relative;
+  outline: none;
+}
+
+.c27 svg {
+  height: 12px;
+  width: 12px;
+}
+
+.c27 svg > g,
+.c27 svg path {
+  fill: #ffffff;
+}
+
+.c27[aria-disabled='true'] {
+  pointer-events: none;
+}
+
+.c27:after {
+  -webkit-transition-property: all;
+  transition-property: all;
+  -webkit-transition-duration: 0.2s;
+  transition-duration: 0.2s;
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  left: -4px;
+  right: -4px;
+  border: 2px solid transparent;
+}
+
+.c27:focus-visible {
+  outline: none;
+}
+
+.c27:focus-visible:after {
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -5px;
+  bottom: -5px;
+  left: -5px;
+  right: -5px;
+  border: 2px solid #4945ff;
+}
+
+.c28 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  height: 2rem;
+  width: 2rem;
+  border: none;
+}
+
+.c28 svg > g,
+.c28 svg path {
+  fill: #8e8ea9;
+}
+
+.c28:hover svg > g,
+.c28:hover svg path {
+  fill: #666687;
+}
+
+.c28:active svg > g,
+.c28:active svg path {
+  fill: #a5a5ba;
+}
+
+.c28[aria-disabled='true'] {
+  background-color: #eaeaef;
+}
+
+.c28[aria-disabled='true'] svg path {
+  fill: #666687;
+}
+
+<main>
+  <div
+    class="c0"
+  >
+    <h1>
+      Storybook story
+    </h1>
+  </div>
+  <div>
+    <div
+      class="c1"
+    >
+      <div
+        class=""
+      >
+        <div
+          class="c2 c3 c4"
+        >
+          <label
+            class="c5 c6"
+          >
+            Label
+          </label>
+          <div
+            class="c7 c8"
+          >
+            <span>
+              <button
+                aria-describedby="tooltip-1"
+                aria-label="Information about the email"
+                style="padding: 0px; background: transparent;"
+                tabindex="0"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="none"
+                  height="1em"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 0C5.383 0 0 5.383 0 12s5.383 12 12 12 12-5.383 12-12S18.617 0 12 0zm0 4.92a1.56 1.56 0 110 3.12 1.56 1.56 0 010-3.12zm3.84 13.06a.5.5 0 01-.5.5h-6.2a.5.5 0 01-.5-.5v-.92a.5.5 0 01.5-.5h2.14v-5.28H9.86a.5.5 0 01-.5-.5v-.92a.5.5 0 01.5-.5h2.84a.5.5 0 01.5.5v6.7h2.14a.5.5 0 01.5.5v.92z"
+                    fill="#212134"
+                  />
+                </svg>
+              </button>
+            </span>
+          </div>
+        </div>
+        <div
+          class="c9"
+        >
+          <div
+            aria-disabled="false"
+            class="c10 c11"
+            data-strapi-expanded="false"
+          >
+            <div
+              class="c2 c12 c13 c14"
+              cursor=""
+            >
+              <div
+                class="c2 c15 c4 c16"
+              >
+                <span
+                  aria-hidden="true"
+                  class="c2 c17 c18"
+                  cursor="pointer"
+                  data-strapi-dropdown="true"
+                  height="1.5rem"
+                  width="1.5rem"
+                >
+                  <svg
+                    class="c19 c20"
+                    fill="none"
+                    height="1em"
+                    viewBox="0 0 14 8"
+                    width="0.5rem"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
+                      fill="#32324D"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-controls="accordion-content-acc-1"
+                  aria-disabled="false"
+                  aria-expanded="false"
+                  aria-labelledby="accordion-label-acc-1"
+                  class="c2 c15 c4 c21 c22"
+                  data-strapi-accordion-toggle="true"
+                  type="button"
+                >
+                  <span
+                    aria-hidden="true"
+                    class="c23"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      fill="none"
+                      height="1em"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M20 22H4v-2a5 5 0 015-5h6a5 5 0 015 5v2zm-8-9A6 6 0 1112 .998 6 6 0 0112 13z"
+                        fill="#8E8EA9"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="c5 c24"
+                  >
+                    <span
+                      class="c5 c25"
+                      id="accordion-label-acc-1"
+                    >
+                      User informations
+                    </span>
+                  </span>
+                </button>
+              </div>
+              <div
+                class="c2 c4 c26"
+              >
+                <span>
+                  <button
+                    aria-disabled="false"
+                    aria-labelledby="tooltip-3"
+                    class="c27 c28"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <svg
+                      fill="none"
+                      height="1em"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M23.604 3.514c.528.528.528 1.36 0 1.887l-2.622 2.607-4.99-4.99L18.6.396a1.322 1.322 0 011.887 0l3.118 3.118zM0 24v-4.99l14.2-14.2 4.99 4.99L4.99 24H0z"
+                        fill="#212134"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </button>
+                </span>
+                <span>
+                  <button
+                    aria-disabled="false"
+                    aria-labelledby="tooltip-5"
+                    class="c27 c28"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <svg
+                      fill="none"
+                      height="1em"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M3.236 6.149a.2.2 0 00-.197.233L6 24h12l2.96-17.618a.2.2 0 00-.196-.233H3.236zM21.8 1.983c.11 0 .2.09.2.2v1.584a.2.2 0 01-.2.2H2.2a.2.2 0 01-.2-.2V2.183c0-.11.09-.2.2-.2h5.511c.9 0 1.631-1.09 1.631-1.983h5.316c0 .894.73 1.983 1.631 1.983H21.8z"
+                        fill="#32324D"
+                      />
+                    </svg>
+                  </button>
+                </span>
+              </div>
+            </div>
+          </div>
+          <div
+            aria-disabled="false"
+            class="c10 c11"
+            data-strapi-expanded="false"
+          >
+            <div
+              class="c2 c12 c13 c14"
+              cursor=""
+            >
+              <div
+                class="c2 c15 c4 c16"
+              >
+                <span
+                  aria-hidden="true"
+                  class="c2 c17 c18"
+                  cursor="pointer"
+                  data-strapi-dropdown="true"
+                  height="1.5rem"
+                  width="1.5rem"
+                >
+                  <svg
+                    class="c19 c20"
+                    fill="none"
+                    height="1em"
+                    viewBox="0 0 14 8"
+                    width="0.5rem"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
+                      fill="#32324D"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-controls="accordion-content-acc-2"
+                  aria-disabled="false"
+                  aria-expanded="false"
+                  aria-labelledby="accordion-label-acc-2"
+                  class="c2 c15 c4 c21 c22"
+                  data-strapi-accordion-toggle="true"
+                  type="button"
+                >
+                  <span
+                    class="c5 c24"
+                  >
+                    <span
+                      class="c5 c25"
+                      id="accordion-label-acc-2"
+                    >
+                      User informations
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            aria-disabled="false"
+            class="c10 c29"
+            data-strapi-expanded="false"
+          >
+            <div
+              class="c2 c12 c13 c14"
+              cursor=""
+            >
+              <div
+                class="c2 c15 c4 c16"
+              >
+                <span
+                  aria-hidden="true"
+                  class="c2 c17 c18"
+                  cursor="pointer"
+                  data-strapi-dropdown="true"
+                  height="1.5rem"
+                  width="1.5rem"
+                >
+                  <svg
+                    class="c19 c20"
+                    fill="none"
+                    height="1em"
+                    viewBox="0 0 14 8"
+                    width="0.5rem"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
+                      fill="#32324D"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-controls="accordion-content-acc-3"
+                  aria-disabled="false"
+                  aria-expanded="false"
+                  aria-labelledby="accordion-label-acc-3"
+                  class="c2 c15 c4 c21 c22"
+                  data-strapi-accordion-toggle="true"
+                  type="button"
+                >
+                  <span
+                    class="c5 c24"
+                  >
+                    <span
+                      class="c5 c25"
+                      id="accordion-label-acc-3"
+                    >
+                      User informations
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            aria-disabled="false"
+            class="c10 c29"
+            data-strapi-expanded="false"
+          >
+            <div
+              class="c2 c12 c13 c14"
+              cursor=""
+            >
+              <div
+                class="c2 c15 c4 c16"
+              >
+                <span
+                  aria-hidden="true"
+                  class="c2 c17 c18"
+                  cursor="pointer"
+                  data-strapi-dropdown="true"
+                  height="1.5rem"
+                  width="1.5rem"
+                >
+                  <svg
+                    class="c19 c20"
+                    fill="none"
+                    height="1em"
+                    viewBox="0 0 14 8"
+                    width="0.5rem"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
+                      fill="#32324D"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <button
+                  aria-controls="accordion-content-acc-2"
+                  aria-disabled="false"
+                  aria-expanded="false"
+                  aria-labelledby="accordion-label-acc-2"
+                  class="c2 c15 c4 c21 c22"
+                  data-strapi-accordion-toggle="true"
+                  type="button"
+                >
+                  <span
+                    aria-hidden="true"
+                    class="c23"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      fill="none"
+                      height="1em"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M20 22H4v-2a5 5 0 015-5h6a5 5 0 015 5v2zm-8-9A6 6 0 1112 .998 6 6 0 0112 13z"
+                        fill="#8E8EA9"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="c5 c24"
+                  >
+                    <span
+                      class="c5 c25"
+                      id="accordion-label-acc-2"
+                    >
+                      User informations
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="c30"
+        >
+          <div
+            class="c2 c31 c18"
+            height="48px"
+          >
+            <button
+              aria-disabled="true"
+              class="c2 c4 c21"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+                class="c23"
+              >
+                <svg
+                  fill="none"
+                  height="1em"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 13.604a.3.3 0 01-.3.3h-9.795V23.7a.3.3 0 01-.3.3h-3.21a.3.3 0 01-.3-.3v-9.795H.3a.3.3 0 01-.3-.3v-3.21a.3.3 0 01.3-.3h9.795V.3a.3.3 0 01.3-.3h3.21a.3.3 0 01.3.3v9.795H23.7a.3.3 0 01.3.3v3.21z"
+                    fill="#212134"
+                  />
+                </svg>
+              </span>
+              <span
+                class="c5 c32"
+              >
+                Add an entry
+              </span>
+            </button>
+          </div>
+        </div>
+        <div
+          class="c33"
+        >
+          <span
+            class="c5 c34"
+          >
+            The components contain error(s)
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>
+`;
+
+exports[`Storyshots Design System/Components/Accordion base 1`] = `
+.c0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c13 {
+  color: #4945ff;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c14 {
+  font-weight: 600;
+  color: #4a4a6a;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
+.c21 {
+  color: #d02b20;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c26 {
+  color: #4a4a6a;
+  font-weight: 500;
+  font-size: 1rem;
+  line-height: 1.25;
+}
+
+.c27 {
+  color: #666687;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
+.c1 {
+  background: #f6f6f9;
+  padding: 40px;
+}
+
+.c2 {
+  border-radius: 4px;
+}
+
+.c5 {
+  background: #ffffff;
+  padding-right: 16px;
+  padding-left: 16px;
+}
+
+.c8 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.c16 {
+  background: #dcdce4;
+  border-radius: 50%;
+  cursor: pointer;
+  width: 1.5rem;
+  height: 1.5rem;
+  cursor: pointer;
+}
+
+.c18 {
+  color: #666687;
+  width: 0.5rem;
+}
+
+.c20 {
+  padding-top: 4px;
+}
+
+.c22 {
+  background: #ffffff;
+  padding: 40px;
+}
+
+.c24 {
+  background: #f6f6f9;
+  padding-right: 24px;
+  padding-left: 24px;
+}
+
+.c28 {
+  background: #dcdce4;
+  border-radius: 50%;
+  cursor: pointer;
+  width: 2rem;
+  height: 2rem;
+  cursor: pointer;
+}
+
+.c29 {
+  color: #666687;
+  width: 0.6875rem;
+}
+
+.c33 {
+  background: #ffffff;
+  padding-right: 24px;
+  padding-left: 24px;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c17 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c3 {
+  border: 1px solid #d02b20 !important;
+}
+
+.c3:hover:not([aria-disabled='true']) {
+  border: 1px solid #4945ff;
+}
+
+.c3:hover:not([aria-disabled='true']) .c12 {
+  color: #4945ff;
+}
+
+.c3:hover:not([aria-disabled='true']) > .c4 {
+  background: #f0f0ff;
+}
+
+.c3:hover:not([aria-disabled='true']) [data-strapi-dropdown='true'] {
+  background: #d9d8ff;
+}
+
+.c23 {
+  border: 1px solid #f6f6f9;
+}
+
+.c23:hover:not([aria-disabled='true']) {
+  border: 1px solid #4945ff;
+}
+
+.c23:hover:not([aria-disabled='true']) .c12 {
+  color: #4945ff;
+}
+
+.c23:hover:not([aria-disabled='true']) > .c4 {
+  background: #f0f0ff;
+}
+
+.c23:hover:not([aria-disabled='true']) [data-strapi-dropdown='true'] {
+  background: #d9d8ff;
+}
+
+.c32 {
+  border: 1px solid #ffffff;
+}
+
+.c32:hover:not([aria-disabled='true']) {
+  border: 1px solid #4945ff;
+}
+
+.c32:hover:not([aria-disabled='true']) .c12 {
+  color: #4945ff;
+}
+
+.c32:hover:not([aria-disabled='true']) > .c4 {
+  background: #f0f0ff;
+}
+
+.c32:hover:not([aria-disabled='true']) [data-strapi-dropdown='true'] {
+  background: #d9d8ff;
+}
+
+.c10 {
+  background: transparent;
+  border: none;
+  position: relative;
+  outline: none;
+}
+
+.c10[aria-disabled='true'] {
+  pointer-events: none;
+}
+
+.c10[aria-disabled='true'] svg path {
+  fill: #666687;
+}
+
+.c10 svg {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 0.625rem;
+}
+
+.c10 svg path {
+  fill: #4945ff;
+}
+
+.c10:after {
+  -webkit-transition-property: all;
+  transition-property: all;
+  -webkit-transition-duration: 0.2s;
+  transition-duration: 0.2s;
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  left: -4px;
+  right: -4px;
+  border: 2px solid transparent;
+}
+
+.c10:focus-visible {
+  outline: none;
+}
+
+.c10:focus-visible:after {
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -5px;
+  bottom: -5px;
+  left: -5px;
+  right: -5px;
+  border: 2px solid #4945ff;
+}
+
+.c15 > * {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.c15 > * + * {
+  margin-left: 12px;
+}
+
+.c19 path {
+  fill: #666687;
+}
+
+.c11 {
+  text-align: left;
+}
+
+.c11 svg {
+  width: 0.875rem;
+  height: 0.875rem;
+}
+
+.c11 svg path {
+  fill: #8e8ea9;
+}
+
+.c7 {
+  height: 3rem;
+  border-radius: 4px;
+}
+
+.c7:hover svg path {
+  fill: #4945ff;
+}
+
+.c25 {
+  height: 5.5rem;
+  border-radius: 4px;
+}
+
+.c25:hover svg path {
+  fill: #4945ff;
+}
+
+.c30 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 4px;
+  background: #ffffff;
+  border: 1px solid #dcdce4;
+  position: relative;
+  outline: none;
+}
+
+.c30 svg {
+  height: 12px;
+  width: 12px;
+}
+
+.c30 svg > g,
+.c30 svg path {
+  fill: #ffffff;
+}
+
+.c30[aria-disabled='true'] {
+  pointer-events: none;
+}
+
+.c30:after {
+  -webkit-transition-property: all;
+  transition-property: all;
+  -webkit-transition-duration: 0.2s;
+  transition-duration: 0.2s;
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  left: -4px;
+  right: -4px;
+  border: 2px solid transparent;
+}
+
+.c30:focus-visible {
+  outline: none;
+}
+
+.c30:focus-visible:after {
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -5px;
+  bottom: -5px;
+  left: -5px;
+  right: -5px;
+  border: 2px solid #4945ff;
+}
+
+.c31 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  height: 2rem;
+  width: 2rem;
+}
+
+.c31 svg > g,
+.c31 svg path {
+  fill: #8e8ea9;
+}
+
+.c31:hover svg > g,
+.c31:hover svg path {
+  fill: #666687;
+}
+
+.c31:active svg > g,
+.c31:active svg path {
+  fill: #a5a5ba;
+}
+
+.c31[aria-disabled='true'] {
+  background-color: #eaeaef;
+}
+
+.c31[aria-disabled='true'] svg path {
+  fill: #666687;
+}
+
+<main>
+  <div
+    class="c0"
+  >
+    <h1>
+      Storybook story
+    </h1>
+  </div>
+  <div>
+    <div
+      class="c1"
+    >
+      <div
+        aria-disabled="false"
+        class="c2 c3"
+        data-strapi-expanded="false"
+      >
+        <div
+          class="c4 c5 c6 c7"
+          cursor=""
+        >
+          <button
+            aria-controls="accordion-content-acc-1"
+            aria-disabled="false"
+            aria-expanded="false"
+            aria-labelledby="accordion-label-acc-1"
+            class="c4 c8 c9 c10 c11"
+            data-strapi-accordion-toggle="true"
+            type="button"
+          >
+            <span
+              class="c12 c13"
+            >
+              <span
+                class="c12 c14"
+                id="accordion-label-acc-1"
+              >
+                User informations
+              </span>
+            </span>
+          </button>
+          <div
+            class="c4 c9 c15"
+          >
+            <span
+              aria-hidden="true"
+              class="c4 c16 c17"
+              cursor="pointer"
+              data-strapi-dropdown="true"
+              height="1.5rem"
+              width="1.5rem"
+            >
+              <svg
+                class="c18 c19"
+                fill="none"
+                height="1em"
+                viewBox="0 0 14 8"
+                width="0.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
+                  fill="#32324D"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        class="c20"
+      >
+        <span
+          class="c12 c21"
+        >
+          The component contain error(s)
+        </span>
+      </div>
+    </div>
+    <div
+      class="c22"
+    >
+      <div
+        aria-disabled="false"
+        class="c2 c23"
+        data-strapi-expanded="false"
+      >
+        <div
+          class="c4 c24 c6 c25"
+          cursor=""
+        >
+          <button
+            aria-controls="accordion-content-acc-2"
+            aria-disabled="false"
+            aria-expanded="false"
+            aria-labelledby="accordion-label-acc-2"
+            class="c4 c8 c9 c10 c11"
+            data-strapi-accordion-toggle="true"
+            type="button"
+          >
+            <span
+              class="c12 c13"
+            >
+              <span
+                class="c12 c26"
+                id="accordion-label-acc-2"
+              >
+                User informations 2
+              </span>
+              <p
+                class="c12 c27"
+                id="accordion-desc-acc-2"
+              >
+                The following contains information about the current user 2
+              </p>
+            </span>
+          </button>
+          <div
+            class="c4 c9 c15"
+          >
+            <span
+              aria-hidden="true"
+              class="c4 c28 c17"
+              cursor="pointer"
+              data-strapi-dropdown="true"
+              height="2rem"
+              width="2rem"
+            >
+              <svg
+                class="c29 c19"
+                fill="none"
+                height="1em"
+                viewBox="0 0 14 8"
+                width="0.6875rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
+                  fill="#32324D"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+            <span>
+              <button
+                aria-disabled="false"
+                aria-labelledby="tooltip-7"
+                class="c30 c31"
+                tabindex="0"
+                type="button"
+              >
+                <svg
+                  fill="none"
+                  height="1em"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M23.604 3.514c.528.528.528 1.36 0 1.887l-2.622 2.607-4.99-4.99L18.6.396a1.322 1.322 0 011.887 0l3.118 3.118zM0 24v-4.99l14.2-14.2 4.99 4.99L4.99 24H0z"
+                    fill="#212134"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </button>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c1"
+    >
+      <div
+        aria-disabled="false"
+        class="c2 c32"
+        data-strapi-expanded="false"
+      >
+        <div
+          class="c4 c33 c6 c25"
+          cursor=""
+        >
+          <div
+            class="c4 c8 c9 c15"
+          >
+            <span
+              aria-hidden="true"
+              class="c4 c28 c17"
+              cursor="pointer"
+              data-strapi-dropdown="true"
+              height="2rem"
+              width="2rem"
+            >
+              <svg
+                class="c29 c19"
+                fill="none"
+                height="1em"
+                viewBox="0 0 14 8"
+                width="0.6875rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
+                  fill="#32324D"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+            <button
+              aria-controls="accordion-content-acc-3"
+              aria-disabled="false"
+              aria-expanded="false"
+              aria-labelledby="accordion-label-acc-3"
+              class="c4 c8 c9 c10 c11"
+              data-strapi-accordion-toggle="true"
+              type="button"
+            >
+              <span
+                class="c12 c13"
+              >
+                <span
+                  class="c12 c26"
+                  id="accordion-label-acc-3"
+                >
+                  User informations 3
+                </span>
+                <p
+                  class="c12 c27"
+                  id="accordion-desc-acc-3"
+                >
+                  The following contains information about the current user 3
+                </p>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c22"
+    >
+      <div
+        aria-disabled="false"
+        class="c2 c23"
+        data-strapi-expanded="false"
+      >
+        <div
+          class="c4 c24 c6 c25"
+          cursor=""
+        >
+          <div
+            class="c4 c8 c9 c15"
+          >
+            <span
+              aria-hidden="true"
+              class="c4 c28 c17"
+              cursor="pointer"
+              data-strapi-dropdown="true"
+              height="2rem"
+              width="2rem"
+            >
+              <svg
+                class="c29 c19"
+                fill="none"
+                height="1em"
+                viewBox="0 0 14 8"
+                width="0.6875rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
+                  fill="#32324D"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+            <button
+              aria-controls="accordion-content-acc-4"
+              aria-disabled="false"
+              aria-expanded="false"
+              aria-labelledby="accordion-label-acc-4"
+              class="c4 c8 c9 c10 c11"
+              data-strapi-accordion-toggle="true"
+              type="button"
+            >
+              <span
+                class="c12 c13"
+              >
+                <span
+                  class="c12 c26"
+                  id="accordion-label-acc-4"
+                >
+                  User informations 4
+                </span>
+              </span>
+            </button>
+          </div>
+          <span>
+            <button
+              aria-disabled="false"
+              aria-labelledby="tooltip-9"
+              class="c30 c31"
+              tabindex="0"
+              type="button"
+            >
+              <svg
+                fill="none"
+                height="1em"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M23.604 3.514c.528.528.528 1.36 0 1.887l-2.622 2.607-4.99-4.99L18.6.396a1.322 1.322 0 011.887 0l3.118 3.118zM0 24v-4.99l14.2-14.2 4.99 4.99L4.99 24H0z"
+                  fill="#212134"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </button>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>
+`;
+
+exports[`Storyshots Design System/Components/Accordion expanded 1`] = `
+.c0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c11 {
+  color: #4945ff;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c12 {
+  color: #4945ff;
+  font-weight: 500;
+  font-size: 1rem;
+  line-height: 1.25;
+}
+
+.c13 {
+  color: #4945ff;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
+.c1 {
+  border-radius: 4px;
+}
+
+.c4 {
+  background: #f0f0ff;
+  padding-right: 24px;
+  padding-left: 24px;
+}
+
+.c7 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.c15 {
+  background: #d9d8ff;
+  border-radius: 50%;
+  cursor: pointer;
+  width: 2rem;
+  height: 2rem;
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+  cursor: pointer;
+}
+
+.c17 {
+  color: #4945ff;
+  width: 0.6875rem;
+}
+
+.c19 {
+  padding: 12px;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c2 {
+  border: 1px solid #4945ff;
+}
+
+.c2:hover:not([aria-disabled='true']) {
+  border: 1px solid #4945ff;
+}
+
+.c2:hover:not([aria-disabled='true']) > .c3 {
+  background: #f0f0ff;
+}
+
+.c2:hover:not([aria-disabled='true']) [data-strapi-dropdown='true'] {
+  background: #d9d8ff;
+}
+
+.c9 {
+  background: transparent;
+  border: none;
+  position: relative;
+  outline: none;
+}
+
+.c9[aria-disabled='true'] {
+  pointer-events: none;
+}
+
+.c9[aria-disabled='true'] svg path {
+  fill: #666687;
+}
+
+.c9 svg {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 0.625rem;
+}
+
+.c9 svg path {
+  fill: #4945ff;
+}
+
+.c9:after {
+  -webkit-transition-property: all;
+  transition-property: all;
+  -webkit-transition-duration: 0.2s;
+  transition-duration: 0.2s;
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  left: -4px;
+  right: -4px;
+  border: 2px solid transparent;
+}
+
+.c9:focus-visible {
+  outline: none;
+}
+
+.c9:focus-visible:after {
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -5px;
+  bottom: -5px;
+  left: -5px;
+  right: -5px;
+  border: 2px solid #4945ff;
+}
+
+.c14 > * {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.c14 > * + * {
+  margin-left: 12px;
+}
+
+.c18 path {
+  fill: #4945ff;
+}
+
+.c10 {
+  text-align: left;
+}
+
+.c10 svg {
+  width: 0.875rem;
+  height: 0.875rem;
+}
+
+.c10 svg path {
+  fill: #4945ff;
+}
+
+.c6 {
+  height: 5.5rem;
+  border-radius: 4px 4px 0 0;
+}
+
+.c6:hover svg path {
+  fill: #4945ff;
+}
+
+<main>
+  <div
+    class="c0"
+  >
+    <h1>
+      Storybook story
+    </h1>
+  </div>
+  <div
+    aria-disabled="false"
+    class="c1 c2"
+    data-strapi-expanded="true"
+  >
+    <div
+      class="c3 c4 c5 c6"
+      cursor=""
+    >
+      <button
+        aria-controls="accordion-content-acc-1"
+        aria-disabled="false"
+        aria-expanded="true"
+        aria-labelledby="accordion-label-acc-1"
+        class="c3 c7 c8 c9 c10"
+        data-strapi-accordion-toggle="true"
+        type="button"
+      >
+        <span
+          class="c11"
+        >
+          <span
+            class="c12"
+            id="accordion-label-acc-1"
+          >
+            User informations
+          </span>
+          <p
+            class="c13"
+            id="accordion-desc-acc-1"
+          >
+            The following contains information about the current user
+          </p>
+        </span>
+      </button>
+      <div
+        class="c3 c8 c14"
+      >
+        <span
+          aria-hidden="true"
+          class="c3 c15 c16"
+          cursor="pointer"
+          data-strapi-dropdown="true"
+          height="2rem"
+          transform="rotate(180deg)"
+          width="2rem"
+        >
+          <svg
+            class="c17 c18"
+            fill="none"
+            height="1em"
+            viewBox="0 0 14 8"
+            width="0.6875rem"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
+              fill="#32324D"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </span>
+      </div>
+    </div>
+    <div
+      aria-describedby="accordion-desc-acc-1"
+      aria-labelledby="accordion-label-acc-1"
+      class=""
+      id="accordion-content-acc-1"
+      role="region"
+    >
+      <div
+        class="c19"
+      >
+        My name is John Duff
+      </div>
+    </div>
+  </div>
+</main>
+`;
+
+exports[`Storyshots Design System/Components/Accordion keyboard navigable 1`] = `
+.c0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c13 {
+  color: #4945ff;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c14 {
+  color: #4a4a6a;
+  font-weight: 500;
+  font-size: 1rem;
+  line-height: 1.25;
+}
+
+.c15 {
+  color: #666687;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
+.c1 {
+  background: #f6f6f9;
+  padding: 40px;
+}
+
+.c2 {
+  border-radius: 4px;
+}
+
+.c5 {
+  background: #ffffff;
+  padding-right: 24px;
+  padding-left: 24px;
+}
+
+.c8 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.c17 {
+  background: #dcdce4;
+  border-radius: 50%;
+  cursor: pointer;
+  width: 2rem;
+  height: 2rem;
+  cursor: pointer;
+}
+
+.c19 {
+  color: #666687;
+  width: 0.6875rem;
+}
+
+.c21 {
+  background: #ffffff;
+  padding: 40px;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c3 {
+  border: 1px solid #ffffff;
+}
+
+.c3:hover:not([aria-disabled='true']) {
+  border: 1px solid #4945ff;
+}
+
+.c3:hover:not([aria-disabled='true']) .c12 {
+  color: #4945ff;
+}
+
+.c3:hover:not([aria-disabled='true']) > .c4 {
+  background: #f0f0ff;
+}
+
+.c3:hover:not([aria-disabled='true']) [data-strapi-dropdown='true'] {
+  background: #d9d8ff;
+}
+
+.c10 {
+  background: transparent;
+  border: none;
+  position: relative;
+  outline: none;
+}
+
+.c10[aria-disabled='true'] {
+  pointer-events: none;
+}
+
+.c10[aria-disabled='true'] svg path {
+  fill: #666687;
+}
+
+.c10 svg {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 0.625rem;
+}
+
+.c10 svg path {
+  fill: #4945ff;
+}
+
+.c10:after {
+  -webkit-transition-property: all;
+  transition-property: all;
+  -webkit-transition-duration: 0.2s;
+  transition-duration: 0.2s;
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  left: -4px;
+  right: -4px;
+  border: 2px solid transparent;
+}
+
+.c10:focus-visible {
+  outline: none;
+}
+
+.c10:focus-visible:after {
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -5px;
+  bottom: -5px;
+  left: -5px;
+  right: -5px;
+  border: 2px solid #4945ff;
+}
+
+.c16 > * {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.c16 > * + * {
+  margin-left: 12px;
+}
+
+.c20 path {
+  fill: #666687;
+}
+
+.c11 {
+  text-align: left;
+}
+
+.c11 svg {
+  width: 0.875rem;
+  height: 0.875rem;
+}
+
+.c11 svg path {
+  fill: #8e8ea9;
+}
+
+.c7 {
+  height: 5.5rem;
+  border-radius: 4px;
+}
+
+.c7:hover svg path {
+  fill: #4945ff;
+}
+
+.c22 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 4px;
+  background: #ffffff;
+  border: 1px solid #dcdce4;
+  position: relative;
+  outline: none;
+}
+
+.c22 svg {
+  height: 12px;
+  width: 12px;
+}
+
+.c22 svg > g,
+.c22 svg path {
+  fill: #ffffff;
+}
+
+.c22[aria-disabled='true'] {
+  pointer-events: none;
+}
+
+.c22:after {
+  -webkit-transition-property: all;
+  transition-property: all;
+  -webkit-transition-duration: 0.2s;
+  transition-duration: 0.2s;
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  left: -4px;
+  right: -4px;
+  border: 2px solid transparent;
+}
+
+.c22:focus-visible {
+  outline: none;
+}
+
+.c22:focus-visible:after {
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -5px;
+  bottom: -5px;
+  left: -5px;
+  right: -5px;
+  border: 2px solid #4945ff;
+}
+
+.c23 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  height: 2rem;
+  width: 2rem;
+}
+
+.c23 svg > g,
+.c23 svg path {
+  fill: #8e8ea9;
+}
+
+.c23:hover svg > g,
+.c23:hover svg path {
+  fill: #666687;
+}
+
+.c23:active svg > g,
+.c23:active svg path {
+  fill: #a5a5ba;
+}
+
+.c23[aria-disabled='true'] {
+  background-color: #eaeaef;
+}
+
+.c23[aria-disabled='true'] svg path {
+  fill: #666687;
+}
+
+<main>
+  <div
+    class="c0"
+  >
+    <h1>
+      Storybook story
+    </h1>
+  </div>
+  <div
+    class=""
+  >
+    <div
+      class="c1"
+    >
+      <div
+        aria-disabled="false"
+        class="c2 c3"
+        data-strapi-expanded="false"
+      >
+        <div
+          class="c4 c5 c6 c7"
+          cursor=""
+        >
+          <button
+            aria-controls="accordion-content-acc-1"
+            aria-disabled="false"
+            aria-expanded="false"
+            aria-labelledby="accordion-label-acc-1"
+            class="c4 c8 c9 c10 c11"
+            data-strapi-accordion-toggle="true"
+            type="button"
+          >
+            <span
+              class="c12 c13"
+            >
+              <span
+                class="c12 c14"
+                id="accordion-label-acc-1"
+              >
+                User informations
+              </span>
+              <p
+                class="c12 c15"
+                id="accordion-desc-acc-1"
+              >
+                The following contains information about the current user
+              </p>
+            </span>
+          </button>
+          <div
+            class="c4 c9 c16"
+          >
+            <span
+              aria-hidden="true"
+              class="c4 c17 c18"
+              cursor="pointer"
+              data-strapi-dropdown="true"
+              height="2rem"
+              width="2rem"
+            >
+              <svg
+                class="c19 c20"
+                fill="none"
+                height="1em"
+                viewBox="0 0 14 8"
+                width="0.6875rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
+                  fill="#32324D"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c21"
+    >
+      <div
+        aria-disabled="false"
+        class="c2 c3"
+        data-strapi-expanded="false"
+      >
+        <div
+          class="c4 c5 c6 c7"
+          cursor=""
+        >
+          <button
+            aria-controls="accordion-content-acc-2"
+            aria-disabled="false"
+            aria-expanded="false"
+            aria-labelledby="accordion-label-acc-2"
+            class="c4 c8 c9 c10 c11"
+            data-strapi-accordion-toggle="true"
+            type="button"
+          >
+            <span
+              class="c12 c13"
+            >
+              <span
+                class="c12 c14"
+                id="accordion-label-acc-2"
+              >
+                User informations 2
+              </span>
+              <p
+                class="c12 c15"
+                id="accordion-desc-acc-2"
+              >
+                The following contains information about the current user 2
+              </p>
+            </span>
+          </button>
+          <div
+            class="c4 c9 c16"
+          >
+            <span
+              aria-hidden="true"
+              class="c4 c17 c18"
+              cursor="pointer"
+              data-strapi-dropdown="true"
+              height="2rem"
+              width="2rem"
+            >
+              <svg
+                class="c19 c20"
+                fill="none"
+                height="1em"
+                viewBox="0 0 14 8"
+                width="0.6875rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
+                  fill="#32324D"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c1"
+    >
+      <div
+        aria-disabled="false"
+        class="c2 c3"
+        data-strapi-expanded="false"
+      >
+        <div
+          class="c4 c5 c6 c7"
+          cursor=""
+        >
+          <div
+            class="c4 c8 c9 c16"
+          >
+            <span
+              aria-hidden="true"
+              class="c4 c17 c18"
+              cursor="pointer"
+              data-strapi-dropdown="true"
+              height="2rem"
+              width="2rem"
+            >
+              <svg
+                class="c19 c20"
+                fill="none"
+                height="1em"
+                viewBox="0 0 14 8"
+                width="0.6875rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
+                  fill="#32324D"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+            <button
+              aria-controls="accordion-content-acc-3"
+              aria-disabled="false"
+              aria-expanded="false"
+              aria-labelledby="accordion-label-acc-3"
+              class="c4 c8 c9 c10 c11"
+              data-strapi-accordion-toggle="true"
+              type="button"
+            >
+              <span
+                class="c12 c13"
+              >
+                <span
+                  class="c12 c14"
+                  id="accordion-label-acc-3"
+                >
+                  User informations 3
+                </span>
+                <p
+                  class="c12 c15"
+                  id="accordion-desc-acc-3"
+                >
+                  The following contains information about the current user 3
+                </p>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c21"
+    >
+      <div
+        aria-disabled="false"
+        class="c2 c3"
+        data-strapi-expanded="false"
+      >
+        <div
+          class="c4 c5 c6 c7"
+          cursor=""
+        >
+          <div
+            class="c4 c8 c9 c16"
+          >
+            <span
+              aria-hidden="true"
+              class="c4 c17 c18"
+              cursor="pointer"
+              data-strapi-dropdown="true"
+              height="2rem"
+              width="2rem"
+            >
+              <svg
+                class="c19 c20"
+                fill="none"
+                height="1em"
+                viewBox="0 0 14 8"
+                width="0.6875rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
+                  fill="#32324D"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+            <button
+              aria-controls="accordion-content-acc-4"
+              aria-disabled="false"
+              aria-expanded="false"
+              aria-labelledby="accordion-label-acc-4"
+              class="c4 c8 c9 c10 c11"
+              data-strapi-accordion-toggle="true"
+              type="button"
+            >
+              <span
+                class="c12 c13"
+              >
+                <span
+                  class="c12 c14"
+                  id="accordion-label-acc-4"
+                >
+                  User informations 4
+                </span>
+              </span>
+            </button>
+          </div>
+          <span>
+            <button
+              aria-disabled="false"
+              aria-labelledby="tooltip-11"
+              class="c22 c23"
+              tabindex="0"
+              type="button"
+            >
+              <svg
+                fill="none"
+                height="1em"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M23.604 3.514c.528.528.528 1.36 0 1.887l-2.622 2.607-4.99-4.99L18.6.396a1.322 1.322 0 011.887 0l3.118 3.118zM0 24v-4.99l14.2-14.2 4.99 4.99L4.99 24H0z"
+                  fill="#212134"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </button>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>
+`;
+
 exports[`Storyshots Design System/Components/Alert base 1`] = `
 .c0 {
   border: 0;
@@ -11,6 +2589,19 @@ exports[`Storyshots Design System/Components/Alert base 1`] = `
   padding: 0;
   position: absolute;
   width: 1px;
+}
+
+.c8 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
+.c10 {
+  color: #32324d;
+  font-size: 0.875rem;
+  line-height: 1.43;
 }
 
 .c1 {
@@ -32,19 +2623,6 @@ exports[`Storyshots Design System/Components/Alert base 1`] = `
 .c9 {
   padding-right: 8px;
   padding-bottom: 20px;
-}
-
-.c8 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.875rem;
-  line-height: 1.43;
-}
-
-.c10 {
-  color: #32324d;
-  font-size: 0.875rem;
-  line-height: 1.43;
 }
 
 .c3 {
@@ -229,6 +2807,19 @@ exports[`Storyshots Design System/Components/Alert variants 1`] = `
   width: 1px;
 }
 
+.c9 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
+.c11 {
+  color: #32324d;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
 .c2 {
   padding-top: 20px;
   padding-right: 24px;
@@ -250,19 +2841,6 @@ exports[`Storyshots Design System/Components/Alert variants 1`] = `
   padding-bottom: 20px;
 }
 
-.c9 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.875rem;
-  line-height: 1.43;
-}
-
-.c11 {
-  color: #32324d;
-  font-size: 0.875rem;
-  line-height: 1.43;
-}
-
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -275,6 +2853,25 @@ exports[`Storyshots Design System/Components/Alert variants 1`] = `
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c1 > * {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.c1 > * + * {
+  margin-top: 4px;
 }
 
 .c7 {
@@ -376,25 +2973,6 @@ exports[`Storyshots Design System/Components/Alert variants 1`] = `
 
 .c16 svg path {
   fill: #b72b1a;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c1 > * {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.c1 > * + * {
-  margin-top: 4px;
 }
 
 <main>
@@ -630,6 +3208,25 @@ exports[`Storyshots Design System/Components/Alert with action 1`] = `
   width: 1px;
 }
 
+.c8 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
+.c10 {
+  color: #32324d;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
+.c15 {
+  color: #4945ff;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
 .c1 {
   padding-top: 20px;
   padding-right: 24px;
@@ -653,25 +3250,6 @@ exports[`Storyshots Design System/Components/Alert with action 1`] = `
 
 .c11 {
   padding-bottom: 20px;
-}
-
-.c8 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.875rem;
-  line-height: 1.43;
-}
-
-.c10 {
-  color: #32324d;
-  font-size: 0.875rem;
-  line-height: 1.43;
-}
-
-.c14 {
-  color: #4945ff;
-  font-size: 0.75rem;
-  line-height: 1.33;
 }
 
 .c3 {
@@ -710,7 +3288,7 @@ exports[`Storyshots Design System/Components/Alert with action 1`] = `
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
 }
 
-.c15 {
+.c16 {
   border: none;
   background: transparent;
   font-size: 0.75rem;
@@ -719,11 +3297,11 @@ exports[`Storyshots Design System/Components/Alert with action 1`] = `
   outline: none;
 }
 
-.c15 svg path {
+.c16 svg path {
   fill: #4a4a6a;
 }
 
-.c15:after {
+.c16:after {
   -webkit-transition-property: all;
   transition-property: all;
   -webkit-transition-duration: 0.2s;
@@ -738,11 +3316,11 @@ exports[`Storyshots Design System/Components/Alert with action 1`] = `
   border: 2px solid transparent;
 }
 
-.c15:focus-visible {
+.c16:focus-visible {
   outline: none;
 }
 
-.c15:focus-visible:after {
+.c16:focus-visible:after {
   border-radius: 8px;
   content: '';
   position: absolute;
@@ -774,6 +3352,10 @@ exports[`Storyshots Design System/Components/Alert with action 1`] = `
 }
 
 .c13 {
+  cursor: pointer;
+}
+
+.c14 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -788,15 +3370,15 @@ exports[`Storyshots Design System/Components/Alert with action 1`] = `
   outline: none;
 }
 
-.c13 svg path {
+.c14 svg path {
   fill: #4945ff;
 }
 
-.c13 svg {
+.c14 svg {
   font-size: 0.625rem;
 }
 
-.c13:after {
+.c14:after {
   -webkit-transition-property: all;
   transition-property: all;
   -webkit-transition-duration: 0.2s;
@@ -811,11 +3393,11 @@ exports[`Storyshots Design System/Components/Alert with action 1`] = `
   border: 2px solid transparent;
 }
 
-.c13:focus-visible {
+.c14:focus-visible {
   outline: none;
 }
 
-.c13:focus-visible:after {
+.c14:focus-visible:after {
   border-radius: 8px;
   content: '';
   position: absolute;
@@ -887,11 +3469,11 @@ exports[`Storyshots Design System/Components/Alert with action 1`] = `
             class="c11 c12"
           >
             <a
-              class="c13"
-              href="/somewhere"
+              class="c13 c14"
+              to="/somewhere"
             >
               <span
-                class="c14"
+                class="c15"
               >
                 See more
               </span>
@@ -900,7 +3482,7 @@ exports[`Storyshots Design System/Components/Alert with action 1`] = `
         </div>
         <button
           aria-label="Close"
-          class="c15"
+          class="c16"
         >
           <svg
             aria-hidden="true"
@@ -1097,10 +3679,6 @@ exports[`Storyshots Design System/Components/Avatar initials 1`] = `
   width: 1px;
 }
 
-.c1 {
-  padding: 64px;
-}
-
 .c4 {
   font-weight: 600;
   font-size: 0.6875rem;
@@ -1108,6 +3686,10 @@ exports[`Storyshots Design System/Components/Avatar initials 1`] = `
   text-transform: uppercase;
   font-size: 0.875rem;
   line-height: 1.43;
+}
+
+.c1 {
+  padding: 64px;
 }
 
 .c2 {
@@ -1176,20 +3758,6 @@ exports[`Storyshots Design System/Components/Badge base 1`] = `
   width: 1px;
 }
 
-.c2 {
-  background: #f6f6f9;
-  padding: 4px;
-  border-radius: 4px;
-  min-width: 20px;
-}
-
-.c5 {
-  background: #f0f0ff;
-  padding: 4px;
-  border-radius: 4px;
-  min-width: 20px;
-}
-
 .c4 {
   color: #666687;
   font-weight: 600;
@@ -1204,6 +3772,20 @@ exports[`Storyshots Design System/Components/Badge base 1`] = `
   font-size: 0.6875rem;
   line-height: 1.45;
   text-transform: uppercase;
+}
+
+.c2 {
+  background: #f6f6f9;
+  padding: 4px;
+  border-radius: 4px;
+  min-width: 20px;
+}
+
+.c5 {
+  background: #f0f0ff;
+  padding: 4px;
+  border-radius: 4px;
+  min-width: 20px;
 }
 
 .c3 {
@@ -1326,16 +3908,16 @@ exports[`Storyshots Design System/Components/Breadcrumbs base 1`] = `
   width: 1px;
 }
 
-.c7 {
-  padding-right: 12px;
-  padding-left: 12px;
-}
-
 .c6 {
   font-weight: 600;
   color: #32324d;
   font-size: 0.875rem;
   line-height: 1.43;
+}
+
+.c7 {
+  padding-right: 12px;
+  padding-left: 12px;
 }
 
 .c2 {
@@ -1502,15 +4084,15 @@ exports[`Storyshots Design System/Components/Button base 1`] = `
   width: 1px;
 }
 
-.c2 {
-  padding-bottom: 8px;
-}
-
 .c6 {
   font-weight: 600;
   color: #32324d;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c2 {
+  padding-bottom: 8px;
 }
 
 .c3 {
@@ -1675,19 +4257,19 @@ exports[`Storyshots Design System/Components/Button disabled 1`] = `
   width: 1px;
 }
 
+.c8 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
 .c2 {
   padding-right: 4px;
 }
 
 .c5 {
   padding-right: 8px;
-}
-
-.c8 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
 }
 
 .c3 {
@@ -1874,6 +4456,13 @@ exports[`Storyshots Design System/Components/Button fullWidth 1`] = `
   width: 1px;
 }
 
+.c8 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
 .c2 {
   padding-right: 4px;
 }
@@ -1884,13 +4473,6 @@ exports[`Storyshots Design System/Components/Button fullWidth 1`] = `
 
 .c9 {
   padding-left: 8px;
-}
-
-.c8 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
 }
 
 .c3 {
@@ -2102,19 +4684,19 @@ exports[`Storyshots Design System/Components/Button icons 1`] = `
   width: 1px;
 }
 
+.c9 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
 .c6 {
   padding-right: 8px;
 }
 
 .c11 {
   padding-left: 8px;
-}
-
-.c9 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
 }
 
 .c2 {
@@ -2503,10 +5085,6 @@ exports[`Storyshots Design System/Components/Button sizes 1`] = `
   width: 1px;
 }
 
-.c3 {
-  padding-right: 4px;
-}
-
 .c7 {
   font-weight: 600;
   color: #32324d;
@@ -2519,6 +5097,10 @@ exports[`Storyshots Design System/Components/Button sizes 1`] = `
   color: #32324d;
   font-size: 0.875rem;
   line-height: 1.43;
+}
+
+.c3 {
+  padding-right: 4px;
 }
 
 .c2 {
@@ -3567,6 +6149,33 @@ exports[`Storyshots Design System/Components/Card base 1`] = `
   width: 1px;
 }
 
+.c17 {
+  color: #ffffff;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c21 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c22 {
+  color: #666687;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c27 {
+  color: #666687;
+  font-weight: 600;
+  font-size: 0.6875rem;
+  line-height: 1.45;
+  text-transform: uppercase;
+}
+
 .c1 {
   background: #ffffff;
   border-radius: 4px;
@@ -3600,33 +6209,6 @@ exports[`Storyshots Design System/Components/Card base 1`] = `
   padding: 4px;
   border-radius: 4px;
   min-width: 20px;
-}
-
-.c17 {
-  color: #ffffff;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c21 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c22 {
-  color: #666687;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c27 {
-  color: #666687;
-  font-weight: 600;
-  font-size: 0.6875rem;
-  line-height: 1.45;
-  text-transform: uppercase;
 }
 
 .c2 {
@@ -3760,6 +6342,46 @@ exports[`Storyshots Design System/Components/Card base 1`] = `
   border: 2px solid #4945ff;
 }
 
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  height: 2rem;
+  width: 2rem;
+}
+
+.c12 svg > g,
+.c12 svg path {
+  fill: #8e8ea9;
+}
+
+.c12:hover svg > g,
+.c12:hover svg path {
+  fill: #666687;
+}
+
+.c12:active svg > g,
+.c12:active svg path {
+  fill: #a5a5ba;
+}
+
+.c12[aria-disabled='true'] {
+  background-color: #eaeaef;
+}
+
+.c12[aria-disabled='true'] svg path {
+  fill: #666687;
+}
+
 .c8 {
   margin: 0;
   height: 18px;
@@ -3887,46 +6509,6 @@ exports[`Storyshots Design System/Components/Card base 1`] = `
   right: 4px;
 }
 
-.c12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  height: 2rem;
-  width: 2rem;
-}
-
-.c12 svg > g,
-.c12 svg path {
-  fill: #8e8ea9;
-}
-
-.c12:hover svg > g,
-.c12:hover svg path {
-  fill: #666687;
-}
-
-.c12:active svg > g,
-.c12:active svg path {
-  fill: #a5a5ba;
-}
-
-.c12[aria-disabled='true'] {
-  background-color: #eaeaef;
-}
-
-.c12[aria-disabled='true'] svg path {
-  fill: #666687;
-}
-
 <main>
   <div
     class="c0"
@@ -3961,7 +6543,7 @@ exports[`Storyshots Design System/Components/Card base 1`] = `
         <span>
           <button
             aria-disabled="false"
-            aria-labelledby="tooltip-1"
+            aria-labelledby="tooltip-13"
             class="c11 c12"
             tabindex="0"
             type="button"
@@ -4055,6 +6637,27 @@ exports[`Storyshots Design System/Components/Card keyboard navigable 1`] = `
   width: 1px;
 }
 
+.c7 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c8 {
+  color: #666687;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c13 {
+  color: #666687;
+  font-weight: 600;
+  font-size: 0.6875rem;
+  line-height: 1.45;
+  text-transform: uppercase;
+}
+
 .c1 {
   background: #ffffff;
   border-radius: 4px;
@@ -4082,27 +6685,6 @@ exports[`Storyshots Design System/Components/Card keyboard navigable 1`] = `
   padding: 4px;
   border-radius: 4px;
   min-width: 20px;
-}
-
-.c7 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c8 {
-  color: #666687;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c13 {
-  color: #666687;
-  font-weight: 600;
-  font-size: 0.6875rem;
-  line-height: 1.45;
-  text-transform: uppercase;
 }
 
 .c3 {
@@ -4428,6 +7010,33 @@ exports[`Storyshots Design System/Components/Card with asset icon 1`] = `
   width: 1px;
 }
 
+.c12 {
+  color: #ffffff;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c16 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c17 {
+  color: #666687;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c22 {
+  color: #666687;
+  font-weight: 600;
+  font-size: 0.6875rem;
+  line-height: 1.45;
+  text-transform: uppercase;
+}
+
 .c1 {
   background: #ffffff;
   border-radius: 4px;
@@ -4457,33 +7066,6 @@ exports[`Storyshots Design System/Components/Card with asset icon 1`] = `
   padding: 4px;
   border-radius: 4px;
   min-width: 20px;
-}
-
-.c12 {
-  color: #ffffff;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c16 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c17 {
-  color: #666687;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c22 {
-  color: #666687;
-  font-weight: 600;
-  font-size: 0.6875rem;
-  line-height: 1.45;
-  text-transform: uppercase;
 }
 
 .c2 {
@@ -4787,6 +7369,27 @@ exports[`Storyshots Design System/Components/Card without asset 1`] = `
   width: 1px;
 }
 
+.c7 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c8 {
+  color: #666687;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c13 {
+  color: #666687;
+  font-weight: 600;
+  font-size: 0.6875rem;
+  line-height: 1.45;
+  text-transform: uppercase;
+}
+
 .c1 {
   background: #ffffff;
   border-radius: 4px;
@@ -4814,27 +7417,6 @@ exports[`Storyshots Design System/Components/Card without asset 1`] = `
   padding: 4px;
   border-radius: 4px;
   min-width: 20px;
-}
-
-.c7 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c8 {
-  color: #666687;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c13 {
-  color: #666687;
-  font-weight: 600;
-  font-size: 0.6875rem;
-  line-height: 1.45;
-  text-transform: uppercase;
 }
 
 .c3 {
@@ -4970,6 +7552,33 @@ exports[`Storyshots Design System/Components/Card without asset action 1`] = `
   width: 1px;
 }
 
+.c13 {
+  color: #ffffff;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c17 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c18 {
+  color: #666687;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c23 {
+  color: #666687;
+  font-weight: 600;
+  font-size: 0.6875rem;
+  line-height: 1.45;
+  text-transform: uppercase;
+}
+
 .c1 {
   background: #ffffff;
   border-radius: 4px;
@@ -4999,33 +7608,6 @@ exports[`Storyshots Design System/Components/Card without asset action 1`] = `
   padding: 4px;
   border-radius: 4px;
   min-width: 20px;
-}
-
-.c13 {
-  color: #ffffff;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c17 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c18 {
-  color: #666687;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c23 {
-  color: #666687;
-  font-weight: 600;
-  font-size: 0.6875rem;
-  line-height: 1.45;
-  text-transform: uppercase;
 }
 
 .c2 {
@@ -5322,6 +7904,27 @@ exports[`Storyshots Design System/Components/Card without asset action nor timer
   width: 1px;
 }
 
+.c14 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c15 {
+  color: #666687;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c20 {
+  color: #666687;
+  font-weight: 600;
+  font-size: 0.6875rem;
+  line-height: 1.45;
+  text-transform: uppercase;
+}
+
 .c1 {
   background: #ffffff;
   border-radius: 4px;
@@ -5344,27 +7947,6 @@ exports[`Storyshots Design System/Components/Card without asset action nor timer
   padding: 4px;
   border-radius: 4px;
   min-width: 20px;
-}
-
-.c14 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c15 {
-  color: #666687;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c20 {
-  color: #666687;
-  font-weight: 600;
-  font-size: 0.6875rem;
-  line-height: 1.45;
-  text-transform: uppercase;
 }
 
 .c2 {
@@ -5646,6 +8228,29 @@ exports[`Storyshots Design System/Components/CarouselInput base 1`] = `
   width: 1px;
 }
 
+.c2 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c22 {
+  color: #666687;
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c23 {
+  color: #666687;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
 .c3 {
   background: #f6f6f9;
   padding: 8px;
@@ -5688,29 +8293,6 @@ exports[`Storyshots Design System/Components/CarouselInput base 1`] = `
   padding-top: 8px;
   padding-right: 16px;
   padding-left: 16px;
-}
-
-.c2 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c22 {
-  color: #666687;
-  display: block;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c23 {
-  color: #666687;
-  font-size: 0.75rem;
-  line-height: 1.33;
 }
 
 .c13 {
@@ -5757,6 +8339,10 @@ exports[`Storyshots Design System/Components/CarouselInput base 1`] = `
 
 .c18 > * + * {
   margin-left: 4px;
+}
+
+.c8 path {
+  fill: #666687;
 }
 
 .c19 {
@@ -5857,10 +8443,6 @@ exports[`Storyshots Design System/Components/CarouselInput base 1`] = `
   fill: #666687;
 }
 
-.c8 path {
-  fill: #666687;
-}
-
 .c5 {
   display: grid;
   grid-template-columns: auto 1fr auto;
@@ -5914,13 +8496,13 @@ exports[`Storyshots Design System/Components/CarouselInput base 1`] = `
     >
       <label
         class="c2"
-        for="carouselinput-3"
+        for="carouselinput-15"
       >
         Carousel of numbers (1/3)
       </label>
       <div
         class=""
-        id="carouselinput-3"
+        id="carouselinput-15"
         style="width: 242px;"
       >
         <div
@@ -6026,7 +8608,7 @@ exports[`Storyshots Design System/Components/CarouselInput base 1`] = `
               <span>
                 <button
                   aria-disabled="false"
-                  aria-labelledby="tooltip-4"
+                  aria-labelledby="tooltip-16"
                   class="c19 c20"
                   id="edit"
                   tabindex="0"
@@ -6051,7 +8633,7 @@ exports[`Storyshots Design System/Components/CarouselInput base 1`] = `
               <span>
                 <button
                   aria-disabled="false"
-                  aria-labelledby="tooltip-6"
+                  aria-labelledby="tooltip-18"
                   class="c19 c20"
                   tabindex="0"
                   type="button"
@@ -6073,7 +8655,7 @@ exports[`Storyshots Design System/Components/CarouselInput base 1`] = `
               <span>
                 <button
                   aria-disabled="false"
-                  aria-labelledby="tooltip-8"
+                  aria-labelledby="tooltip-20"
                   class="c19 c20"
                   tabindex="0"
                   type="button"
@@ -6095,7 +8677,7 @@ exports[`Storyshots Design System/Components/CarouselInput base 1`] = `
               <span>
                 <button
                   aria-disabled="false"
-                  aria-labelledby="tooltip-10"
+                  aria-labelledby="tooltip-22"
                   class="c19 c20"
                   tabindex="0"
                   type="button"
@@ -6121,7 +8703,7 @@ exports[`Storyshots Design System/Components/CarouselInput base 1`] = `
           >
             <span>
               <div
-                aria-labelledby="tooltip-12"
+                aria-labelledby="tooltip-24"
                 class="c13"
                 tabindex="0"
               >
@@ -6137,7 +8719,7 @@ exports[`Storyshots Design System/Components/CarouselInput base 1`] = `
       </div>
       <p
         class="c23"
-        id="carouselinput-3-hint"
+        id="carouselinput-15-hint"
       >
         Description line
       </p>
@@ -6157,6 +8739,19 @@ exports[`Storyshots Design System/Components/CarouselInput one slide only 1`] = 
   padding: 0;
   position: absolute;
   width: 1px;
+}
+
+.c2 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c16 {
+  color: #666687;
+  font-size: 0.75rem;
+  line-height: 1.33;
 }
 
 .c3 {
@@ -6189,19 +8784,6 @@ exports[`Storyshots Design System/Components/CarouselInput one slide only 1`] = 
   position: absolute;
   bottom: 4px;
   width: 100%;
-}
-
-.c2 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c16 {
-  color: #666687;
-  font-size: 0.75rem;
-  line-height: 1.33;
 }
 
 .c9 {
@@ -6379,13 +8961,13 @@ exports[`Storyshots Design System/Components/CarouselInput one slide only 1`] = 
     >
       <label
         class="c2"
-        for="carouselinput-14"
+        for="carouselinput-26"
       >
         Carousel of numbers 1/1)
       </label>
       <div
         class=""
-        id="carouselinput-14"
+        id="carouselinput-26"
         style="width: 242px;"
       >
         <div
@@ -6423,7 +9005,7 @@ exports[`Storyshots Design System/Components/CarouselInput one slide only 1`] = 
               <span>
                 <button
                   aria-disabled="false"
-                  aria-labelledby="tooltip-15"
+                  aria-labelledby="tooltip-27"
                   class="c14 c15"
                   id="edit"
                   tabindex="0"
@@ -6448,7 +9030,7 @@ exports[`Storyshots Design System/Components/CarouselInput one slide only 1`] = 
               <span>
                 <button
                   aria-disabled="false"
-                  aria-labelledby="tooltip-17"
+                  aria-labelledby="tooltip-29"
                   class="c14 c15"
                   tabindex="0"
                   type="button"
@@ -6470,7 +9052,7 @@ exports[`Storyshots Design System/Components/CarouselInput one slide only 1`] = 
               <span>
                 <button
                   aria-disabled="false"
-                  aria-labelledby="tooltip-19"
+                  aria-labelledby="tooltip-31"
                   class="c14 c15"
                   tabindex="0"
                   type="button"
@@ -6492,7 +9074,7 @@ exports[`Storyshots Design System/Components/CarouselInput one slide only 1`] = 
               <span>
                 <button
                   aria-disabled="false"
-                  aria-labelledby="tooltip-21"
+                  aria-labelledby="tooltip-33"
                   class="c14 c15"
                   tabindex="0"
                   type="button"
@@ -6517,7 +9099,7 @@ exports[`Storyshots Design System/Components/CarouselInput one slide only 1`] = 
       </div>
       <p
         class="c16"
-        id="carouselinput-14-hint"
+        id="carouselinput-26-hint"
       >
         Description line
       </p>
@@ -6539,14 +9121,14 @@ exports[`Storyshots Design System/Components/Checkbox base 1`] = `
   width: 1px;
 }
 
-.c5 {
-  padding-left: 8px;
-}
-
 .c2 {
   color: #32324d;
   font-size: 0.875rem;
   line-height: 1.43;
+}
+
+.c5 {
+  padding-left: 8px;
 }
 
 .c1 {
@@ -6668,7 +9250,7 @@ exports[`Storyshots Design System/Components/Checkbox base 1`] = `
       >
         <input
           class="c4"
-          id="checkbox-23"
+          id="checkbox-35"
           name="default"
           type="checkbox"
         />
@@ -6696,14 +9278,14 @@ exports[`Storyshots Design System/Components/Checkbox disabled 1`] = `
   width: 1px;
 }
 
-.c5 {
-  padding-left: 8px;
-}
-
 .c2 {
   color: #32324d;
   font-size: 0.875rem;
   line-height: 1.43;
+}
+
+.c5 {
+  padding-left: 8px;
 }
 
 .c1 {
@@ -6827,7 +9409,7 @@ exports[`Storyshots Design System/Components/Checkbox disabled 1`] = `
         <input
           class="c4"
           disabled=""
-          id="checkbox-24"
+          id="checkbox-36"
           name="default"
           type="checkbox"
         />
@@ -6855,10 +9437,6 @@ exports[`Storyshots Design System/Components/Checkbox error 1`] = `
   width: 1px;
 }
 
-.c5 {
-  padding-left: 8px;
-}
-
 .c2 {
   color: #32324d;
   font-size: 0.875rem;
@@ -6869,6 +9447,10 @@ exports[`Storyshots Design System/Components/Checkbox error 1`] = `
   color: #d02b20;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c5 {
+  padding-left: 8px;
 }
 
 .c1 {
@@ -6989,9 +9571,9 @@ exports[`Storyshots Design System/Components/Checkbox error 1`] = `
         class="c2 c3"
       >
         <input
-          aria-describedby="checkbox-25-error"
+          aria-describedby="checkbox-37-error"
           class="c4"
-          id="checkbox-25"
+          id="checkbox-37"
           name="default"
           type="checkbox"
         />
@@ -7004,7 +9586,7 @@ exports[`Storyshots Design System/Components/Checkbox error 1`] = `
       <p
         class="c6"
         data-strapi-field-error="true"
-        id="checkbox-25-error"
+        id="checkbox-37-error"
       >
         Description line lorem ipsum
       </p>
@@ -7026,10 +9608,6 @@ exports[`Storyshots Design System/Components/Checkbox hint 1`] = `
   width: 1px;
 }
 
-.c5 {
-  padding-left: 8px;
-}
-
 .c2 {
   color: #32324d;
   font-size: 0.875rem;
@@ -7040,6 +9618,10 @@ exports[`Storyshots Design System/Components/Checkbox hint 1`] = `
   color: #666687;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c5 {
+  padding-left: 8px;
 }
 
 .c1 {
@@ -7160,9 +9742,9 @@ exports[`Storyshots Design System/Components/Checkbox hint 1`] = `
         class="c2 c3"
       >
         <input
-          aria-describedby="checkbox-26-hint"
+          aria-describedby="checkbox-38-hint"
           class="c4"
-          id="checkbox-26"
+          id="checkbox-38"
           name="default"
           type="checkbox"
         />
@@ -7174,7 +9756,7 @@ exports[`Storyshots Design System/Components/Checkbox hint 1`] = `
       </label>
       <p
         class="c6"
-        id="checkbox-26-hint"
+        id="checkbox-38-hint"
       >
         Description line lorem ipsum
       </p>
@@ -7196,14 +9778,14 @@ exports[`Storyshots Design System/Components/Checkbox indeterminate 1`] = `
   width: 1px;
 }
 
-.c5 {
-  padding-left: 8px;
-}
-
 .c2 {
   color: #32324d;
   font-size: 0.875rem;
   line-height: 1.43;
+}
+
+.c5 {
+  padding-left: 8px;
 }
 
 .c1 {
@@ -7408,15 +9990,15 @@ exports[`Storyshots Design System/Components/Combobox base 1`] = `
   width: 1px;
 }
 
-.c8 {
-  padding-left: 12px;
-}
-
 .c2 {
   font-weight: 600;
   color: #32324d;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c8 {
+  padding-left: 12px;
 }
 
 .c3 {
@@ -7573,8 +10155,8 @@ exports[`Storyshots Design System/Components/Combobox base 1`] = `
     >
       <label
         class="c2"
-        for="combobox-27"
-        id="combobox-27-label"
+        for="combobox-39"
+        id="combobox-39-label"
       >
         Food
       </label>
@@ -7589,15 +10171,15 @@ exports[`Storyshots Design System/Components/Combobox base 1`] = `
           <input
             aria-activedescendant=""
             aria-autocomplete="list"
-            aria-controls="combobox-27-listbox"
+            aria-controls="combobox-39-listbox"
             aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-labelledby="combobox-27-label"
+            aria-labelledby="combobox-39-label"
             autocomplete="off"
             autocorrect="off"
             class="c7"
-            id="combobox-27"
+            id="combobox-39"
             placeholder="Select or enter a value"
             role="combobox"
             spellcheck="off"
@@ -7650,15 +10232,15 @@ exports[`Storyshots Design System/Components/Combobox creatable 1`] = `
   width: 1px;
 }
 
-.c8 {
-  padding-left: 12px;
-}
-
 .c2 {
   font-weight: 600;
   color: #32324d;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c8 {
+  padding-left: 12px;
 }
 
 .c3 {
@@ -7815,8 +10397,8 @@ exports[`Storyshots Design System/Components/Combobox creatable 1`] = `
     >
       <label
         class="c2"
-        for="combobox-28"
-        id="combobox-28-label"
+        for="combobox-40"
+        id="combobox-40-label"
       >
         Food
       </label>
@@ -7831,15 +10413,15 @@ exports[`Storyshots Design System/Components/Combobox creatable 1`] = `
           <input
             aria-activedescendant=""
             aria-autocomplete="list"
-            aria-controls="combobox-28-listbox"
+            aria-controls="combobox-40-listbox"
             aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-labelledby="combobox-28-label"
+            aria-labelledby="combobox-40-label"
             autocomplete="off"
             autocorrect="off"
             class="c7"
-            id="combobox-28"
+            id="combobox-40"
             placeholder="Select or enter a value"
             role="combobox"
             spellcheck="off"
@@ -7892,15 +10474,15 @@ exports[`Storyshots Design System/Components/Combobox disabled 1`] = `
   width: 1px;
 }
 
-.c8 {
-  padding-left: 12px;
-}
-
 .c2 {
   font-weight: 600;
   color: #32324d;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c8 {
+  padding-left: 12px;
 }
 
 .c3 {
@@ -8060,8 +10642,8 @@ exports[`Storyshots Design System/Components/Combobox disabled 1`] = `
     >
       <label
         class="c2"
-        for="combobox-29"
-        id="combobox-29-label"
+        for="combobox-41"
+        id="combobox-41-label"
       >
         Food
       </label>
@@ -8076,15 +10658,15 @@ exports[`Storyshots Design System/Components/Combobox disabled 1`] = `
           <input
             aria-activedescendant=""
             aria-autocomplete="list"
-            aria-controls="combobox-29-listbox"
+            aria-controls="combobox-41-listbox"
             aria-disabled="true"
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-labelledby="combobox-29-label"
+            aria-labelledby="combobox-41-label"
             autocomplete="off"
             autocorrect="off"
             class="c7"
-            id="combobox-29"
+            id="combobox-41"
             placeholder="Select or enter a value"
             readonly=""
             role="combobox"
@@ -8139,10 +10721,6 @@ exports[`Storyshots Design System/Components/Combobox error 1`] = `
   width: 1px;
 }
 
-.c8 {
-  padding-left: 12px;
-}
-
 .c2 {
   font-weight: 600;
   color: #32324d;
@@ -8154,6 +10732,10 @@ exports[`Storyshots Design System/Components/Combobox error 1`] = `
   color: #d02b20;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c8 {
+  padding-left: 12px;
 }
 
 .c3 {
@@ -8310,8 +10892,8 @@ exports[`Storyshots Design System/Components/Combobox error 1`] = `
     >
       <label
         class="c2"
-        for="combobox-30"
-        id="combobox-30-label"
+        for="combobox-42"
+        id="combobox-42-label"
       >
         Food
       </label>
@@ -8326,15 +10908,15 @@ exports[`Storyshots Design System/Components/Combobox error 1`] = `
           <input
             aria-activedescendant=""
             aria-autocomplete="list"
-            aria-controls="combobox-30-listbox"
+            aria-controls="combobox-42-listbox"
             aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-labelledby="combobox-30-label"
+            aria-labelledby="combobox-42-label"
             autocomplete="off"
             autocorrect="off"
             class="c7"
-            id="combobox-30"
+            id="combobox-42"
             placeholder="Select or enter a value"
             role="combobox"
             spellcheck="off"
@@ -8372,7 +10954,7 @@ exports[`Storyshots Design System/Components/Combobox error 1`] = `
       <p
         class="c11"
         data-strapi-field-error="true"
-        id="combobox-30-error"
+        id="combobox-42-error"
       >
         An error occured
       </p>
@@ -8394,10 +10976,6 @@ exports[`Storyshots Design System/Components/Combobox initial-data 1`] = `
   width: 1px;
 }
 
-.c10 {
-  padding-left: 12px;
-}
-
 .c2 {
   font-weight: 600;
   color: #32324d;
@@ -8409,6 +10987,10 @@ exports[`Storyshots Design System/Components/Combobox initial-data 1`] = `
   color: #32324d;
   font-size: 0.875rem;
   line-height: 1.43;
+}
+
+.c10 {
+  padding-left: 12px;
 }
 
 .c3 {
@@ -8572,8 +11154,8 @@ exports[`Storyshots Design System/Components/Combobox initial-data 1`] = `
     >
       <label
         class="c2"
-        for="combobox-31"
-        id="combobox-31-label"
+        for="combobox-43"
+        id="combobox-43-label"
       >
         Food
       </label>
@@ -8586,7 +11168,7 @@ exports[`Storyshots Design System/Components/Combobox initial-data 1`] = `
         >
           <div
             class="c7"
-            id="combobox-31-selected-value"
+            id="combobox-43-selected-value"
           >
             <span
               class="c8"
@@ -8597,15 +11179,15 @@ exports[`Storyshots Design System/Components/Combobox initial-data 1`] = `
           <input
             aria-activedescendant=""
             aria-autocomplete="list"
-            aria-controls="combobox-31-listbox"
+            aria-controls="combobox-43-listbox"
             aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-labelledby="combobox-31-label"
+            aria-labelledby="combobox-43-label"
             autocomplete="off"
             autocorrect="off"
             class="c9"
-            id="combobox-31"
+            id="combobox-43"
             placeholder=""
             role="combobox"
             spellcheck="off"
@@ -8619,7 +11201,7 @@ exports[`Storyshots Design System/Components/Combobox initial-data 1`] = `
           <button
             aria-label="clear"
             class="c10 c11"
-            id="combobox-31-clear"
+            id="combobox-43-clear"
             type="button"
           >
             <svg
@@ -8843,14 +11425,14 @@ exports[`Storyshots Design System/Components/Combobox withoutLabel 1`] = `
           <input
             aria-activedescendant=""
             aria-autocomplete="list"
-            aria-controls="combobox-32-listbox"
+            aria-controls="combobox-44-listbox"
             aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="listbox"
             autocomplete="off"
             autocorrect="off"
             class="c6"
-            id="combobox-32"
+            id="combobox-44"
             placeholder="Select or enter a value"
             role="combobox"
             spellcheck="off"
@@ -8903,16 +11485,16 @@ exports[`Storyshots Design System/Components/DatePicker base 1`] = `
   width: 1px;
 }
 
-.c6 {
-  padding-right: 8px;
-  padding-left: 12px;
-}
-
 .c3 {
   font-weight: 600;
   color: #32324d;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c6 {
+  padding-right: 8px;
+  padding-left: 12px;
 }
 
 .c2 {
@@ -9058,7 +11640,7 @@ exports[`Storyshots Design System/Components/DatePicker base 1`] = `
             >
               <label
                 class="c3"
-                for="datepicker-33"
+                for="datepicker-45"
               >
                 Date picker
               </label>
@@ -9097,7 +11679,7 @@ exports[`Storyshots Design System/Components/DatePicker base 1`] = `
                 aria-disabled="false"
                 aria-invalid="false"
                 class="c8"
-                id="datepicker-33"
+                id="datepicker-45"
                 name="datepicker"
                 placeholder="1/1/1970"
                 value=""
@@ -9131,16 +11713,16 @@ exports[`Storyshots Design System/Components/DatePicker disabled 1`] = `
   width: 1px;
 }
 
-.c6 {
-  padding-right: 8px;
-  padding-left: 12px;
-}
-
 .c3 {
   font-weight: 600;
   color: #32324d;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c6 {
+  padding-right: 8px;
+  padding-left: 12px;
 }
 
 .c2 {
@@ -9290,7 +11872,7 @@ exports[`Storyshots Design System/Components/DatePicker disabled 1`] = `
             >
               <label
                 class="c3"
-                for="datepicker-34"
+                for="datepicker-46"
               >
                 Date picker
               </label>
@@ -9330,7 +11912,7 @@ exports[`Storyshots Design System/Components/DatePicker disabled 1`] = `
                 aria-disabled="true"
                 aria-invalid="false"
                 class="c8"
-                id="datepicker-34"
+                id="datepicker-46"
                 name="datepicker"
                 placeholder="1/1/1970"
                 value=""
@@ -9364,16 +11946,16 @@ exports[`Storyshots Design System/Components/DatePicker size S 1`] = `
   width: 1px;
 }
 
-.c6 {
-  padding-right: 8px;
-  padding-left: 12px;
-}
-
 .c3 {
   font-weight: 600;
   color: #32324d;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c6 {
+  padding-right: 8px;
+  padding-left: 12px;
 }
 
 .c2 {
@@ -9519,7 +12101,7 @@ exports[`Storyshots Design System/Components/DatePicker size S 1`] = `
             >
               <label
                 class="c3"
-                for="datepicker-35"
+                for="datepicker-47"
               >
                 Date picker
               </label>
@@ -9558,7 +12140,7 @@ exports[`Storyshots Design System/Components/DatePicker size S 1`] = `
                 aria-disabled="false"
                 aria-invalid="false"
                 class="c8"
-                id="datepicker-35"
+                id="datepicker-47"
                 name="datepicker"
                 placeholder="1/1/1970"
                 value=""
@@ -9835,6 +12417,20 @@ exports[`Storyshots Design System/Components/EmptyStateLayout base 1`] = `
   width: 1px;
 }
 
+.c9 {
+  color: #666687;
+  font-weight: 500;
+  font-size: 1rem;
+  line-height: 1.25;
+}
+
+.c14 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
 .c2 {
   background: #f6f6f9;
   padding: 40px;
@@ -9857,20 +12453,6 @@ exports[`Storyshots Design System/Components/EmptyStateLayout base 1`] = `
 
 .c12 {
   padding-right: 8px;
-}
-
-.c9 {
-  color: #666687;
-  font-weight: 500;
-  font-size: 1rem;
-  line-height: 1.25;
-}
-
-.c14 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
 }
 
 .c10 {
@@ -10163,6 +12745,20 @@ exports[`Storyshots Design System/Components/EmptyStateLayout with large text 1`
   width: 1px;
 }
 
+.c9 {
+  color: #666687;
+  font-weight: 500;
+  font-size: 1rem;
+  line-height: 1.25;
+}
+
+.c14 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
 .c2 {
   background: #f6f6f9;
   padding: 40px;
@@ -10185,20 +12781,6 @@ exports[`Storyshots Design System/Components/EmptyStateLayout with large text 1`
 
 .c12 {
   padding-right: 8px;
-}
-
-.c9 {
-  color: #666687;
-  font-weight: 500;
-  font-size: 1rem;
-  line-height: 1.25;
-}
-
-.c14 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
 }
 
 .c10 {
@@ -10491,6 +13073,13 @@ exports[`Storyshots Design System/Components/EmptyStateLayout without action 1`]
   width: 1px;
 }
 
+.c7 {
+  color: #666687;
+  font-weight: 500;
+  font-size: 1rem;
+  line-height: 1.25;
+}
+
 .c1 {
   background: #f6f6f9;
   padding: 40px;
@@ -10509,13 +13098,6 @@ exports[`Storyshots Design System/Components/EmptyStateLayout without action 1`]
 
 .c6 {
   padding-bottom: 16px;
-}
-
-.c7 {
-  color: #666687;
-  font-weight: 500;
-  font-size: 1rem;
-  line-height: 1.25;
 }
 
 .c3 {
@@ -10754,7 +13336,7 @@ exports[`Storyshots Design System/Components/Field base 1`] = `
     >
       <label
         class="c2"
-        for="field-37"
+        for="field-49"
       >
         Email
       </label>
@@ -10765,7 +13347,7 @@ exports[`Storyshots Design System/Components/Field base 1`] = `
           aria-disabled="false"
           aria-invalid="false"
           class="c5"
-          id="field-37"
+          id="field-49"
           name="email"
           placeholder="Placeholder"
           type="text"
@@ -10917,7 +13499,7 @@ exports[`Storyshots Design System/Components/Field disabled 1`] = `
     >
       <label
         class="c2"
-        for="field-38"
+        for="field-50"
       >
         Password
       </label>
@@ -10926,11 +13508,11 @@ exports[`Storyshots Design System/Components/Field disabled 1`] = `
         disabled=""
       >
         <input
-          aria-describedby="field-38-hint"
+          aria-describedby="field-50-hint"
           aria-disabled="true"
           aria-invalid="false"
           class="c5"
-          id="field-38"
+          id="field-50"
           name="password"
           placeholder="Placeholder"
           value="Hello world"
@@ -10938,7 +13520,7 @@ exports[`Storyshots Design System/Components/Field disabled 1`] = `
       </div>
       <p
         class="c6"
-        id="field-38-hint"
+        id="field-50-hint"
       >
         Description line
       </p>
@@ -10960,6 +13542,19 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
   width: 1px;
 }
 
+.c4 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c12 {
+  color: #666687;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
 .c1 {
   padding: 40px;
 }
@@ -10976,19 +13571,6 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
 .c11 {
   padding-right: 12px;
   padding-left: 8px;
-}
-
-.c4 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c12 {
-  color: #666687;
-  font-size: 0.75rem;
-  line-height: 1.33;
 }
 
 .c3 {
@@ -11138,7 +13720,7 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
         >
           <label
             class="c4"
-            for="field-39"
+            for="field-51"
           >
             Password
           </label>
@@ -11147,7 +13729,7 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
           >
             <span>
               <button
-                aria-describedby="tooltip-40"
+                aria-describedby="tooltip-52"
                 aria-label="Information about the email"
                 style="padding: 0px; background: transparent;"
                 tabindex="0"
@@ -11206,11 +13788,11 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
             </button>
           </div>
           <input
-            aria-describedby="field-39-hint"
+            aria-describedby="field-51-hint"
             aria-disabled="false"
             aria-invalid="false"
             class="c10"
-            id="field-39"
+            id="field-51"
             name="password"
             placeholder="example@domain.com"
             value=""
@@ -11245,7 +13827,7 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
         </div>
         <p
           class="c12"
-          id="field-39-hint"
+          id="field-51-hint"
         >
           Description line
         </p>
@@ -11268,6 +13850,19 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
   width: 1px;
 }
 
+.c4 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c12 {
+  color: #666687;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
 .c1 {
   padding: 40px;
 }
@@ -11284,19 +13879,6 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
 .c11 {
   padding-right: 12px;
   padding-left: 8px;
-}
-
-.c4 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c12 {
-  color: #666687;
-  font-size: 0.75rem;
-  line-height: 1.33;
 }
 
 .c3 {
@@ -11446,7 +14028,7 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
         >
           <label
             class="c4"
-            for="field-42"
+            for="field-54"
           >
             Password
           </label>
@@ -11455,7 +14037,7 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
           >
             <span>
               <button
-                aria-describedby="tooltip-43"
+                aria-describedby="tooltip-55"
                 aria-label="Information about the email"
                 style="padding: 0px; background: transparent;"
                 tabindex="0"
@@ -11514,11 +14096,11 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
             </button>
           </div>
           <input
-            aria-describedby="field-42-hint"
+            aria-describedby="field-54-hint"
             aria-disabled="false"
             aria-invalid="false"
             class="c10"
-            id="field-42"
+            id="field-54"
             name="password"
             placeholder="example@domain.com"
             value=""
@@ -11553,7 +14135,7 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
         </div>
         <p
           class="c12"
-          id="field-42-hint"
+          id="field-54-hint"
         >
           Description line
         </p>
@@ -11710,7 +14292,7 @@ exports[`Storyshots Design System/Components/Field with description 1`] = `
     >
       <label
         class="c2"
-        for="field-45"
+        for="field-57"
         required=""
       >
         Email
@@ -11724,11 +14306,11 @@ exports[`Storyshots Design System/Components/Field with description 1`] = `
         class="c5 c6"
       >
         <input
-          aria-describedby="field-45-hint"
+          aria-describedby="field-57-hint"
           aria-disabled="false"
           aria-invalid="false"
           class="c7"
-          id="field-45"
+          id="field-57"
           name="email"
           placeholder="Placeholder"
           type="text"
@@ -11737,7 +14319,7 @@ exports[`Storyshots Design System/Components/Field with description 1`] = `
       </div>
       <p
         class="c8"
-        id="field-45-hint"
+        id="field-57-hint"
       >
         Description line
       </p>
@@ -11883,7 +14465,7 @@ exports[`Storyshots Design System/Components/Field with error 1`] = `
     >
       <label
         class="c2"
-        for="field-46"
+        for="field-58"
       >
         Password
       </label>
@@ -11891,11 +14473,11 @@ exports[`Storyshots Design System/Components/Field with error 1`] = `
         class="c3 c4"
       >
         <input
-          aria-describedby="field-46-error"
+          aria-describedby="field-58-error"
           aria-disabled="false"
           aria-invalid="true"
           class="c5"
-          id="field-46"
+          id="field-58"
           name="password"
           placeholder="Placeholder"
           type="password"
@@ -11905,7 +14487,7 @@ exports[`Storyshots Design System/Components/Field with error 1`] = `
       <p
         class="c6"
         data-strapi-field-error="true"
-        id="field-46-error"
+        id="field-58-error"
       >
         Password is too short
       </p>
@@ -12037,6 +14619,32 @@ exports[`Storyshots Design System/Components/HeaderLayout base 1`] = `
   width: 1px;
 }
 
+.c10 {
+  color: #4945ff;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c13 {
+  color: #32324d;
+  font-weight: 600;
+  font-size: 2rem;
+  line-height: 1.25;
+}
+
+.c18 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c20 {
+  color: #666687;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
 .c2 {
   background: #f6f6f9;
 }
@@ -12053,41 +14661,15 @@ exports[`Storyshots Design System/Components/HeaderLayout base 1`] = `
   padding-bottom: 8px;
 }
 
-.c6 {
+.c7 {
   padding-right: 8px;
 }
 
-.c13 {
+.c14 {
   padding-left: 16px;
 }
 
-.c9 {
-  color: #4945ff;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c12 {
-  color: #32324d;
-  font-weight: 600;
-  font-size: 2rem;
-  line-height: 1.25;
-}
-
-.c17 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c19 {
-  color: #666687;
-  font-size: 1rem;
-  line-height: 1.5;
-}
-
-.c10 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12105,7 +14687,7 @@ exports[`Storyshots Design System/Components/HeaderLayout base 1`] = `
   align-items: center;
 }
 
-.c11 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12119,7 +14701,69 @@ exports[`Storyshots Design System/Components/HeaderLayout base 1`] = `
   align-items: center;
 }
 
+.c15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 4px;
+  background: #ffffff;
+  border: 1px solid #dcdce4;
+  position: relative;
+  outline: none;
+}
+
+.c15 svg {
+  height: 12px;
+  width: 12px;
+}
+
+.c15 svg > g,
+.c15 svg path {
+  fill: #ffffff;
+}
+
+.c15[aria-disabled='true'] {
+  pointer-events: none;
+}
+
+.c15:after {
+  -webkit-transition-property: all;
+  transition-property: all;
+  -webkit-transition-duration: 0.2s;
+  transition-duration: 0.2s;
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  left: -4px;
+  right: -4px;
+  border: 2px solid transparent;
+}
+
+.c15:focus-visible {
+  outline: none;
+}
+
+.c15:focus-visible:after {
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -5px;
+  bottom: -5px;
+  left: -5px;
+  right: -5px;
+  border: 2px solid #4945ff;
+}
+
 .c5 {
+  cursor: pointer;
+}
+
+.c6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -12134,15 +14778,15 @@ exports[`Storyshots Design System/Components/HeaderLayout base 1`] = `
   outline: none;
 }
 
-.c5 svg path {
+.c6 svg path {
   fill: #4945ff;
 }
 
-.c5 svg {
+.c6 svg {
   font-size: 0.625rem;
 }
 
-.c5:after {
+.c6:after {
   -webkit-transition-property: all;
   transition-property: all;
   -webkit-transition-duration: 0.2s;
@@ -12157,11 +14801,11 @@ exports[`Storyshots Design System/Components/HeaderLayout base 1`] = `
   border: 2px solid transparent;
 }
 
-.c5:focus-visible {
+.c6:focus-visible {
   outline: none;
 }
 
-.c5:focus-visible:after {
+.c6:focus-visible:after {
   border-radius: 8px;
   content: '';
   position: absolute;
@@ -12172,76 +14816,18 @@ exports[`Storyshots Design System/Components/HeaderLayout base 1`] = `
   border: 2px solid #4945ff;
 }
 
-.c7 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c14 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  cursor: pointer;
-  padding: 8px;
-  border-radius: 4px;
-  background: #ffffff;
-  border: 1px solid #dcdce4;
-  position: relative;
-  outline: none;
-}
-
-.c14 svg {
-  height: 12px;
-  width: 12px;
-}
-
-.c14 svg > g,
-.c14 svg path {
-  fill: #ffffff;
-}
-
-.c14[aria-disabled='true'] {
-  pointer-events: none;
-}
-
-.c14:after {
-  -webkit-transition-property: all;
-  transition-property: all;
-  -webkit-transition-duration: 0.2s;
-  transition-duration: 0.2s;
-  border-radius: 8px;
-  content: '';
-  position: absolute;
-  top: -4px;
-  bottom: -4px;
-  left: -4px;
-  right: -4px;
-  border: 2px solid transparent;
-}
-
-.c14:focus-visible {
-  outline: none;
-}
-
-.c14:focus-visible:after {
-  border-radius: 8px;
-  content: '';
-  position: absolute;
-  top: -5px;
-  bottom: -5px;
-  left: -5px;
-  right: -5px;
-  border: 2px solid #4945ff;
-}
-
-.c16 {
+.c17 {
   height: 100%;
 }
 
-.c15 {
+.c16 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -12253,7 +14839,7 @@ exports[`Storyshots Design System/Components/HeaderLayout base 1`] = `
   background: #ffffff;
 }
 
-.c15 .c1 {
+.c16 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12264,56 +14850,56 @@ exports[`Storyshots Design System/Components/HeaderLayout base 1`] = `
   align-items: center;
 }
 
-.c15 .c8 {
+.c16 .c9 {
   color: #ffffff;
 }
 
-.c15[aria-disabled='true'] {
+.c16[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c15[aria-disabled='true'] .c8 {
+.c16[aria-disabled='true'] .c9 {
   color: #666687;
 }
 
-.c15[aria-disabled='true'] svg > g,
-.c15[aria-disabled='true'] svg path {
+.c16[aria-disabled='true'] svg > g,
+.c16[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c15[aria-disabled='true']:active {
+.c16[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c15[aria-disabled='true']:active .c8 {
+.c16[aria-disabled='true']:active .c9 {
   color: #666687;
 }
 
-.c15[aria-disabled='true']:active svg > g,
-.c15[aria-disabled='true']:active svg path {
+.c16[aria-disabled='true']:active svg > g,
+.c16[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c15:hover {
+.c16:hover {
   background-color: #f6f6f9;
 }
 
-.c15:active {
+.c16:active {
   background-color: #eaeaef;
 }
 
-.c15 .c8 {
+.c16 .c9 {
   color: #32324d;
 }
 
-.c15 svg > g,
-.c15 svg path {
+.c16 svg > g,
+.c16 svg path {
   fill: #32324d;
 }
 
-.c18 {
+.c19 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -12325,7 +14911,7 @@ exports[`Storyshots Design System/Components/HeaderLayout base 1`] = `
   background: #4945ff;
 }
 
-.c18 .c1 {
+.c19 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12336,44 +14922,44 @@ exports[`Storyshots Design System/Components/HeaderLayout base 1`] = `
   align-items: center;
 }
 
-.c18 .c8 {
+.c19 .c9 {
   color: #ffffff;
 }
 
-.c18[aria-disabled='true'] {
+.c19[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c18[aria-disabled='true'] .c8 {
+.c19[aria-disabled='true'] .c9 {
   color: #666687;
 }
 
-.c18[aria-disabled='true'] svg > g,
-.c18[aria-disabled='true'] svg path {
+.c19[aria-disabled='true'] svg > g,
+.c19[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c18[aria-disabled='true']:active {
+.c19[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c18[aria-disabled='true']:active .c8 {
+.c19[aria-disabled='true']:active .c9 {
   color: #666687;
 }
 
-.c18[aria-disabled='true']:active svg > g,
-.c18[aria-disabled='true']:active svg path {
+.c19[aria-disabled='true']:active svg > g,
+.c19[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c18:hover {
+.c19:hover {
   border: 1px solid #7b79ff;
   background: #7b79ff;
 }
 
-.c18:active {
+.c19:active {
   border: 1px solid #4945ff;
   background: #4945ff;
 }
@@ -12397,13 +14983,12 @@ exports[`Storyshots Design System/Components/HeaderLayout base 1`] = `
         class="c1 c4"
       >
         <a
-          aria-current="page"
-          class="c5 active"
-          href="/"
+          class="c5 c6"
+          to="/"
         >
           <span
             aria-hidden="true"
-            class="c1 c6 c7"
+            class="c1 c7 c8"
           >
             <svg
               fill="none"
@@ -12419,34 +15004,34 @@ exports[`Storyshots Design System/Components/HeaderLayout base 1`] = `
             </svg>
           </span>
           <span
-            class="c8 c9"
+            class="c9 c10"
           >
             Go back
           </span>
         </a>
       </div>
       <div
-        class="c1 c10"
+        class="c1 c11"
       >
         <div
-          class="c1 c11"
+          class="c1 c12"
         >
           <h2
-            class="c8 c12"
+            class="c9 c13"
           >
             Restaurants
           </h2>
           <div
-            class="c1 c13"
+            class="c1 c14"
           >
             <button
               aria-disabled="false"
-              class="c14 c15"
+              class="c15 c16"
               type="button"
             >
               <div
                 aria-hidden="true"
-                class="c1 c6 c16"
+                class="c1 c7 c17"
               >
                 <svg
                   fill="none"
@@ -12464,7 +15049,7 @@ exports[`Storyshots Design System/Components/HeaderLayout base 1`] = `
                 </svg>
               </div>
               <span
-                class="c8 c17"
+                class="c9 c18"
               >
                 Edit
               </span>
@@ -12473,12 +15058,12 @@ exports[`Storyshots Design System/Components/HeaderLayout base 1`] = `
         </div>
         <button
           aria-disabled="false"
-          class="c14 c18"
+          class="c15 c19"
           type="button"
         >
           <div
             aria-hidden="true"
-            class="c1 c6 c16"
+            class="c1 c7 c17"
           >
             <svg
               fill="none"
@@ -12494,14 +15079,14 @@ exports[`Storyshots Design System/Components/HeaderLayout base 1`] = `
             </svg>
           </div>
           <span
-            class="c8 c17"
+            class="c9 c18"
           >
             Add an entry
           </span>
         </button>
       </div>
       <p
-        class="c8 c19"
+        class="c9 c20"
       >
         36 entries found
       </p>
@@ -12523,26 +15108,6 @@ exports[`Storyshots Design System/Components/HeaderLayout base without nav actio
   width: 1px;
 }
 
-.c2 {
-  background: #f6f6f9;
-}
-
-.c3 {
-  background: #f6f6f9;
-  padding-top: 40px;
-  padding-right: 56px;
-  padding-bottom: 40px;
-  padding-left: 56px;
-}
-
-.c8 {
-  padding-left: 16px;
-}
-
-.c11 {
-  padding-right: 8px;
-}
-
 .c7 {
   color: #32324d;
   font-weight: 600;
@@ -12561,6 +15126,26 @@ exports[`Storyshots Design System/Components/HeaderLayout base without nav actio
   color: #666687;
   font-size: 1rem;
   line-height: 1.5;
+}
+
+.c2 {
+  background: #f6f6f9;
+}
+
+.c3 {
+  background: #f6f6f9;
+  padding-top: 40px;
+  padding-right: 56px;
+  padding-bottom: 40px;
+  padding-left: 56px;
+}
+
+.c8 {
+  padding-left: 16px;
+}
+
+.c11 {
+  padding-right: 8px;
 }
 
 .c4 {
@@ -12907,6 +15492,32 @@ exports[`Storyshots Design System/Components/HeaderLayout combined w/ scroll 1`]
   width: 1px;
 }
 
+.c10 {
+  color: #4945ff;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c13 {
+  color: #32324d;
+  font-weight: 600;
+  font-size: 2rem;
+  line-height: 1.25;
+}
+
+.c18 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c20 {
+  color: #666687;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
 .c2 {
   background: #f6f6f9;
 }
@@ -12923,41 +15534,15 @@ exports[`Storyshots Design System/Components/HeaderLayout combined w/ scroll 1`]
   padding-bottom: 8px;
 }
 
-.c6 {
+.c7 {
   padding-right: 8px;
 }
 
-.c13 {
+.c14 {
   padding-left: 16px;
 }
 
-.c9 {
-  color: #4945ff;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c12 {
-  color: #32324d;
-  font-weight: 600;
-  font-size: 2rem;
-  line-height: 1.25;
-}
-
-.c17 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c19 {
-  color: #666687;
-  font-size: 1rem;
-  line-height: 1.5;
-}
-
-.c10 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12975,7 +15560,7 @@ exports[`Storyshots Design System/Components/HeaderLayout combined w/ scroll 1`]
   align-items: center;
 }
 
-.c11 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12989,7 +15574,69 @@ exports[`Storyshots Design System/Components/HeaderLayout combined w/ scroll 1`]
   align-items: center;
 }
 
+.c15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 4px;
+  background: #ffffff;
+  border: 1px solid #dcdce4;
+  position: relative;
+  outline: none;
+}
+
+.c15 svg {
+  height: 12px;
+  width: 12px;
+}
+
+.c15 svg > g,
+.c15 svg path {
+  fill: #ffffff;
+}
+
+.c15[aria-disabled='true'] {
+  pointer-events: none;
+}
+
+.c15:after {
+  -webkit-transition-property: all;
+  transition-property: all;
+  -webkit-transition-duration: 0.2s;
+  transition-duration: 0.2s;
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  left: -4px;
+  right: -4px;
+  border: 2px solid transparent;
+}
+
+.c15:focus-visible {
+  outline: none;
+}
+
+.c15:focus-visible:after {
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -5px;
+  bottom: -5px;
+  left: -5px;
+  right: -5px;
+  border: 2px solid #4945ff;
+}
+
 .c5 {
+  cursor: pointer;
+}
+
+.c6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -13004,15 +15651,15 @@ exports[`Storyshots Design System/Components/HeaderLayout combined w/ scroll 1`]
   outline: none;
 }
 
-.c5 svg path {
+.c6 svg path {
   fill: #4945ff;
 }
 
-.c5 svg {
+.c6 svg {
   font-size: 0.625rem;
 }
 
-.c5:after {
+.c6:after {
   -webkit-transition-property: all;
   transition-property: all;
   -webkit-transition-duration: 0.2s;
@@ -13027,11 +15674,11 @@ exports[`Storyshots Design System/Components/HeaderLayout combined w/ scroll 1`]
   border: 2px solid transparent;
 }
 
-.c5:focus-visible {
+.c6:focus-visible {
   outline: none;
 }
 
-.c5:focus-visible:after {
+.c6:focus-visible:after {
   border-radius: 8px;
   content: '';
   position: absolute;
@@ -13042,76 +15689,18 @@ exports[`Storyshots Design System/Components/HeaderLayout combined w/ scroll 1`]
   border: 2px solid #4945ff;
 }
 
-.c7 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c14 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  cursor: pointer;
-  padding: 8px;
-  border-radius: 4px;
-  background: #ffffff;
-  border: 1px solid #dcdce4;
-  position: relative;
-  outline: none;
-}
-
-.c14 svg {
-  height: 12px;
-  width: 12px;
-}
-
-.c14 svg > g,
-.c14 svg path {
-  fill: #ffffff;
-}
-
-.c14[aria-disabled='true'] {
-  pointer-events: none;
-}
-
-.c14:after {
-  -webkit-transition-property: all;
-  transition-property: all;
-  -webkit-transition-duration: 0.2s;
-  transition-duration: 0.2s;
-  border-radius: 8px;
-  content: '';
-  position: absolute;
-  top: -4px;
-  bottom: -4px;
-  left: -4px;
-  right: -4px;
-  border: 2px solid transparent;
-}
-
-.c14:focus-visible {
-  outline: none;
-}
-
-.c14:focus-visible:after {
-  border-radius: 8px;
-  content: '';
-  position: absolute;
-  top: -5px;
-  bottom: -5px;
-  left: -5px;
-  right: -5px;
-  border: 2px solid #4945ff;
-}
-
-.c16 {
+.c17 {
   height: 100%;
 }
 
-.c15 {
+.c16 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -13123,7 +15712,7 @@ exports[`Storyshots Design System/Components/HeaderLayout combined w/ scroll 1`]
   background: #ffffff;
 }
 
-.c15 .c1 {
+.c16 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -13134,56 +15723,56 @@ exports[`Storyshots Design System/Components/HeaderLayout combined w/ scroll 1`]
   align-items: center;
 }
 
-.c15 .c8 {
+.c16 .c9 {
   color: #ffffff;
 }
 
-.c15[aria-disabled='true'] {
+.c16[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c15[aria-disabled='true'] .c8 {
+.c16[aria-disabled='true'] .c9 {
   color: #666687;
 }
 
-.c15[aria-disabled='true'] svg > g,
-.c15[aria-disabled='true'] svg path {
+.c16[aria-disabled='true'] svg > g,
+.c16[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c15[aria-disabled='true']:active {
+.c16[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c15[aria-disabled='true']:active .c8 {
+.c16[aria-disabled='true']:active .c9 {
   color: #666687;
 }
 
-.c15[aria-disabled='true']:active svg > g,
-.c15[aria-disabled='true']:active svg path {
+.c16[aria-disabled='true']:active svg > g,
+.c16[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c15:hover {
+.c16:hover {
   background-color: #f6f6f9;
 }
 
-.c15:active {
+.c16:active {
   background-color: #eaeaef;
 }
 
-.c15 .c8 {
+.c16 .c9 {
   color: #32324d;
 }
 
-.c15 svg > g,
-.c15 svg path {
+.c16 svg > g,
+.c16 svg path {
   fill: #32324d;
 }
 
-.c18 {
+.c19 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -13195,7 +15784,7 @@ exports[`Storyshots Design System/Components/HeaderLayout combined w/ scroll 1`]
   background: #4945ff;
 }
 
-.c18 .c1 {
+.c19 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -13206,44 +15795,44 @@ exports[`Storyshots Design System/Components/HeaderLayout combined w/ scroll 1`]
   align-items: center;
 }
 
-.c18 .c8 {
+.c19 .c9 {
   color: #ffffff;
 }
 
-.c18[aria-disabled='true'] {
+.c19[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c18[aria-disabled='true'] .c8 {
+.c19[aria-disabled='true'] .c9 {
   color: #666687;
 }
 
-.c18[aria-disabled='true'] svg > g,
-.c18[aria-disabled='true'] svg path {
+.c19[aria-disabled='true'] svg > g,
+.c19[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c18[aria-disabled='true']:active {
+.c19[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c18[aria-disabled='true']:active .c8 {
+.c19[aria-disabled='true']:active .c9 {
   color: #666687;
 }
 
-.c18[aria-disabled='true']:active svg > g,
-.c18[aria-disabled='true']:active svg path {
+.c19[aria-disabled='true']:active svg > g,
+.c19[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c18:hover {
+.c19:hover {
   border: 1px solid #7b79ff;
   background: #7b79ff;
 }
 
-.c18:active {
+.c19:active {
   border: 1px solid #4945ff;
   background: #4945ff;
 }
@@ -13271,13 +15860,12 @@ exports[`Storyshots Design System/Components/HeaderLayout combined w/ scroll 1`]
           class="c1 c4"
         >
           <a
-            aria-current="page"
-            class="c5 active"
-            href="/"
+            class="c5 c6"
+            to="/"
           >
             <span
               aria-hidden="true"
-              class="c1 c6 c7"
+              class="c1 c7 c8"
             >
               <svg
                 fill="none"
@@ -13293,34 +15881,34 @@ exports[`Storyshots Design System/Components/HeaderLayout combined w/ scroll 1`]
               </svg>
             </span>
             <span
-              class="c8 c9"
+              class="c9 c10"
             >
               Go back
             </span>
           </a>
         </div>
         <div
-          class="c1 c10"
+          class="c1 c11"
         >
           <div
-            class="c1 c11"
+            class="c1 c12"
           >
             <h2
-              class="c8 c12"
+              class="c9 c13"
             >
               Restaurants
             </h2>
             <div
-              class="c1 c13"
+              class="c1 c14"
             >
               <button
                 aria-disabled="false"
-                class="c14 c15"
+                class="c15 c16"
                 type="button"
               >
                 <div
                   aria-hidden="true"
-                  class="c1 c6 c16"
+                  class="c1 c7 c17"
                 >
                   <svg
                     fill="none"
@@ -13338,7 +15926,7 @@ exports[`Storyshots Design System/Components/HeaderLayout combined w/ scroll 1`]
                   </svg>
                 </div>
                 <span
-                  class="c8 c17"
+                  class="c9 c18"
                 >
                   Edit
                 </span>
@@ -13347,12 +15935,12 @@ exports[`Storyshots Design System/Components/HeaderLayout combined w/ scroll 1`]
           </div>
           <button
             aria-disabled="false"
-            class="c14 c18"
+            class="c15 c19"
             type="button"
           >
             <div
               aria-hidden="true"
-              class="c1 c6 c16"
+              class="c1 c7 c17"
             >
               <svg
                 fill="none"
@@ -13368,14 +15956,14 @@ exports[`Storyshots Design System/Components/HeaderLayout combined w/ scroll 1`]
               </svg>
             </div>
             <span
-              class="c8 c17"
+              class="c9 c18"
             >
               Add an entry
             </span>
           </button>
         </div>
         <p
-          class="c8 c19"
+          class="c9 c20"
         >
           36 entries found
         </p>
@@ -13398,6 +15986,32 @@ exports[`Storyshots Design System/Components/HeaderLayout sticky 1`] = `
   width: 1px;
 }
 
+.c13 {
+  color: #4945ff;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c14 {
+  color: #32324d;
+  font-weight: 600;
+  font-size: 1.125rem;
+  line-height: 1.22;
+}
+
+.c15 {
+  color: #666687;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c20 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
 .c2 {
   background: #f6f6f9;
 }
@@ -13414,42 +16028,16 @@ exports[`Storyshots Design System/Components/HeaderLayout sticky 1`] = `
   padding-right: 12px;
 }
 
-.c9 {
+.c10 {
   padding-right: 8px;
 }
 
-.c15 {
+.c16 {
   padding-left: 16px;
 }
 
-.c20 {
+.c21 {
   padding-left: 8px;
-}
-
-.c12 {
-  color: #4945ff;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c13 {
-  color: #32324d;
-  font-weight: 600;
-  font-size: 1.125rem;
-  line-height: 1.22;
-}
-
-.c14 {
-  color: #666687;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c19 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
 }
 
 .c5 {
@@ -13484,7 +16072,69 @@ exports[`Storyshots Design System/Components/HeaderLayout sticky 1`] = `
   align-items: center;
 }
 
+.c17 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 4px;
+  background: #ffffff;
+  border: 1px solid #dcdce4;
+  position: relative;
+  outline: none;
+}
+
+.c17 svg {
+  height: 12px;
+  width: 12px;
+}
+
+.c17 svg > g,
+.c17 svg path {
+  fill: #ffffff;
+}
+
+.c17[aria-disabled='true'] {
+  pointer-events: none;
+}
+
+.c17:after {
+  -webkit-transition-property: all;
+  transition-property: all;
+  -webkit-transition-duration: 0.2s;
+  transition-duration: 0.2s;
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  left: -4px;
+  right: -4px;
+  border: 2px solid transparent;
+}
+
+.c17:focus-visible {
+  outline: none;
+}
+
+.c17:focus-visible:after {
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -5px;
+  bottom: -5px;
+  left: -5px;
+  right: -5px;
+  border: 2px solid #4945ff;
+}
+
 .c8 {
+  cursor: pointer;
+}
+
+.c9 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -13499,15 +16149,15 @@ exports[`Storyshots Design System/Components/HeaderLayout sticky 1`] = `
   outline: none;
 }
 
-.c8 svg path {
+.c9 svg path {
   fill: #4945ff;
 }
 
-.c8 svg {
+.c9 svg {
   font-size: 0.625rem;
 }
 
-.c8:after {
+.c9:after {
   -webkit-transition-property: all;
   transition-property: all;
   -webkit-transition-duration: 0.2s;
@@ -13522,11 +16172,11 @@ exports[`Storyshots Design System/Components/HeaderLayout sticky 1`] = `
   border: 2px solid transparent;
 }
 
-.c8:focus-visible {
+.c9:focus-visible {
   outline: none;
 }
 
-.c8:focus-visible:after {
+.c9:focus-visible:after {
   border-radius: 8px;
   content: '';
   position: absolute;
@@ -13537,76 +16187,18 @@ exports[`Storyshots Design System/Components/HeaderLayout sticky 1`] = `
   border: 2px solid #4945ff;
 }
 
-.c10 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c16 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  cursor: pointer;
-  padding: 8px;
-  border-radius: 4px;
-  background: #ffffff;
-  border: 1px solid #dcdce4;
-  position: relative;
-  outline: none;
-}
-
-.c16 svg {
-  height: 12px;
-  width: 12px;
-}
-
-.c16 svg > g,
-.c16 svg path {
-  fill: #ffffff;
-}
-
-.c16[aria-disabled='true'] {
-  pointer-events: none;
-}
-
-.c16:after {
-  -webkit-transition-property: all;
-  transition-property: all;
-  -webkit-transition-duration: 0.2s;
-  transition-duration: 0.2s;
-  border-radius: 8px;
-  content: '';
-  position: absolute;
-  top: -4px;
-  bottom: -4px;
-  left: -4px;
-  right: -4px;
-  border: 2px solid transparent;
-}
-
-.c16:focus-visible {
-  outline: none;
-}
-
-.c16:focus-visible:after {
-  border-radius: 8px;
-  content: '';
-  position: absolute;
-  top: -5px;
-  bottom: -5px;
-  left: -5px;
-  right: -5px;
-  border: 2px solid #4945ff;
-}
-
-.c18 {
+.c19 {
   height: 100%;
 }
 
-.c17 {
+.c18 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -13618,7 +16210,7 @@ exports[`Storyshots Design System/Components/HeaderLayout sticky 1`] = `
   background: #ffffff;
 }
 
-.c17 .c1 {
+.c18 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -13629,56 +16221,56 @@ exports[`Storyshots Design System/Components/HeaderLayout sticky 1`] = `
   align-items: center;
 }
 
-.c17 .c11 {
+.c18 .c12 {
   color: #ffffff;
 }
 
-.c17[aria-disabled='true'] {
+.c18[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c17[aria-disabled='true'] .c11 {
+.c18[aria-disabled='true'] .c12 {
   color: #666687;
 }
 
-.c17[aria-disabled='true'] svg > g,
-.c17[aria-disabled='true'] svg path {
+.c18[aria-disabled='true'] svg > g,
+.c18[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c17[aria-disabled='true']:active {
+.c18[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c17[aria-disabled='true']:active .c11 {
+.c18[aria-disabled='true']:active .c12 {
   color: #666687;
 }
 
-.c17[aria-disabled='true']:active svg > g,
-.c17[aria-disabled='true']:active svg path {
+.c18[aria-disabled='true']:active svg > g,
+.c18[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c17:hover {
+.c18:hover {
   background-color: #f6f6f9;
 }
 
-.c17:active {
+.c18:active {
   background-color: #eaeaef;
 }
 
-.c17 .c11 {
+.c18 .c12 {
   color: #32324d;
 }
 
-.c17 svg > g,
-.c17 svg path {
+.c18 svg > g,
+.c18 svg path {
   fill: #32324d;
 }
 
-.c21 {
+.c22 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -13690,7 +16282,7 @@ exports[`Storyshots Design System/Components/HeaderLayout sticky 1`] = `
   background: #4945ff;
 }
 
-.c21 .c1 {
+.c22 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -13701,44 +16293,44 @@ exports[`Storyshots Design System/Components/HeaderLayout sticky 1`] = `
   align-items: center;
 }
 
-.c21 .c11 {
+.c22 .c12 {
   color: #ffffff;
 }
 
-.c21[aria-disabled='true'] {
+.c22[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c21[aria-disabled='true'] .c11 {
+.c22[aria-disabled='true'] .c12 {
   color: #666687;
 }
 
-.c21[aria-disabled='true'] svg > g,
-.c21[aria-disabled='true'] svg path {
+.c22[aria-disabled='true'] svg > g,
+.c22[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c21[aria-disabled='true']:active {
+.c22[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c21[aria-disabled='true']:active .c11 {
+.c22[aria-disabled='true']:active .c12 {
   color: #666687;
 }
 
-.c21[aria-disabled='true']:active svg > g,
-.c21[aria-disabled='true']:active svg path {
+.c22[aria-disabled='true']:active svg > g,
+.c22[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c21:hover {
+.c22:hover {
   border: 1px solid #7b79ff;
   background: #7b79ff;
 }
 
-.c21:active {
+.c22:active {
   border: 1px solid #4945ff;
   background: #4945ff;
 }
@@ -13777,13 +16369,12 @@ exports[`Storyshots Design System/Components/HeaderLayout sticky 1`] = `
             class="c1 c7"
           >
             <a
-              aria-current="page"
-              class="c8 active"
-              href="/"
+              class="c8 c9"
+              to="/"
             >
               <span
                 aria-hidden="true"
-                class="c1 c9 c10"
+                class="c1 c10 c11"
               >
                 <svg
                   fill="none"
@@ -13799,7 +16390,7 @@ exports[`Storyshots Design System/Components/HeaderLayout sticky 1`] = `
                 </svg>
               </span>
               <span
-                class="c11 c12"
+                class="c12 c13"
               >
                 <div
                   class="c0"
@@ -13813,27 +16404,27 @@ exports[`Storyshots Design System/Components/HeaderLayout sticky 1`] = `
             class="c1 "
           >
             <h2
-              class="c11 c13"
+              class="c12 c14"
             >
               Restaurants
             </h2>
             <span
-              class="c11 c14"
+              class="c12 c15"
             >
               36 entries found
             </span>
           </div>
           <div
-            class="c1 c15"
+            class="c1 c16"
           >
             <button
               aria-disabled="false"
-              class="c16 c17"
+              class="c17 c18"
               type="button"
             >
               <div
                 aria-hidden="true"
-                class="c1 c9 c18"
+                class="c1 c10 c19"
               >
                 <svg
                   fill="none"
@@ -13851,7 +16442,7 @@ exports[`Storyshots Design System/Components/HeaderLayout sticky 1`] = `
                 </svg>
               </div>
               <span
-                class="c11 c19"
+                class="c12 c20"
               >
                 Edit
               </span>
@@ -13862,16 +16453,16 @@ exports[`Storyshots Design System/Components/HeaderLayout sticky 1`] = `
           class="c1 c6"
         >
           <div
-            class="c1 c20"
+            class="c1 c21"
           >
             <button
               aria-disabled="false"
-              class="c16 c21"
+              class="c17 c22"
               type="button"
             >
               <div
                 aria-hidden="true"
-                class="c1 c9 c18"
+                class="c1 c10 c19"
               >
                 <svg
                   fill="none"
@@ -13887,7 +16478,7 @@ exports[`Storyshots Design System/Components/HeaderLayout sticky 1`] = `
                 </svg>
               </div>
               <span
-                class="c11 c19"
+                class="c12 c20"
               >
                 Add an entry
               </span>
@@ -14046,7 +16637,7 @@ exports[`Storyshots Design System/Components/IconButton base 1`] = `
       <span>
         <button
           aria-disabled="false"
-          aria-labelledby="tooltip-47"
+          aria-labelledby="tooltip-59"
           class="c3 c4"
           tabindex="0"
           type="button"
@@ -14070,7 +16661,7 @@ exports[`Storyshots Design System/Components/IconButton base 1`] = `
       <span>
         <button
           aria-disabled="false"
-          aria-labelledby="tooltip-49"
+          aria-labelledby="tooltip-61"
           class="c3 c4"
           tabindex="0"
           type="button"
@@ -14092,7 +16683,7 @@ exports[`Storyshots Design System/Components/IconButton base 1`] = `
       <span>
         <button
           aria-disabled="false"
-          aria-labelledby="tooltip-51"
+          aria-labelledby="tooltip-63"
           class="c3 c4"
           tabindex="0"
           type="button"
@@ -14114,7 +16705,7 @@ exports[`Storyshots Design System/Components/IconButton base 1`] = `
       <span>
         <button
           aria-disabled="false"
-          aria-labelledby="tooltip-53"
+          aria-labelledby="tooltip-65"
           class="c3 c4"
           tabindex="0"
           type="button"
@@ -14284,7 +16875,7 @@ exports[`Storyshots Design System/Components/IconButton disabled 1`] = `
       <span>
         <button
           aria-disabled="true"
-          aria-labelledby="tooltip-55"
+          aria-labelledby="tooltip-67"
           class="c3 c4"
           tabindex="0"
           type="button"
@@ -14308,7 +16899,7 @@ exports[`Storyshots Design System/Components/IconButton disabled 1`] = `
       <span>
         <button
           aria-disabled="true"
-          aria-labelledby="tooltip-57"
+          aria-labelledby="tooltip-69"
           class="c3 c4"
           tabindex="0"
           type="button"
@@ -14330,7 +16921,7 @@ exports[`Storyshots Design System/Components/IconButton disabled 1`] = `
       <span>
         <button
           aria-disabled="true"
-          aria-labelledby="tooltip-59"
+          aria-labelledby="tooltip-71"
           class="c3 c4"
           tabindex="0"
           type="button"
@@ -14352,7 +16943,7 @@ exports[`Storyshots Design System/Components/IconButton disabled 1`] = `
       <span>
         <button
           aria-disabled="true"
-          aria-labelledby="tooltip-61"
+          aria-labelledby="tooltip-73"
           class="c3 c4"
           tabindex="0"
           type="button"
@@ -14560,7 +17151,7 @@ exports[`Storyshots Design System/Components/IconButton group 1`] = `
       <span>
         <button
           aria-disabled="false"
-          aria-labelledby="tooltip-63"
+          aria-labelledby="tooltip-75"
           class="c4 c5 c6"
           tabindex="0"
           type="button"
@@ -14584,7 +17175,7 @@ exports[`Storyshots Design System/Components/IconButton group 1`] = `
       <span>
         <button
           aria-disabled="false"
-          aria-labelledby="tooltip-65"
+          aria-labelledby="tooltip-77"
           class="c4 c5 c6"
           tabindex="0"
           type="button"
@@ -14606,7 +17197,7 @@ exports[`Storyshots Design System/Components/IconButton group 1`] = `
       <span>
         <button
           aria-disabled="false"
-          aria-labelledby="tooltip-67"
+          aria-labelledby="tooltip-79"
           class="c4 c5 c6"
           tabindex="0"
           type="button"
@@ -14628,7 +17219,7 @@ exports[`Storyshots Design System/Components/IconButton group 1`] = `
       <span>
         <button
           aria-disabled="false"
-          aria-labelledby="tooltip-69"
+          aria-labelledby="tooltip-81"
           class="c4 c5 c6"
           tabindex="0"
           type="button"
@@ -14816,6 +17407,76 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   width: 1px;
 }
 
+.c8 {
+  color: #32324d;
+  font-weight: 600;
+  font-size: 1.125rem;
+  line-height: 1.22;
+}
+
+.c23 {
+  color: #666687;
+  font-weight: 600;
+  font-size: 0.6875rem;
+  line-height: 1.45;
+  text-transform: uppercase;
+}
+
+.c32 {
+  color: #32324d;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
+.c37 {
+  font-weight: 500;
+  color: #32324d;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
+.c41 {
+  color: #32324d;
+  font-weight: 600;
+  font-size: 2rem;
+  line-height: 1.25;
+}
+
+.c46 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c48 {
+  color: #666687;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.c60 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
+.c72 {
+  color: #32324d;
+  font-weight: 600;
+  font-size: 0.6875rem;
+  line-height: 1.45;
+  text-transform: uppercase;
+}
+
+.c82 {
+  font-weight: 600;
+  color: #4945ff;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
 .c2 {
   background: #f6f6f9;
 }
@@ -14949,76 +17610,6 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   padding-left: 12px;
 }
 
-.c8 {
-  color: #32324d;
-  font-weight: 600;
-  font-size: 1.125rem;
-  line-height: 1.22;
-}
-
-.c23 {
-  color: #666687;
-  font-weight: 600;
-  font-size: 0.6875rem;
-  line-height: 1.45;
-  text-transform: uppercase;
-}
-
-.c32 {
-  color: #32324d;
-  font-size: 0.875rem;
-  line-height: 1.43;
-}
-
-.c37 {
-  font-weight: 500;
-  color: #32324d;
-  font-size: 0.875rem;
-  line-height: 1.43;
-}
-
-.c41 {
-  color: #32324d;
-  font-weight: 600;
-  font-size: 2rem;
-  line-height: 1.25;
-}
-
-.c46 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c48 {
-  color: #666687;
-  font-size: 1rem;
-  line-height: 1.5;
-}
-
-.c60 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.875rem;
-  line-height: 1.43;
-}
-
-.c72 {
-  color: #32324d;
-  font-weight: 600;
-  font-size: 0.6875rem;
-  line-height: 1.45;
-  text-transform: uppercase;
-}
-
-.c82 {
-  font-weight: 600;
-  color: #4945ff;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
 .c6 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -15123,18 +17714,6 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   margin-top: 8px;
 }
 
-.c75 {
-  border-radius: 50%;
-  display: block;
-  position: relative;
-}
-
-.c74 {
-  position: relative;
-  width: 26px;
-  height: 26px;
-}
-
 .c9 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -15191,6 +17770,58 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   left: -5px;
   right: -5px;
   border: 2px solid #4945ff;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  height: 2rem;
+  width: 2rem;
+}
+
+.c10 svg > g,
+.c10 svg path {
+  fill: #8e8ea9;
+}
+
+.c10:hover svg > g,
+.c10:hover svg path {
+  fill: #666687;
+}
+
+.c10:active svg > g,
+.c10:active svg path {
+  fill: #a5a5ba;
+}
+
+.c10[aria-disabled='true'] {
+  background-color: #eaeaef;
+}
+
+.c10[aria-disabled='true'] svg path {
+  fill: #666687;
+}
+
+.c75 {
+  border-radius: 50%;
+  display: block;
+  position: relative;
+}
+
+.c74 {
+  position: relative;
+  width: 26px;
+  height: 26px;
 }
 
 .c70 {
@@ -15472,46 +18103,6 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
 .c59 svg > g,
 .c59 svg path {
   fill: #32324d;
-}
-
-.c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  height: 2rem;
-  width: 2rem;
-}
-
-.c10 svg > g,
-.c10 svg path {
-  fill: #8e8ea9;
-}
-
-.c10:hover svg > g,
-.c10:hover svg path {
-  fill: #666687;
-}
-
-.c10:active svg > g,
-.c10:active svg path {
-  fill: #a5a5ba;
-}
-
-.c10[aria-disabled='true'] {
-  background-color: #eaeaef;
-}
-
-.c10[aria-disabled='true'] svg path {
-  fill: #666687;
 }
 
 .c13 {
@@ -15859,7 +18450,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
             <span>
               <button
                 aria-disabled="false"
-                aria-labelledby="tooltip-72"
+                aria-labelledby="tooltip-84"
                 class="c9 c10"
                 tabindex="0"
                 type="button"
@@ -15897,445 +18488,457 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
           >
             <li>
               <div
-                class="c1 c17 c18"
+                class="c1 "
               >
                 <div
-                  class="c1 c19"
+                  class="c1 c17 c18"
                 >
-                  <button
-                    aria-controls="subnav-list-74"
-                    aria-expanded="true"
-                    class="c1 c20 c21"
+                  <div
+                    class="c1 c19"
                   >
+                    <button
+                      aria-controls="subnav-list-86"
+                      aria-expanded="true"
+                      class="c1 c20 c21"
+                    >
+                      <div
+                        class="c1 c22"
+                      >
+                        <span
+                          class="c7 c23"
+                        >
+                          Collection Type
+                        </span>
+                      </div>
+                      <div
+                        class="c24"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          fill="none"
+                          height="1em"
+                          viewBox="0 0 14 8"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
+                            fill="#32324D"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
                     <div
-                      class="c1 c22"
+                      class="c1 c25 c26 c27"
                     >
                       <span
                         class="c7 c23"
                       >
-                        Collection Type
+                        4
                       </span>
                     </div>
-                    <div
-                      class="c24"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        fill="none"
-                        height="1em"
-                        viewBox="0 0 14 8"
-                        width="1em"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          clip-rule="evenodd"
-                          d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
-                          fill="#32324D"
-                          fill-rule="evenodd"
-                        />
-                      </svg>
-                    </div>
-                  </button>
-                  <div
-                    class="c1 c25 c26 c27"
-                  >
-                    <span
-                      class="c7 c23"
-                    >
-                      4
-                    </span>
                   </div>
                 </div>
-              </div>
-              <ul
-                id="subnav-list-74"
-              >
-                <li>
-                  <a
-                    class="c1 c28 c29"
-                    href="/address"
-                  >
-                    <div
-                      class="c1 c20"
-                    >
-                      <svg
-                        class="c30"
-                        fill="none"
-                        height="1em"
-                        viewBox="0 0 4 4"
-                        width="1em"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="#A5A5BA"
-                          height="4"
-                          rx="2"
-                          width="4"
-                        />
-                      </svg>
-                      <div
-                        class="c1 c31"
-                      >
-                        <span
-                          class="c7 c32"
-                        >
-                          Addresses
-                        </span>
-                      </div>
-                    </div>
-                  </a>
-                </li>
-                <li>
-                  <a
-                    class="c1 c28 c29"
-                    href="/category"
-                  >
-                    <div
-                      class="c1 c20"
-                    >
-                      <svg
-                        class="c30"
-                        fill="none"
-                        height="1em"
-                        viewBox="0 0 4 4"
-                        width="1em"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="#A5A5BA"
-                          height="4"
-                          rx="2"
-                          width="4"
-                        />
-                      </svg>
-                      <div
-                        class="c1 c31"
-                      >
-                        <span
-                          class="c7 c32"
-                        >
-                          Categories
-                        </span>
-                      </div>
-                    </div>
-                  </a>
-                </li>
-                <li>
-                  <a
-                    class="c1 c28 c29"
-                    href="/city"
-                  >
-                    <div
-                      class="c1 c20"
-                    >
-                      <svg
-                        class="c30"
-                        fill="none"
-                        height="1em"
-                        viewBox="0 0 4 4"
-                        width="1em"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="#A5A5BA"
-                          height="4"
-                          rx="2"
-                          width="4"
-                        />
-                      </svg>
-                      <div
-                        class="c1 c31"
-                      >
-                        <span
-                          class="c7 c32"
-                        >
-                          Cities
-                        </span>
-                      </div>
-                    </div>
-                  </a>
-                </li>
-                <li>
-                  <a
-                    class="c1 c28 c29"
-                    href="/country"
-                  >
-                    <div
-                      class="c1 c20"
-                    >
-                      <svg
-                        class="c30"
-                        fill="none"
-                        height="1em"
-                        viewBox="0 0 4 4"
-                        width="1em"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="#A5A5BA"
-                          height="4"
-                          rx="2"
-                          width="4"
-                        />
-                      </svg>
-                      <div
-                        class="c1 c31"
-                      >
-                        <span
-                          class="c7 c32"
-                        >
-                          Countries
-                        </span>
-                      </div>
-                    </div>
-                  </a>
-                </li>
-              </ul>
-            </li>
-            <li>
-              <div
-                class="c1 c17 c18"
-              >
-                <div
-                  class="c1 c19"
+                <ul
+                  id="subnav-list-86"
                 >
-                  <button
-                    aria-controls="subnav-list-75"
-                    aria-expanded="true"
-                    class="c1 c20 c21"
-                  >
+                  <li>
                     <div
-                      class="c1 c22"
+                      class="c1 c28 c29"
+                      to="/address"
                     >
-                      <span
-                        class="c7 c23"
+                      <div
+                        class="c1 c20"
                       >
-                        Single Type
-                      </span>
-                    </div>
-                    <div
-                      class="c24"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        fill="none"
-                        height="1em"
-                        viewBox="0 0 14 8"
-                        width="1em"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          clip-rule="evenodd"
-                          d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
-                          fill="#32324D"
-                          fill-rule="evenodd"
-                        />
-                      </svg>
-                    </div>
-                  </button>
-                  <div
-                    class="c1 c25 c26 c27"
-                  >
-                    <span
-                      class="c7 c23"
-                    >
-                      4
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <ul
-                id="subnav-list-75"
-              >
-                <li>
-                  <div
-                    class="c1 c33 c34"
-                  >
-                    <div
-                      class="c1 c19"
-                    >
-                      <button
-                        aria-controls="subnav-list-76"
-                        aria-expanded="true"
-                        class="c35"
-                      >
-                        <div
-                          class="c36"
+                        <svg
+                          class="c30"
+                          fill="none"
+                          height="1em"
+                          viewBox="0 0 4 4"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <svg
-                            aria-hidden="true"
-                            fill="none"
-                            height="1em"
-                            viewBox="0 0 14 8"
-                            width="1em"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              clip-rule="evenodd"
-                              d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
-                              fill="#32324D"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
+                          <rect
+                            fill="#A5A5BA"
+                            height="4"
+                            rx="2"
+                            width="4"
+                          />
+                        </svg>
                         <div
                           class="c1 c31"
                         >
                           <span
-                            class="c7 c37"
+                            class="c7 c32"
                           >
-                            Default
+                            Addresses
                           </span>
                         </div>
-                      </button>
+                      </div>
+                    </div>
+                  </li>
+                  <li>
+                    <div
+                      class="c1 c28 c29"
+                      to="/category"
+                    >
+                      <div
+                        class="c1 c20"
+                      >
+                        <svg
+                          class="c30"
+                          fill="none"
+                          height="1em"
+                          viewBox="0 0 4 4"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            fill="#A5A5BA"
+                            height="4"
+                            rx="2"
+                            width="4"
+                          />
+                        </svg>
+                        <div
+                          class="c1 c31"
+                        >
+                          <span
+                            class="c7 c32"
+                          >
+                            Categories
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </li>
+                  <li>
+                    <div
+                      class="c1 c28 c29"
+                      to="/city"
+                    >
+                      <div
+                        class="c1 c20"
+                      >
+                        <svg
+                          class="c30"
+                          fill="none"
+                          height="1em"
+                          viewBox="0 0 4 4"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            fill="#A5A5BA"
+                            height="4"
+                            rx="2"
+                            width="4"
+                          />
+                        </svg>
+                        <div
+                          class="c1 c31"
+                        >
+                          <span
+                            class="c7 c32"
+                          >
+                            Cities
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </li>
+                  <li>
+                    <div
+                      class="c1 c28 c29"
+                      to="/country"
+                    >
+                      <div
+                        class="c1 c20"
+                      >
+                        <svg
+                          class="c30"
+                          fill="none"
+                          height="1em"
+                          viewBox="0 0 4 4"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            fill="#A5A5BA"
+                            height="4"
+                            rx="2"
+                            width="4"
+                          />
+                        </svg>
+                        <div
+                          class="c1 c31"
+                        >
+                          <span
+                            class="c7 c32"
+                          >
+                            Countries
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li>
+              <div
+                class="c1 "
+              >
+                <div
+                  class="c1 c17 c18"
+                >
+                  <div
+                    class="c1 c19"
+                  >
+                    <button
+                      aria-controls="subnav-list-87"
+                      aria-expanded="true"
+                      class="c1 c20 c21"
+                    >
+                      <div
+                        class="c1 c22"
+                      >
+                        <span
+                          class="c7 c23"
+                        >
+                          Single Type
+                        </span>
+                      </div>
+                      <div
+                        class="c24"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          fill="none"
+                          height="1em"
+                          viewBox="0 0 14 8"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
+                            fill="#32324D"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                    <div
+                      class="c1 c25 c26 c27"
+                    >
+                      <span
+                        class="c7 c23"
+                      >
+                        4
+                      </span>
                     </div>
                   </div>
-                  <ul
-                    id="subnav-list-76"
-                  >
-                    <li>
-                      <a
-                        class="c1 c28 c29"
-                        href="/address"
+                </div>
+                <ul
+                  id="subnav-list-87"
+                >
+                  <li>
+                    <div
+                      class="c1 "
+                    >
+                      <div
+                        class="c1 c33 c34"
                       >
                         <div
-                          class="c1 c20"
+                          class="c1 c19"
                         >
-                          <svg
-                            class="c30"
-                            fill="none"
-                            height="1em"
-                            viewBox="0 0 4 4"
-                            width="1em"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <button
+                            aria-controls="subnav-list-88"
+                            aria-expanded="true"
+                            class="c35"
                           >
-                            <rect
-                              fill="#A5A5BA"
-                              height="4"
-                              rx="2"
-                              width="4"
-                            />
-                          </svg>
-                          <div
-                            class="c1 c31"
-                          >
-                            <span
-                              class="c7 c32"
+                            <div
+                              class="c36"
                             >
-                              Addresses
-                            </span>
-                          </div>
+                              <svg
+                                aria-hidden="true"
+                                fill="none"
+                                height="1em"
+                                viewBox="0 0 14 8"
+                                width="1em"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
+                                  fill="#32324D"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="c1 c31"
+                            >
+                              <span
+                                class="c7 c37"
+                              >
+                                Default
+                              </span>
+                            </div>
+                          </button>
                         </div>
-                      </a>
-                    </li>
-                    <li>
-                      <a
-                        class="c1 c28 c29"
-                        href="/category"
+                      </div>
+                      <ul
+                        id="subnav-list-88"
                       >
-                        <div
-                          class="c1 c20"
-                        >
-                          <svg
-                            class="c30"
-                            fill="none"
-                            height="1em"
-                            viewBox="0 0 4 4"
-                            width="1em"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <rect
-                              fill="#A5A5BA"
-                              height="4"
-                              rx="2"
-                              width="4"
-                            />
-                          </svg>
+                        <li>
                           <div
-                            class="c1 c31"
+                            class="c1 c28 c29"
+                            to="/address"
                           >
-                            <span
-                              class="c7 c32"
+                            <div
+                              class="c1 c20"
                             >
-                              Categories
-                            </span>
+                              <svg
+                                class="c30"
+                                fill="none"
+                                height="1em"
+                                viewBox="0 0 4 4"
+                                width="1em"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <rect
+                                  fill="#A5A5BA"
+                                  height="4"
+                                  rx="2"
+                                  width="4"
+                                />
+                              </svg>
+                              <div
+                                class="c1 c31"
+                              >
+                                <span
+                                  class="c7 c32"
+                                >
+                                  Addresses
+                                </span>
+                              </div>
+                            </div>
                           </div>
-                        </div>
-                      </a>
-                    </li>
-                    <li>
-                      <a
-                        class="c1 c28 c29"
-                        href="/city"
-                      >
-                        <div
-                          class="c1 c20"
-                        >
-                          <svg
-                            class="c30"
-                            fill="none"
-                            height="1em"
-                            viewBox="0 0 4 4"
-                            width="1em"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <rect
-                              fill="#A5A5BA"
-                              height="4"
-                              rx="2"
-                              width="4"
-                            />
-                          </svg>
+                        </li>
+                        <li>
                           <div
-                            class="c1 c31"
+                            class="c1 c28 c29"
+                            to="/category"
                           >
-                            <span
-                              class="c7 c32"
+                            <div
+                              class="c1 c20"
                             >
-                              Cities
-                            </span>
+                              <svg
+                                class="c30"
+                                fill="none"
+                                height="1em"
+                                viewBox="0 0 4 4"
+                                width="1em"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <rect
+                                  fill="#A5A5BA"
+                                  height="4"
+                                  rx="2"
+                                  width="4"
+                                />
+                              </svg>
+                              <div
+                                class="c1 c31"
+                              >
+                                <span
+                                  class="c7 c32"
+                                >
+                                  Categories
+                                </span>
+                              </div>
+                            </div>
                           </div>
-                        </div>
-                      </a>
-                    </li>
-                    <li>
-                      <a
-                        class="c1 c28 c29"
-                        href="/country"
-                      >
-                        <div
-                          class="c1 c20"
-                        >
-                          <svg
-                            class="c30"
-                            fill="none"
-                            height="1em"
-                            viewBox="0 0 4 4"
-                            width="1em"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <rect
-                              fill="#A5A5BA"
-                              height="4"
-                              rx="2"
-                              width="4"
-                            />
-                          </svg>
+                        </li>
+                        <li>
                           <div
-                            class="c1 c31"
+                            class="c1 c28 c29"
+                            to="/city"
                           >
-                            <span
-                              class="c7 c32"
+                            <div
+                              class="c1 c20"
                             >
-                              Countries
-                            </span>
+                              <svg
+                                class="c30"
+                                fill="none"
+                                height="1em"
+                                viewBox="0 0 4 4"
+                                width="1em"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <rect
+                                  fill="#A5A5BA"
+                                  height="4"
+                                  rx="2"
+                                  width="4"
+                                />
+                              </svg>
+                              <div
+                                class="c1 c31"
+                              >
+                                <span
+                                  class="c7 c32"
+                                >
+                                  Cities
+                                </span>
+                              </div>
+                            </div>
                           </div>
-                        </div>
-                      </a>
-                    </li>
-                  </ul>
-                </li>
-              </ul>
+                        </li>
+                        <li>
+                          <div
+                            class="c1 c28 c29"
+                            to="/country"
+                          >
+                            <div
+                              class="c1 c20"
+                            >
+                              <svg
+                                class="c30"
+                                fill="none"
+                                height="1em"
+                                viewBox="0 0 4 4"
+                                width="1em"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <rect
+                                  fill="#A5A5BA"
+                                  height="4"
+                                  rx="2"
+                                  width="4"
+                                />
+                              </svg>
+                              <div
+                                class="c1 c31"
+                              >
+                                <span
+                                  class="c7 c32"
+                                >
+                                  Countries
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </li>
+                      </ul>
+                    </div>
+                  </li>
+                </ul>
+              </div>
             </li>
           </ul>
         </div>
@@ -17613,7 +20216,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-77"
+                              aria-labelledby="tooltip-89"
                               class="c9 c10"
                               tabindex="-1"
                               type="button"
@@ -17640,7 +20243,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                             <span>
                               <button
                                 aria-disabled="false"
-                                aria-labelledby="tooltip-79"
+                                aria-labelledby="tooltip-91"
                                 class="c9 c10"
                                 tabindex="-1"
                                 type="button"
@@ -17784,7 +20387,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-81"
+                              aria-labelledby="tooltip-93"
                               class="c9 c10"
                               tabindex="-1"
                               type="button"
@@ -17811,7 +20414,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                             <span>
                               <button
                                 aria-disabled="false"
-                                aria-labelledby="tooltip-83"
+                                aria-labelledby="tooltip-95"
                                 class="c9 c10"
                                 tabindex="-1"
                                 type="button"
@@ -17955,7 +20558,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-85"
+                              aria-labelledby="tooltip-97"
                               class="c9 c10"
                               tabindex="-1"
                               type="button"
@@ -17982,7 +20585,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                             <span>
                               <button
                                 aria-disabled="false"
-                                aria-labelledby="tooltip-87"
+                                aria-labelledby="tooltip-99"
                                 class="c9 c10"
                                 tabindex="-1"
                                 type="button"
@@ -18126,7 +20729,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-89"
+                              aria-labelledby="tooltip-101"
                               class="c9 c10"
                               tabindex="-1"
                               type="button"
@@ -18153,7 +20756,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                             <span>
                               <button
                                 aria-disabled="false"
-                                aria-labelledby="tooltip-91"
+                                aria-labelledby="tooltip-103"
                                 class="c9 c10"
                                 tabindex="-1"
                                 type="button"
@@ -18297,7 +20900,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-93"
+                              aria-labelledby="tooltip-105"
                               class="c9 c10"
                               tabindex="-1"
                               type="button"
@@ -18324,7 +20927,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                             <span>
                               <button
                                 aria-disabled="false"
-                                aria-labelledby="tooltip-95"
+                                aria-labelledby="tooltip-107"
                                 class="c9 c10"
                                 tabindex="-1"
                                 type="button"
@@ -19097,15 +21700,6 @@ exports[`Storyshots Design System/Components/LightTheme spaces 1`] = `
   width: 1px;
 }
 
-.c1 {
-  background: #f6f6f9;
-  padding: 40px;
-}
-
-.c4 {
-  padding-left: 8px;
-}
-
 .c5 {
   color: #32324d;
   font-size: 0.875rem;
@@ -19116,6 +21710,15 @@ exports[`Storyshots Design System/Components/LightTheme spaces 1`] = `
   color: #32324d;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c1 {
+  background: #f6f6f9;
+  padding: 40px;
+}
+
+.c4 {
+  padding-left: 8px;
 }
 
 .c3 {
@@ -19436,23 +22039,13 @@ exports[`Storyshots Design System/Components/Link base 1`] = `
 }
 
 .c4 {
-  padding-right: 8px;
-}
-
-.c8 {
-  padding-left: 8px;
-}
-
-.c3 {
   color: #4945ff;
   font-size: 0.75rem;
   line-height: 1.33;
 }
 
-.c7 {
-  color: #666687;
-  font-size: 0.75rem;
-  line-height: 1.33;
+.c5 {
+  padding-left: 8px;
 }
 
 .c1 {
@@ -19475,6 +22068,10 @@ exports[`Storyshots Design System/Components/Link base 1`] = `
 }
 
 .c2 {
+  cursor: pointer;
+}
+
+.c3 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -19489,15 +22086,15 @@ exports[`Storyshots Design System/Components/Link base 1`] = `
   outline: none;
 }
 
-.c2 svg path {
+.c3 svg path {
   fill: #4945ff;
 }
 
-.c2 svg {
+.c3 svg {
   font-size: 0.625rem;
 }
 
-.c2:after {
+.c3:after {
   -webkit-transition-property: all;
   transition-property: all;
   -webkit-transition-duration: 0.2s;
@@ -19512,11 +22109,11 @@ exports[`Storyshots Design System/Components/Link base 1`] = `
   border: 2px solid transparent;
 }
 
-.c2:focus-visible {
+.c3:focus-visible {
   outline: none;
 }
 
-.c2:focus-visible:after {
+.c3:focus-visible:after {
   border-radius: 8px;
   content: '';
   position: absolute;
@@ -19528,6 +22125,103 @@ exports[`Storyshots Design System/Components/Link base 1`] = `
 }
 
 .c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+<main>
+  <div
+    class="c0"
+  >
+    <h1>
+      Storybook story
+    </h1>
+  </div>
+  <div
+    class="c1"
+  >
+    <a
+      class="c2 c3"
+      href="https://strapi.io/"
+      rel="noreferrer noopener"
+      target="_blank"
+    >
+      <span
+        class="c4"
+      >
+        External link
+      </span>
+      <span
+        aria-hidden="true"
+        class="c5 c6"
+      >
+        <svg
+          fill="none"
+          height="1em"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M16.235 2.824a1.412 1.412 0 010-2.824h6.353C23.368 0 24 .633 24 1.412v6.353a1.412 1.412 0 01-2.823 0V4.82l-8.179 8.178a1.412 1.412 0 01-1.996-1.996l8.178-8.178h-2.945zm4.942 10.588a1.412 1.412 0 012.823 0v9.176c0 .78-.632 1.412-1.412 1.412H1.412C.632 24 0 23.368 0 22.588V1.412C0 .632.632 0 1.412 0h9.176a1.412 1.412 0 010 2.824H2.824v18.353h18.353v-7.765z"
+            fill="#32324D"
+          />
+        </svg>
+      </span>
+    </a>
+  </div>
+</main>
+`;
+
+exports[`Storyshots Design System/Components/Link disabled 1`] = `
+.c0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c4 {
+  color: #666687;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c5 {
+  padding-left: 8px;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c1 > * {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.c1 > * + * {
+  margin-top: 20px;
+}
+
+.c2 {
+  cursor: pointer;
+}
+
+.c3 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -19543,15 +22237,15 @@ exports[`Storyshots Design System/Components/Link base 1`] = `
   outline: none;
 }
 
-.c6 svg path {
+.c3 svg path {
   fill: #666687;
 }
 
-.c6 svg {
+.c3 svg {
   font-size: 0.625rem;
 }
 
-.c6:after {
+.c3:after {
   -webkit-transition-property: all;
   transition-property: all;
   -webkit-transition-duration: 0.2s;
@@ -19566,11 +22260,166 @@ exports[`Storyshots Design System/Components/Link base 1`] = `
   border: 2px solid transparent;
 }
 
-.c6:focus-visible {
+.c3:focus-visible {
   outline: none;
 }
 
-.c6:focus-visible:after {
+.c3:focus-visible:after {
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -5px;
+  bottom: -5px;
+  left: -5px;
+  right: -5px;
+  border: 2px solid #4945ff;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+<main>
+  <div
+    class="c0"
+  >
+    <h1>
+      Storybook story
+    </h1>
+  </div>
+  <div
+    class="c1"
+  >
+    <a
+      class="c2 c3"
+      disabled=""
+      href="#"
+      rel="noreferrer noopener"
+      target="_blank"
+    >
+      <span
+        class="c4"
+      >
+        Disabled link
+      </span>
+      <span
+        aria-hidden="true"
+        class="c5 c6"
+      >
+        <svg
+          fill="none"
+          height="1em"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M16.235 2.824a1.412 1.412 0 010-2.824h6.353C23.368 0 24 .633 24 1.412v6.353a1.412 1.412 0 01-2.823 0V4.82l-8.179 8.178a1.412 1.412 0 01-1.996-1.996l8.178-8.178h-2.945zm4.942 10.588a1.412 1.412 0 012.823 0v9.176c0 .78-.632 1.412-1.412 1.412H1.412C.632 24 0 23.368 0 22.588V1.412C0 .632.632 0 1.412 0h9.176a1.412 1.412 0 010 2.824H2.824v18.353h18.353v-7.765z"
+            fill="#32324D"
+          />
+        </svg>
+      </span>
+    </a>
+  </div>
+</main>
+`;
+
+exports[`Storyshots Design System/Components/Link icons 1`] = `
+.c0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c6 {
+  color: #4945ff;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c4 {
+  padding-right: 8px;
+}
+
+.c7 {
+  padding-left: 8px;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c1 > * {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.c1 > * + * {
+  margin-top: 20px;
+}
+
+.c2 {
+  cursor: pointer;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  position: relative;
+  outline: none;
+}
+
+.c3 svg path {
+  fill: #4945ff;
+}
+
+.c3 svg {
+  font-size: 0.625rem;
+}
+
+.c3:after {
+  -webkit-transition-property: all;
+  transition-property: all;
+  -webkit-transition-duration: 0.2s;
+  transition-duration: 0.2s;
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  left: -4px;
+  right: -4px;
+  border: 2px solid transparent;
+}
+
+.c3:focus-visible {
+  outline: none;
+}
+
+.c3:focus-visible:after {
   border-radius: 8px;
   content: '';
   position: absolute;
@@ -19601,20 +22450,10 @@ exports[`Storyshots Design System/Components/Link base 1`] = `
   >
     <div>
       <a
-        class="c2"
-        href="/https://strapi.io/"
-      >
-        <span
-          class="c3"
-        >
-          External link
-        </span>
-      </a>
-    </div>
-    <div>
-      <a
-        class="c2"
-        href="/somewhere-internal"
+        class="c2 c3"
+        href="https://strapi.io/"
+        rel="noreferrer noopener"
+        target="_blank"
       >
         <span
           aria-hidden="true"
@@ -19628,40 +22467,28 @@ exports[`Storyshots Design System/Components/Link base 1`] = `
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
-              d="M24 13.3a.2.2 0 01-.2.2H5.74l8.239 8.239a.2.2 0 010 .282L12.14 23.86a.2.2 0 01-.282 0L.14 12.14a.2.2 0 010-.282L11.86.14a.2.2 0 01.282 0L13.98 1.98a.2.2 0 010 .282L5.74 10.5H23.8c.11 0 .2.09.2.2v2.6z"
-              fill="#212134"
+              clip-rule="evenodd"
+              d="M23.498 0H7.68v8.035h7.783c.278 0 .503.224.503.502v7.783H24V.502A.502.502 0 0023.498 0z"
+              fill="#8E75FF"
+              fill-rule="evenodd"
+            />
+            <path
+              clip-rule="evenodd"
+              d="M7.68 0v8.035H.252a.25.25 0 01-.178-.429L7.68 0zm8.715 23.926a.251.251 0 01-.43-.177V16.32H24l-7.605 7.606zm-.68-15.891H7.68v7.783c0 .278.225.502.503.502h7.783V8.286a.251.251 0 00-.252-.251z"
+              fill="#8E75FF"
+              fill-rule="evenodd"
+              opacity="0.405"
             />
           </svg>
         </span>
         <span
-          class="c3"
+          class="c6"
         >
-          Internal link
+          Strapi
         </span>
-      </a>
-    </div>
-    <div>
-      <a
-        class="c6"
-        disabled=""
-        href="#"
-      >
-        <span
-          class="c7"
-        >
-          External disabled link
-        </span>
-      </a>
-    </div>
-    <div>
-      <a
-        class="c6"
-        disabled=""
-        href="#"
-      >
         <span
           aria-hidden="true"
-          class="c4 c5"
+          class="c7 c5"
         >
           <svg
             fill="none"
@@ -19671,30 +22498,48 @@ exports[`Storyshots Design System/Components/Link base 1`] = `
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
-              d="M24 13.3a.2.2 0 01-.2.2H5.74l8.239 8.239a.2.2 0 010 .282L12.14 23.86a.2.2 0 01-.282 0L.14 12.14a.2.2 0 010-.282L11.86.14a.2.2 0 01.282 0L13.98 1.98a.2.2 0 010 .282L5.74 10.5H23.8c.11 0 .2.09.2.2v2.6z"
-              fill="#212134"
-            />
-          </svg>
-        </span>
-        <span
-          class="c7"
-        >
-          Internal disabled link
-        </span>
-        <span
-          aria-hidden="true"
-          class="c8 c5"
-        >
-          <svg
-            fill="none"
-            height="1em"
-            viewBox="0 0 10 16"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M0 1.88L6.107 8 0 14.12 1.88 16l8-8-8-8L0 1.88z"
+              d="M16.235 2.824a1.412 1.412 0 010-2.824h6.353C23.368 0 24 .633 24 1.412v6.353a1.412 1.412 0 01-2.823 0V4.82l-8.179 8.178a1.412 1.412 0 01-1.996-1.996l8.178-8.178h-2.945zm4.942 10.588a1.412 1.412 0 012.823 0v9.176c0 .78-.632 1.412-1.412 1.412H1.412C.632 24 0 23.368 0 22.588V1.412C0 .632.632 0 1.412 0h9.176a1.412 1.412 0 010 2.824H2.824v18.353h18.353v-7.765z"
               fill="#32324D"
+            />
+          </svg>
+        </span>
+      </a>
+    </div>
+    <div>
+      <a
+        class="c2 c3"
+        href="https://strapi.io/"
+        rel="noreferrer noopener"
+        target="_blank"
+      >
+        <span
+          class="c6"
+        >
+          Strapi
+        </span>
+        <span
+          aria-hidden="true"
+          class="c7 c5"
+        >
+          <svg
+            fill="none"
+            height="1em"
+            viewBox="0 0 24 24"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M23.498 0H7.68v8.035h7.783c.278 0 .503.224.503.502v7.783H24V.502A.502.502 0 0023.498 0z"
+              fill="#8E75FF"
+              fill-rule="evenodd"
+            />
+            <path
+              clip-rule="evenodd"
+              d="M7.68 0v8.035H.252a.25.25 0 01-.178-.429L7.68 0zm8.715 23.926a.251.251 0 01-.43-.177V16.32H24l-7.605 7.606zm-.68-15.891H7.68v7.783c0 .278.225.502.503.502h7.783V8.286a.251.251 0 00-.252-.251z"
+              fill="#8E75FF"
+              fill-rule="evenodd"
+              opacity="0.405"
             />
           </svg>
         </span>
@@ -19717,192 +22562,6 @@ exports[`Storyshots Design System/Components/LinkButton base 1`] = `
   width: 1px;
 }
 
-.c2 {
-  padding-bottom: 8px;
-}
-
-.c6 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  cursor: pointer;
-  padding: 8px;
-  border-radius: 4px;
-  background: #ffffff;
-  border: 1px solid #dcdce4;
-  position: relative;
-  outline: none;
-}
-
-.c3 svg {
-  height: 12px;
-  width: 12px;
-}
-
-.c3 svg > g,
-.c3 svg path {
-  fill: #ffffff;
-}
-
-.c3[aria-disabled='true'] {
-  pointer-events: none;
-}
-
-.c3:after {
-  -webkit-transition-property: all;
-  transition-property: all;
-  -webkit-transition-duration: 0.2s;
-  transition-duration: 0.2s;
-  border-radius: 8px;
-  content: '';
-  position: absolute;
-  top: -4px;
-  bottom: -4px;
-  left: -4px;
-  right: -4px;
-  border: 2px solid transparent;
-}
-
-.c3:focus-visible {
-  outline: none;
-}
-
-.c3:focus-visible:after {
-  border-radius: 8px;
-  content: '';
-  position: absolute;
-  top: -5px;
-  bottom: -5px;
-  left: -5px;
-  right: -5px;
-  border: 2px solid #4945ff;
-}
-
-.c4 {
-  padding: 8px 16px;
-  background: #4945ff;
-  border: none;
-  border-radius: 4px;
-  border: 1px solid #4945ff;
-  background: #4945ff;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c4 .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c4 .c5 {
-  color: #ffffff;
-}
-
-.c4[aria-disabled='true'] {
-  border: 1px solid #dcdce4;
-  background: #eaeaef;
-}
-
-.c4[aria-disabled='true'] .c5 {
-  color: #666687;
-}
-
-.c4[aria-disabled='true'] svg > g,
-.c4[aria-disabled='true'] svg path {
-  fill: #666687;
-}
-
-.c4[aria-disabled='true']:active {
-  border: 1px solid #dcdce4;
-  background: #eaeaef;
-}
-
-.c4[aria-disabled='true']:active .c5 {
-  color: #666687;
-}
-
-.c4[aria-disabled='true']:active svg > g,
-.c4[aria-disabled='true']:active svg path {
-  fill: #666687;
-}
-
-.c4:hover {
-  border: 1px solid #7b79ff;
-  background: #7b79ff;
-}
-
-.c4:active {
-  border: 1px solid #4945ff;
-  background: #4945ff;
-}
-
-<main>
-  <div
-    class="c0"
-  >
-    <h1>
-      Storybook story
-    </h1>
-  </div>
-  <div
-    class="c1 c2"
-  >
-    <a
-      aria-current="page"
-      aria-disabled="false"
-      class="c3 c4 active"
-      href="/"
-      variant="default"
-    >
-      <span
-        class="c5 c6"
-      >
-        Default
-      </span>
-    </a>
-  </div>
-</main>
-`;
-
-exports[`Storyshots Design System/Components/LinkButton disabled 1`] = `
-.c0 {
-  border: 0;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 1px;
-}
-
-.c2 {
-  padding-right: 4px;
-}
-
-.c5 {
-  padding-right: 8px;
-}
-
 .c7 {
   font-weight: 600;
   color: #32324d;
@@ -19910,219 +22569,8 @@ exports[`Storyshots Design System/Components/LinkButton disabled 1`] = `
   line-height: 1.33;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  cursor: pointer;
-  padding: 8px;
-  border-radius: 4px;
-  background: #ffffff;
-  border: 1px solid #dcdce4;
-  position: relative;
-  outline: none;
-}
-
-.c3 svg {
-  height: 12px;
-  width: 12px;
-}
-
-.c3 svg > g,
-.c3 svg path {
-  fill: #ffffff;
-}
-
-.c3[aria-disabled='true'] {
-  pointer-events: none;
-}
-
-.c3:after {
-  -webkit-transition-property: all;
-  transition-property: all;
-  -webkit-transition-duration: 0.2s;
-  transition-duration: 0.2s;
-  border-radius: 8px;
-  content: '';
-  position: absolute;
-  top: -4px;
-  bottom: -4px;
-  left: -4px;
-  right: -4px;
-  border: 2px solid transparent;
-}
-
-.c3:focus-visible {
-  outline: none;
-}
-
-.c3:focus-visible:after {
-  border-radius: 8px;
-  content: '';
-  position: absolute;
-  top: -5px;
-  bottom: -5px;
-  left: -5px;
-  right: -5px;
-  border: 2px solid #4945ff;
-}
-
-.c4 {
-  padding: 8px 16px;
-  background: #4945ff;
-  border: none;
-  border-radius: 4px;
-  border: 1px solid #4945ff;
-  background: #4945ff;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c4 .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c4 .c6 {
-  color: #ffffff;
-}
-
-.c4[aria-disabled='true'] {
-  border: 1px solid #dcdce4;
-  background: #eaeaef;
-}
-
-.c4[aria-disabled='true'] .c6 {
-  color: #666687;
-}
-
-.c4[aria-disabled='true'] svg > g,
-.c4[aria-disabled='true'] svg path {
-  fill: #666687;
-}
-
-.c4[aria-disabled='true']:active {
-  border: 1px solid #dcdce4;
-  background: #eaeaef;
-}
-
-.c4[aria-disabled='true']:active .c6 {
-  color: #666687;
-}
-
-.c4[aria-disabled='true']:active svg > g,
-.c4[aria-disabled='true']:active svg path {
-  fill: #666687;
-}
-
-.c4:hover {
-  border: 1px solid #7b79ff;
-  background: #7b79ff;
-}
-
-.c4:active {
-  border: 1px solid #4945ff;
-  background: #4945ff;
-}
-
-<main>
-  <div
-    class="c0"
-  >
-    <h1>
-      Storybook story
-    </h1>
-  </div>
-  <div
-    class="c1 c2"
-  >
-    <a
-      aria-disabled="true"
-      class="c3 c4"
-      href="#"
-    >
-      <div
-        aria-hidden="true"
-        class="c1 c5"
-      >
-        <svg
-          fill="none"
-          height="1em"
-          viewBox="0 0 24 24"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12 0C5.383 0 0 5.383 0 12s5.383 12 12 12 12-5.383 12-12S18.617 0 12 0zm0 4.92a1.56 1.56 0 110 3.12 1.56 1.56 0 010-3.12zm3.84 13.06a.5.5 0 01-.5.5h-6.2a.5.5 0 01-.5-.5v-.92a.5.5 0 01.5-.5h2.14v-5.28H9.86a.5.5 0 01-.5-.5v-.92a.5.5 0 01.5-.5h2.84a.5.5 0 01.5.5v6.7h2.14a.5.5 0 01.5.5v.92z"
-            fill="#212134"
-          />
-        </svg>
-      </div>
-      <span
-        class="c6 c7"
-      >
-        Information
-      </span>
-    </a>
-  </div>
-</main>
-`;
-
-exports[`Storyshots Design System/Components/LinkButton icons 1`] = `
-.c0 {
-  border: 0;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 1px;
-}
-
-.c3 {
-  padding-right: 4px;
-}
-
-.c6 {
-  padding-right: 8px;
-}
-
-.c10 {
-  padding-left: 8px;
-}
-
-.c8 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
 .c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  padding-bottom: 8px;
 }
 
 .c4 {
@@ -20181,6 +22629,196 @@ exports[`Storyshots Design System/Components/LinkButton icons 1`] = `
   left: -5px;
   right: -5px;
   border: 2px solid #4945ff;
+}
+
+.c3 {
+  cursor: pointer;
+}
+
+.c5 {
+  padding: 8px 16px;
+  background: #4945ff;
+  border: none;
+  border-radius: 4px;
+  border: 1px solid #4945ff;
+  background: #4945ff;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c5 .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c5 .c6 {
+  color: #ffffff;
+}
+
+.c5[aria-disabled='true'] {
+  border: 1px solid #dcdce4;
+  background: #eaeaef;
+}
+
+.c5[aria-disabled='true'] .c6 {
+  color: #666687;
+}
+
+.c5[aria-disabled='true'] svg > g,
+.c5[aria-disabled='true'] svg path {
+  fill: #666687;
+}
+
+.c5[aria-disabled='true']:active {
+  border: 1px solid #dcdce4;
+  background: #eaeaef;
+}
+
+.c5[aria-disabled='true']:active .c6 {
+  color: #666687;
+}
+
+.c5[aria-disabled='true']:active svg > g,
+.c5[aria-disabled='true']:active svg path {
+  fill: #666687;
+}
+
+.c5:hover {
+  border: 1px solid #7b79ff;
+  background: #7b79ff;
+}
+
+.c5:active {
+  border: 1px solid #4945ff;
+  background: #4945ff;
+}
+
+<main>
+  <div
+    class="c0"
+  >
+    <h1>
+      Storybook story
+    </h1>
+  </div>
+  <div
+    class="c1 c2"
+  >
+    <a
+      aria-disabled="false"
+      class="c3 c4 c5"
+      href="https://strapi.io/"
+      rel="noreferrer noopener"
+      target="_blank"
+    >
+      <span
+        class="c6 c7"
+      >
+        Default
+      </span>
+    </a>
+  </div>
+</main>
+`;
+
+exports[`Storyshots Design System/Components/LinkButton disabled 1`] = `
+.c0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c8 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c2 {
+  padding-right: 4px;
+}
+
+.c6 {
+  padding-right: 8px;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 4px;
+  background: #ffffff;
+  border: 1px solid #dcdce4;
+  position: relative;
+  outline: none;
+}
+
+.c4 svg {
+  height: 12px;
+  width: 12px;
+}
+
+.c4 svg > g,
+.c4 svg path {
+  fill: #ffffff;
+}
+
+.c4[aria-disabled='true'] {
+  pointer-events: none;
+}
+
+.c4:after {
+  -webkit-transition-property: all;
+  transition-property: all;
+  -webkit-transition-duration: 0.2s;
+  transition-duration: 0.2s;
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  left: -4px;
+  right: -4px;
+  border: 2px solid transparent;
+}
+
+.c4:focus-visible {
+  outline: none;
+}
+
+.c4:focus-visible:after {
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -5px;
+  bottom: -5px;
+  left: -5px;
+  right: -5px;
+  border: 2px solid #4945ff;
+}
+
+.c3 {
+  cursor: pointer;
 }
 
 .c5 {
@@ -20247,6 +22885,839 @@ exports[`Storyshots Design System/Components/LinkButton icons 1`] = `
 }
 
 .c5:active {
+  border: 1px solid #4945ff;
+  background: #4945ff;
+}
+
+<main>
+  <div
+    class="c0"
+  >
+    <h1>
+      Storybook story
+    </h1>
+  </div>
+  <div
+    class="c1 c2"
+  >
+    <a
+      aria-disabled="true"
+      class="c3 c4 c5"
+      to="/"
+    >
+      <div
+        aria-hidden="true"
+        class="c1 c6"
+      >
+        <svg
+          fill="none"
+          height="1em"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 0C5.383 0 0 5.383 0 12s5.383 12 12 12 12-5.383 12-12S18.617 0 12 0zm0 4.92a1.56 1.56 0 110 3.12 1.56 1.56 0 010-3.12zm3.84 13.06a.5.5 0 01-.5.5h-6.2a.5.5 0 01-.5-.5v-.92a.5.5 0 01.5-.5h2.14v-5.28H9.86a.5.5 0 01-.5-.5v-.92a.5.5 0 01.5-.5h2.84a.5.5 0 01.5.5v6.7h2.14a.5.5 0 01.5.5v.92z"
+            fill="#212134"
+          />
+        </svg>
+      </div>
+      <span
+        class="c7 c8"
+      >
+        Information
+      </span>
+    </a>
+  </div>
+</main>
+`;
+
+exports[`Storyshots Design System/Components/LinkButton icons 1`] = `
+.c0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c9 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c3 {
+  padding-right: 4px;
+}
+
+.c7 {
+  padding-right: 8px;
+}
+
+.c11 {
+  padding-left: 8px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 4px;
+  background: #ffffff;
+  border: 1px solid #dcdce4;
+  position: relative;
+  outline: none;
+}
+
+.c5 svg {
+  height: 12px;
+  width: 12px;
+}
+
+.c5 svg > g,
+.c5 svg path {
+  fill: #ffffff;
+}
+
+.c5[aria-disabled='true'] {
+  pointer-events: none;
+}
+
+.c5:after {
+  -webkit-transition-property: all;
+  transition-property: all;
+  -webkit-transition-duration: 0.2s;
+  transition-duration: 0.2s;
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  left: -4px;
+  right: -4px;
+  border: 2px solid transparent;
+}
+
+.c5:focus-visible {
+  outline: none;
+}
+
+.c5:focus-visible:after {
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -5px;
+  bottom: -5px;
+  left: -5px;
+  right: -5px;
+  border: 2px solid #4945ff;
+}
+
+.c4 {
+  cursor: pointer;
+}
+
+.c6 {
+  padding: 8px 16px;
+  background: #4945ff;
+  border: none;
+  border-radius: 4px;
+  border: 1px solid #4945ff;
+  background: #4945ff;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6 .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c6 .c8 {
+  color: #ffffff;
+}
+
+.c6[aria-disabled='true'] {
+  border: 1px solid #dcdce4;
+  background: #eaeaef;
+}
+
+.c6[aria-disabled='true'] .c8 {
+  color: #666687;
+}
+
+.c6[aria-disabled='true'] svg > g,
+.c6[aria-disabled='true'] svg path {
+  fill: #666687;
+}
+
+.c6[aria-disabled='true']:active {
+  border: 1px solid #dcdce4;
+  background: #eaeaef;
+}
+
+.c6[aria-disabled='true']:active .c8 {
+  color: #666687;
+}
+
+.c6[aria-disabled='true']:active svg > g,
+.c6[aria-disabled='true']:active svg path {
+  fill: #666687;
+}
+
+.c6:hover {
+  border: 1px solid #7b79ff;
+  background: #7b79ff;
+}
+
+.c6:active {
+  border: 1px solid #4945ff;
+  background: #4945ff;
+}
+
+.c10 {
+  padding: 8px 16px;
+  background: #4945ff;
+  border: none;
+  border-radius: 4px;
+  border: 1px solid #d9d8ff;
+  background: #f0f0ff;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c10 .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c10 .c8 {
+  color: #ffffff;
+}
+
+.c10[aria-disabled='true'] {
+  border: 1px solid #dcdce4;
+  background: #eaeaef;
+}
+
+.c10[aria-disabled='true'] .c8 {
+  color: #666687;
+}
+
+.c10[aria-disabled='true'] svg > g,
+.c10[aria-disabled='true'] svg path {
+  fill: #666687;
+}
+
+.c10[aria-disabled='true']:active {
+  border: 1px solid #dcdce4;
+  background: #eaeaef;
+}
+
+.c10[aria-disabled='true']:active .c8 {
+  color: #666687;
+}
+
+.c10[aria-disabled='true']:active svg > g,
+.c10[aria-disabled='true']:active svg path {
+  fill: #666687;
+}
+
+.c10:hover {
+  background-color: #ffffff;
+}
+
+.c10:active {
+  background-color: #ffffff;
+  border: 1px solid #4945ff;
+}
+
+.c10:active .c8 {
+  color: #4945ff;
+}
+
+.c10:active svg > g,
+.c10:active svg path {
+  fill: #4945ff;
+}
+
+.c10 .c8 {
+  color: #271fe0;
+}
+
+.c10 svg > g,
+.c10 svg path {
+  fill: #271fe0;
+}
+
+<main>
+  <div
+    class="c0"
+  >
+    <h1>
+      Storybook story
+    </h1>
+  </div>
+  <div
+    class="c1 c2"
+  >
+    <div
+      class="c1 c3"
+    >
+      <a
+        aria-disabled="false"
+        class="c4 c5 c6"
+        to="/"
+      >
+        <div
+          aria-hidden="true"
+          class="c1 c7"
+        >
+          <svg
+            fill="none"
+            height="1em"
+            viewBox="0 0 24 24"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 0C5.383 0 0 5.383 0 12s5.383 12 12 12 12-5.383 12-12S18.617 0 12 0zm0 4.92a1.56 1.56 0 110 3.12 1.56 1.56 0 010-3.12zm3.84 13.06a.5.5 0 01-.5.5h-6.2a.5.5 0 01-.5-.5v-.92a.5.5 0 01.5-.5h2.14v-5.28H9.86a.5.5 0 01-.5-.5v-.92a.5.5 0 01.5-.5h2.84a.5.5 0 01.5.5v6.7h2.14a.5.5 0 01.5.5v.92z"
+              fill="#212134"
+            />
+          </svg>
+        </div>
+        <span
+          class="c8 c9"
+        >
+          Information
+        </span>
+      </a>
+    </div>
+    <a
+      aria-disabled="false"
+      class="c4 c5 c10"
+      to="/"
+    >
+      <span
+        class="c8 c9"
+      >
+        Write content
+      </span>
+      <div
+        aria-hidden="true"
+        class="c1 c11"
+      >
+        <svg
+          fill="none"
+          height="1em"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            clip-rule="evenodd"
+            d="M23.707.297A1 1 0 0023 .004h-2a13.907 13.907 0 00-5.38 1.077 1 1 0 00-.615.923V4.92a.035.035 0 01-.022.038l-2-1.47a1 1 0 00-1.265.052A14 14 0 007 14.004v1.585l-2.707 2.707a1 1 0 101.415 1.415l2.707-2.708H10a14.014 14.014 0 0014-14v-2a1 1 0 00-.293-.706zM18 23.999H3a3 3 0 01-3-3V6A3 3 0 013 3h3a1 1 0 110 2H3a1 1 0 00-1 1v15a1 1 0 001 1h15a1 1 0 001-1v-3a1 1 0 112 0v3a3 3 0 01-3 3z"
+            fill="#212134"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </div>
+    </a>
+  </div>
+</main>
+`;
+
+exports[`Storyshots Design System/Components/LinkButton sizes 1`] = `
+.c0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c8 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c10 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
+.c3 {
+  padding-right: 4px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 4px;
+  background: #ffffff;
+  border: 1px solid #dcdce4;
+  position: relative;
+  outline: none;
+}
+
+.c5 svg {
+  height: 12px;
+  width: 12px;
+}
+
+.c5 svg > g,
+.c5 svg path {
+  fill: #ffffff;
+}
+
+.c5[aria-disabled='true'] {
+  pointer-events: none;
+}
+
+.c5:after {
+  -webkit-transition-property: all;
+  transition-property: all;
+  -webkit-transition-duration: 0.2s;
+  transition-duration: 0.2s;
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  left: -4px;
+  right: -4px;
+  border: 2px solid transparent;
+}
+
+.c5:focus-visible {
+  outline: none;
+}
+
+.c5:focus-visible:after {
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -5px;
+  bottom: -5px;
+  left: -5px;
+  right: -5px;
+  border: 2px solid #4945ff;
+}
+
+.c4 {
+  cursor: pointer;
+}
+
+.c6 {
+  padding: 8px 16px;
+  background: #4945ff;
+  border: none;
+  border-radius: 4px;
+  border: 1px solid #4945ff;
+  background: #4945ff;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6 .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c6 .c7 {
+  color: #ffffff;
+}
+
+.c6[aria-disabled='true'] {
+  border: 1px solid #dcdce4;
+  background: #eaeaef;
+}
+
+.c6[aria-disabled='true'] .c7 {
+  color: #666687;
+}
+
+.c6[aria-disabled='true'] svg > g,
+.c6[aria-disabled='true'] svg path {
+  fill: #666687;
+}
+
+.c6[aria-disabled='true']:active {
+  border: 1px solid #dcdce4;
+  background: #eaeaef;
+}
+
+.c6[aria-disabled='true']:active .c7 {
+  color: #666687;
+}
+
+.c6[aria-disabled='true']:active svg > g,
+.c6[aria-disabled='true']:active svg path {
+  fill: #666687;
+}
+
+.c6:hover {
+  border: 1px solid #7b79ff;
+  background: #7b79ff;
+}
+
+.c6:active {
+  border: 1px solid #4945ff;
+  background: #4945ff;
+}
+
+.c9 {
+  padding: 10px 16px;
+  background: #4945ff;
+  border: none;
+  border-radius: 4px;
+  border: 1px solid #4945ff;
+  background: #4945ff;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c9 .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c9 .c7 {
+  color: #ffffff;
+}
+
+.c9[aria-disabled='true'] {
+  border: 1px solid #dcdce4;
+  background: #eaeaef;
+}
+
+.c9[aria-disabled='true'] .c7 {
+  color: #666687;
+}
+
+.c9[aria-disabled='true'] svg > g,
+.c9[aria-disabled='true'] svg path {
+  fill: #666687;
+}
+
+.c9[aria-disabled='true']:active {
+  border: 1px solid #dcdce4;
+  background: #eaeaef;
+}
+
+.c9[aria-disabled='true']:active .c7 {
+  color: #666687;
+}
+
+.c9[aria-disabled='true']:active svg > g,
+.c9[aria-disabled='true']:active svg path {
+  fill: #666687;
+}
+
+.c9:hover {
+  border: 1px solid #7b79ff;
+  background: #7b79ff;
+}
+
+.c9:active {
+  border: 1px solid #4945ff;
+  background: #4945ff;
+}
+
+<main>
+  <div
+    class="c0"
+  >
+    <h1>
+      Storybook story
+    </h1>
+  </div>
+  <div
+    class="c1 c2"
+  >
+    <div
+      class="c1 c3"
+    >
+      <a
+        aria-disabled="false"
+        class="c4 c5 c6"
+        to="/"
+      >
+        <span
+          class="c7 c8"
+        >
+          Small
+        </span>
+      </a>
+    </div>
+    <a
+      aria-disabled="false"
+      class="c4 c5 c9"
+      to="/"
+    >
+      <span
+        class="c7 c10"
+      >
+        Large
+      </span>
+    </a>
+  </div>
+</main>
+`;
+
+exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
+.c0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c8 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c3 {
+  padding-right: 8px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 4px;
+  background: #ffffff;
+  border: 1px solid #dcdce4;
+  position: relative;
+  outline: none;
+}
+
+.c5 svg {
+  height: 12px;
+  width: 12px;
+}
+
+.c5 svg > g,
+.c5 svg path {
+  fill: #ffffff;
+}
+
+.c5[aria-disabled='true'] {
+  pointer-events: none;
+}
+
+.c5:after {
+  -webkit-transition-property: all;
+  transition-property: all;
+  -webkit-transition-duration: 0.2s;
+  transition-duration: 0.2s;
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  left: -4px;
+  right: -4px;
+  border: 2px solid transparent;
+}
+
+.c5:focus-visible {
+  outline: none;
+}
+
+.c5:focus-visible:after {
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -5px;
+  bottom: -5px;
+  left: -5px;
+  right: -5px;
+  border: 2px solid #4945ff;
+}
+
+.c4 {
+  cursor: pointer;
+}
+
+.c6 {
+  padding: 8px 16px;
+  background: #4945ff;
+  border: none;
+  border-radius: 4px;
+  border: 1px solid #4945ff;
+  background: #4945ff;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6 .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c6 .c7 {
+  color: #ffffff;
+}
+
+.c6[aria-disabled='true'] {
+  border: 1px solid #dcdce4;
+  background: #eaeaef;
+}
+
+.c6[aria-disabled='true'] .c7 {
+  color: #666687;
+}
+
+.c6[aria-disabled='true'] svg > g,
+.c6[aria-disabled='true'] svg path {
+  fill: #666687;
+}
+
+.c6[aria-disabled='true']:active {
+  border: 1px solid #dcdce4;
+  background: #eaeaef;
+}
+
+.c6[aria-disabled='true']:active .c7 {
+  color: #666687;
+}
+
+.c6[aria-disabled='true']:active svg > g,
+.c6[aria-disabled='true']:active svg path {
+  fill: #666687;
+}
+
+.c6:hover {
+  border: 1px solid #7b79ff;
+  background: #7b79ff;
+}
+
+.c6:active {
   border: 1px solid #4945ff;
   background: #4945ff;
 }
@@ -20336,702 +23807,13 @@ exports[`Storyshots Design System/Components/LinkButton icons 1`] = `
   fill: #271fe0;
 }
 
-<main>
-  <div
-    class="c0"
-  >
-    <h1>
-      Storybook story
-    </h1>
-  </div>
-  <div
-    class="c1 c2"
-  >
-    <div
-      class="c1 c3"
-    >
-      <a
-        aria-current="page"
-        aria-disabled="false"
-        class="c4 c5 active"
-        href="/"
-        variant="default"
-      >
-        <div
-          aria-hidden="true"
-          class="c1 c6"
-        >
-          <svg
-            fill="none"
-            height="1em"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M12 0C5.383 0 0 5.383 0 12s5.383 12 12 12 12-5.383 12-12S18.617 0 12 0zm0 4.92a1.56 1.56 0 110 3.12 1.56 1.56 0 010-3.12zm3.84 13.06a.5.5 0 01-.5.5h-6.2a.5.5 0 01-.5-.5v-.92a.5.5 0 01.5-.5h2.14v-5.28H9.86a.5.5 0 01-.5-.5v-.92a.5.5 0 01.5-.5h2.84a.5.5 0 01.5.5v6.7h2.14a.5.5 0 01.5.5v.92z"
-              fill="#212134"
-            />
-          </svg>
-        </div>
-        <span
-          class="c7 c8"
-        >
-          Information
-        </span>
-      </a>
-    </div>
-    <a
-      aria-current="page"
-      aria-disabled="false"
-      class="c4 c9 active"
-      href="/"
-      variant="secondary"
-    >
-      <span
-        class="c7 c8"
-      >
-        Write content
-      </span>
-      <div
-        aria-hidden="true"
-        class="c1 c10"
-      >
-        <svg
-          fill="none"
-          height="1em"
-          viewBox="0 0 24 24"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M23.707.297A1 1 0 0023 .004h-2a13.907 13.907 0 00-5.38 1.077 1 1 0 00-.615.923V4.92a.035.035 0 01-.022.038l-2-1.47a1 1 0 00-1.265.052A14 14 0 007 14.004v1.585l-2.707 2.707a1 1 0 101.415 1.415l2.707-2.708H10a14.014 14.014 0 0014-14v-2a1 1 0 00-.293-.706zM18 23.999H3a3 3 0 01-3-3V6A3 3 0 013 3h3a1 1 0 110 2H3a1 1 0 00-1 1v15a1 1 0 001 1h15a1 1 0 001-1v-3a1 1 0 112 0v3a3 3 0 01-3 3z"
-            fill="#212134"
-            fill-rule="evenodd"
-          />
-        </svg>
-      </div>
-    </a>
-  </div>
-</main>
-`;
-
-exports[`Storyshots Design System/Components/LinkButton sizes 1`] = `
-.c0 {
-  border: 0;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 1px;
-}
-
-.c3 {
-  padding-right: 4px;
-}
-
-.c7 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c9 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.875rem;
-  line-height: 1.43;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  cursor: pointer;
-  padding: 8px;
-  border-radius: 4px;
-  background: #ffffff;
-  border: 1px solid #dcdce4;
-  position: relative;
-  outline: none;
-}
-
-.c4 svg {
-  height: 12px;
-  width: 12px;
-}
-
-.c4 svg > g,
-.c4 svg path {
-  fill: #ffffff;
-}
-
-.c4[aria-disabled='true'] {
-  pointer-events: none;
-}
-
-.c4:after {
-  -webkit-transition-property: all;
-  transition-property: all;
-  -webkit-transition-duration: 0.2s;
-  transition-duration: 0.2s;
-  border-radius: 8px;
-  content: '';
-  position: absolute;
-  top: -4px;
-  bottom: -4px;
-  left: -4px;
-  right: -4px;
-  border: 2px solid transparent;
-}
-
-.c4:focus-visible {
-  outline: none;
-}
-
-.c4:focus-visible:after {
-  border-radius: 8px;
-  content: '';
-  position: absolute;
-  top: -5px;
-  bottom: -5px;
-  left: -5px;
-  right: -5px;
-  border: 2px solid #4945ff;
-}
-
-.c5 {
-  padding: 8px 16px;
-  background: #4945ff;
-  border: none;
-  border-radius: 4px;
-  border: 1px solid #4945ff;
-  background: #4945ff;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c5 .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c5 .c6 {
-  color: #ffffff;
-}
-
-.c5[aria-disabled='true'] {
-  border: 1px solid #dcdce4;
-  background: #eaeaef;
-}
-
-.c5[aria-disabled='true'] .c6 {
-  color: #666687;
-}
-
-.c5[aria-disabled='true'] svg > g,
-.c5[aria-disabled='true'] svg path {
-  fill: #666687;
-}
-
-.c5[aria-disabled='true']:active {
-  border: 1px solid #dcdce4;
-  background: #eaeaef;
-}
-
-.c5[aria-disabled='true']:active .c6 {
-  color: #666687;
-}
-
-.c5[aria-disabled='true']:active svg > g,
-.c5[aria-disabled='true']:active svg path {
-  fill: #666687;
-}
-
-.c5:hover {
-  border: 1px solid #7b79ff;
-  background: #7b79ff;
-}
-
-.c5:active {
-  border: 1px solid #4945ff;
-  background: #4945ff;
-}
-
-.c8 {
-  padding: 10px 16px;
-  background: #4945ff;
-  border: none;
-  border-radius: 4px;
-  border: 1px solid #4945ff;
-  background: #4945ff;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c8 .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c8 .c6 {
-  color: #ffffff;
-}
-
-.c8[aria-disabled='true'] {
-  border: 1px solid #dcdce4;
-  background: #eaeaef;
-}
-
-.c8[aria-disabled='true'] .c6 {
-  color: #666687;
-}
-
-.c8[aria-disabled='true'] svg > g,
-.c8[aria-disabled='true'] svg path {
-  fill: #666687;
-}
-
-.c8[aria-disabled='true']:active {
-  border: 1px solid #dcdce4;
-  background: #eaeaef;
-}
-
-.c8[aria-disabled='true']:active .c6 {
-  color: #666687;
-}
-
-.c8[aria-disabled='true']:active svg > g,
-.c8[aria-disabled='true']:active svg path {
-  fill: #666687;
-}
-
-.c8:hover {
-  border: 1px solid #7b79ff;
-  background: #7b79ff;
-}
-
-.c8:active {
-  border: 1px solid #4945ff;
-  background: #4945ff;
-}
-
-<main>
-  <div
-    class="c0"
-  >
-    <h1>
-      Storybook story
-    </h1>
-  </div>
-  <div
-    class="c1 c2"
-  >
-    <div
-      class="c1 c3"
-    >
-      <a
-        aria-current="page"
-        aria-disabled="false"
-        class="c4 c5 active"
-        href="/"
-        variant="default"
-      >
-        <span
-          class="c6 c7"
-        >
-          Small
-        </span>
-      </a>
-    </div>
-    <a
-      aria-current="page"
-      aria-disabled="false"
-      class="c4 c8 active"
-      href="/"
-      variant="default"
-    >
-      <span
-        class="c6 c9"
-      >
-        Large
-      </span>
-    </a>
-  </div>
-</main>
-`;
-
-exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
-.c0 {
-  border: 0;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 1px;
-}
-
-.c3 {
-  padding-right: 8px;
-}
-
-.c7 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  cursor: pointer;
-  padding: 8px;
-  border-radius: 4px;
-  background: #ffffff;
-  border: 1px solid #dcdce4;
-  position: relative;
-  outline: none;
-}
-
-.c4 svg {
-  height: 12px;
-  width: 12px;
-}
-
-.c4 svg > g,
-.c4 svg path {
-  fill: #ffffff;
-}
-
-.c4[aria-disabled='true'] {
-  pointer-events: none;
-}
-
-.c4:after {
-  -webkit-transition-property: all;
-  transition-property: all;
-  -webkit-transition-duration: 0.2s;
-  transition-duration: 0.2s;
-  border-radius: 8px;
-  content: '';
-  position: absolute;
-  top: -4px;
-  bottom: -4px;
-  left: -4px;
-  right: -4px;
-  border: 2px solid transparent;
-}
-
-.c4:focus-visible {
-  outline: none;
-}
-
-.c4:focus-visible:after {
-  border-radius: 8px;
-  content: '';
-  position: absolute;
-  top: -5px;
-  bottom: -5px;
-  left: -5px;
-  right: -5px;
-  border: 2px solid #4945ff;
-}
-
-.c5 {
-  padding: 8px 16px;
-  background: #4945ff;
-  border: none;
-  border-radius: 4px;
-  border: 1px solid #4945ff;
-  background: #4945ff;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c5 .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c5 .c6 {
-  color: #ffffff;
-}
-
-.c5[aria-disabled='true'] {
-  border: 1px solid #dcdce4;
-  background: #eaeaef;
-}
-
-.c5[aria-disabled='true'] .c6 {
-  color: #666687;
-}
-
-.c5[aria-disabled='true'] svg > g,
-.c5[aria-disabled='true'] svg path {
-  fill: #666687;
-}
-
-.c5[aria-disabled='true']:active {
-  border: 1px solid #dcdce4;
-  background: #eaeaef;
-}
-
-.c5[aria-disabled='true']:active .c6 {
-  color: #666687;
-}
-
-.c5[aria-disabled='true']:active svg > g,
-.c5[aria-disabled='true']:active svg path {
-  fill: #666687;
-}
-
-.c5:hover {
-  border: 1px solid #7b79ff;
-  background: #7b79ff;
-}
-
-.c5:active {
-  border: 1px solid #4945ff;
-  background: #4945ff;
-}
-
-.c8 {
-  padding: 8px 16px;
-  background: #4945ff;
-  border: none;
-  border-radius: 4px;
-  border: 1px solid #d9d8ff;
-  background: #f0f0ff;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c8 .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c8 .c6 {
-  color: #ffffff;
-}
-
-.c8[aria-disabled='true'] {
-  border: 1px solid #dcdce4;
-  background: #eaeaef;
-}
-
-.c8[aria-disabled='true'] .c6 {
-  color: #666687;
-}
-
-.c8[aria-disabled='true'] svg > g,
-.c8[aria-disabled='true'] svg path {
-  fill: #666687;
-}
-
-.c8[aria-disabled='true']:active {
-  border: 1px solid #dcdce4;
-  background: #eaeaef;
-}
-
-.c8[aria-disabled='true']:active .c6 {
-  color: #666687;
-}
-
-.c8[aria-disabled='true']:active svg > g,
-.c8[aria-disabled='true']:active svg path {
-  fill: #666687;
-}
-
-.c8:hover {
-  background-color: #ffffff;
-}
-
-.c8:active {
-  background-color: #ffffff;
-  border: 1px solid #4945ff;
-}
-
-.c8:active .c6 {
-  color: #4945ff;
-}
-
-.c8:active svg > g,
-.c8:active svg path {
-  fill: #4945ff;
-}
-
-.c8 .c6 {
-  color: #271fe0;
-}
-
-.c8 svg > g,
-.c8 svg path {
-  fill: #271fe0;
-}
-
-.c9 {
-  padding: 8px 16px;
-  background: #4945ff;
-  border: none;
-  border-radius: 4px;
-  border: 1px solid #dcdce4;
-  background: #ffffff;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c9 .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c9 .c6 {
-  color: #ffffff;
-}
-
-.c9[aria-disabled='true'] {
-  border: 1px solid #dcdce4;
-  background: #eaeaef;
-}
-
-.c9[aria-disabled='true'] .c6 {
-  color: #666687;
-}
-
-.c9[aria-disabled='true'] svg > g,
-.c9[aria-disabled='true'] svg path {
-  fill: #666687;
-}
-
-.c9[aria-disabled='true']:active {
-  border: 1px solid #dcdce4;
-  background: #eaeaef;
-}
-
-.c9[aria-disabled='true']:active .c6 {
-  color: #666687;
-}
-
-.c9[aria-disabled='true']:active svg > g,
-.c9[aria-disabled='true']:active svg path {
-  fill: #666687;
-}
-
-.c9:hover {
-  background-color: #f6f6f9;
-}
-
-.c9:active {
-  background-color: #eaeaef;
-}
-
-.c9 .c6 {
-  color: #32324d;
-}
-
-.c9 svg > g,
-.c9 svg path {
-  fill: #32324d;
-}
-
 .c10 {
   padding: 8px 16px;
   background: #4945ff;
   border: none;
   border-radius: 4px;
-  border: 1px solid #328048;
-  background: #328048;
+  border: 1px solid #dcdce4;
+  background: #ffffff;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -21051,7 +23833,7 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
   align-items: center;
 }
 
-.c10 .c6 {
+.c10 .c7 {
   color: #ffffff;
 }
 
@@ -21060,7 +23842,7 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
   background: #eaeaef;
 }
 
-.c10[aria-disabled='true'] .c6 {
+.c10[aria-disabled='true'] .c7 {
   color: #666687;
 }
 
@@ -21074,7 +23856,7 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
   background: #eaeaef;
 }
 
-.c10[aria-disabled='true']:active .c6 {
+.c10[aria-disabled='true']:active .c7 {
   color: #666687;
 }
 
@@ -21084,13 +23866,20 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
 }
 
 .c10:hover {
-  border: 1px solid #5cb176;
-  background: #5cb176;
+  background-color: #f6f6f9;
 }
 
 .c10:active {
-  border: 1px solid #328048;
-  background: #328048;
+  background-color: #eaeaef;
+}
+
+.c10 .c7 {
+  color: #32324d;
+}
+
+.c10 svg > g,
+.c10 svg path {
+  fill: #32324d;
 }
 
 .c11 {
@@ -21098,8 +23887,8 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
   background: #4945ff;
   border: none;
   border-radius: 4px;
-  border: 1px solid #d02b20;
-  background: #d02b20;
+  border: 1px solid #328048;
+  background: #328048;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -21119,7 +23908,7 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
   align-items: center;
 }
 
-.c11 .c6 {
+.c11 .c7 {
   color: #ffffff;
 }
 
@@ -21128,7 +23917,7 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
   background: #eaeaef;
 }
 
-.c11[aria-disabled='true'] .c6 {
+.c11[aria-disabled='true'] .c7 {
   color: #666687;
 }
 
@@ -21142,7 +23931,7 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
   background: #eaeaef;
 }
 
-.c11[aria-disabled='true']:active .c6 {
+.c11[aria-disabled='true']:active .c7 {
   color: #666687;
 }
 
@@ -21152,13 +23941,13 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
 }
 
 .c11:hover {
-  border: 1px solid #ee5e52;
-  background: #ee5e52;
+  border: 1px solid #5cb176;
+  background: #5cb176;
 }
 
 .c11:active {
-  border: 1px solid #d02b20;
-  background: #d02b20;
+  border: 1px solid #328048;
+  background: #328048;
 }
 
 .c12 {
@@ -21166,8 +23955,8 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
   background: #4945ff;
   border: none;
   border-radius: 4px;
-  border: 1px solid #c6f0c2;
-  background: #eafbe7;
+  border: 1px solid #d02b20;
+  background: #d02b20;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -21187,7 +23976,7 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
   align-items: center;
 }
 
-.c12 .c6 {
+.c12 .c7 {
   color: #ffffff;
 }
 
@@ -21196,7 +23985,7 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
   background: #eaeaef;
 }
 
-.c12[aria-disabled='true'] .c6 {
+.c12[aria-disabled='true'] .c7 {
   color: #666687;
 }
 
@@ -21210,7 +23999,7 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
   background: #eaeaef;
 }
 
-.c12[aria-disabled='true']:active .c6 {
+.c12[aria-disabled='true']:active .c7 {
   color: #666687;
 }
 
@@ -21220,30 +24009,13 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
 }
 
 .c12:hover {
-  background-color: #ffffff;
+  border: 1px solid #ee5e52;
+  background: #ee5e52;
 }
 
 .c12:active {
-  background-color: #ffffff;
-  border: 1px solid #328048;
-}
-
-.c12:active .c6 {
-  color: #328048;
-}
-
-.c12:active svg > g,
-.c12:active svg path {
-  fill: #328048;
-}
-
-.c12 .c6 {
-  color: #2f6846;
-}
-
-.c12 svg > g,
-.c12 svg path {
-  fill: #2f6846;
+  border: 1px solid #d02b20;
+  background: #d02b20;
 }
 
 .c13 {
@@ -21251,8 +24023,8 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
   background: #4945ff;
   border: none;
   border-radius: 4px;
-  border: 1px solid #f5c0b8;
-  background: #fcecea;
+  border: 1px solid #c6f0c2;
+  background: #eafbe7;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -21272,7 +24044,7 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
   align-items: center;
 }
 
-.c13 .c6 {
+.c13 .c7 {
   color: #ffffff;
 }
 
@@ -21281,7 +24053,7 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
   background: #eaeaef;
 }
 
-.c13[aria-disabled='true'] .c6 {
+.c13[aria-disabled='true'] .c7 {
   color: #666687;
 }
 
@@ -21295,7 +24067,7 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
   background: #eaeaef;
 }
 
-.c13[aria-disabled='true']:active .c6 {
+.c13[aria-disabled='true']:active .c7 {
   color: #666687;
 }
 
@@ -21310,24 +24082,109 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
 
 .c13:active {
   background-color: #ffffff;
-  border: 1px solid #d02b20;
+  border: 1px solid #328048;
 }
 
-.c13:active .c6 {
-  color: #d02b20;
+.c13:active .c7 {
+  color: #328048;
 }
 
 .c13:active svg > g,
 .c13:active svg path {
-  fill: #d02b20;
+  fill: #328048;
 }
 
-.c13 .c6 {
-  color: #b72b1a;
+.c13 .c7 {
+  color: #2f6846;
 }
 
 .c13 svg > g,
 .c13 svg path {
+  fill: #2f6846;
+}
+
+.c14 {
+  padding: 8px 16px;
+  background: #4945ff;
+  border: none;
+  border-radius: 4px;
+  border: 1px solid #f5c0b8;
+  background: #fcecea;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c14 .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c14 .c7 {
+  color: #ffffff;
+}
+
+.c14[aria-disabled='true'] {
+  border: 1px solid #dcdce4;
+  background: #eaeaef;
+}
+
+.c14[aria-disabled='true'] .c7 {
+  color: #666687;
+}
+
+.c14[aria-disabled='true'] svg > g,
+.c14[aria-disabled='true'] svg path {
+  fill: #666687;
+}
+
+.c14[aria-disabled='true']:active {
+  border: 1px solid #dcdce4;
+  background: #eaeaef;
+}
+
+.c14[aria-disabled='true']:active .c7 {
+  color: #666687;
+}
+
+.c14[aria-disabled='true']:active svg > g,
+.c14[aria-disabled='true']:active svg path {
+  fill: #666687;
+}
+
+.c14:hover {
+  background-color: #ffffff;
+}
+
+.c14:active {
+  background-color: #ffffff;
+  border: 1px solid #d02b20;
+}
+
+.c14:active .c7 {
+  color: #d02b20;
+}
+
+.c14:active svg > g,
+.c14:active svg path {
+  fill: #d02b20;
+}
+
+.c14 .c7 {
+  color: #b72b1a;
+}
+
+.c14 svg > g,
+.c14 svg path {
   fill: #b72b1a;
 }
 
@@ -21346,14 +24203,12 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
       class="c1 c3"
     >
       <a
-        aria-current="page"
         aria-disabled="false"
-        class="c4 c5 active"
-        href="/"
-        variant="default"
+        class="c4 c5 c6"
+        to="/"
       >
         <span
-          class="c6 c7"
+          class="c7 c8"
         >
           default
         </span>
@@ -21363,14 +24218,12 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
       class="c1 c3"
     >
       <a
-        aria-current="page"
         aria-disabled="false"
-        class="c4 c8 active"
-        href="/"
-        variant="secondary"
+        class="c4 c5 c9"
+        to="/"
       >
         <span
-          class="c6 c7"
+          class="c7 c8"
         >
           secondary
         </span>
@@ -21380,14 +24233,12 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
       class="c1 c3"
     >
       <a
-        aria-current="page"
         aria-disabled="false"
-        class="c4 c9 active"
-        href="/"
-        variant="tertiary"
+        class="c4 c5 c10"
+        to="/"
       >
         <span
-          class="c6 c7"
+          class="c7 c8"
         >
           tertiary
         </span>
@@ -21397,14 +24248,12 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
       class="c1 c3"
     >
       <a
-        aria-current="page"
         aria-disabled="false"
-        class="c4 c10 active"
-        href="/"
-        variant="success"
+        class="c4 c5 c11"
+        to="/"
       >
         <span
-          class="c6 c7"
+          class="c7 c8"
         >
           success
         </span>
@@ -21414,14 +24263,12 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
       class="c1 c3"
     >
       <a
-        aria-current="page"
         aria-disabled="false"
-        class="c4 c11 active"
-        href="/"
-        variant="danger"
+        class="c4 c5 c12"
+        to="/"
       >
         <span
-          class="c6 c7"
+          class="c7 c8"
         >
           danger
         </span>
@@ -21431,14 +24278,12 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
       class="c1 c3"
     >
       <a
-        aria-current="page"
         aria-disabled="false"
-        class="c4 c12 active"
-        href="/"
-        variant="success-light"
+        class="c4 c5 c13"
+        to="/"
       >
         <span
-          class="c6 c7"
+          class="c7 c8"
         >
           success-light
         </span>
@@ -21448,14 +24293,12 @@ exports[`Storyshots Design System/Components/LinkButton variants 1`] = `
       class="c1 c3"
     >
       <a
-        aria-current="page"
         aria-disabled="false"
-        class="c4 c13 active"
-        href="/"
-        variant="danger-light"
+        class="c4 c5 c14"
+        to="/"
       >
         <span
-          class="c6 c7"
+          class="c7 c8"
         >
           danger-light
         </span>
@@ -22122,81 +24965,26 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
   width: 1px;
 }
 
-.c1 {
-  background: #f6f6f9;
-  padding: 56px;
-}
-
-.c3 {
-  padding-top: 16px;
-  padding-right: 12px;
-  padding-bottom: 16px;
-  padding-left: 12px;
-}
-
-.c6 {
-  padding-left: 8px;
-}
-
-.c11 {
-  background: #eaeaef;
-}
-
-.c13 {
-  padding-top: 12px;
-  padding-right: 8px;
-  padding-left: 12px;
-}
-
-.c18 {
-  padding-right: 12px;
-}
-
-.c22 {
-  background: #ffffff;
-  padding-top: 4px;
-  padding-right: 12px;
-  padding-bottom: 4px;
-  padding-left: 12px;
-  border-radius: 4px;
-}
-
-.c24 {
-  padding-top: 12px;
-  padding-right: 20px;
-  padding-bottom: 12px;
-  padding-left: 20px;
-}
-
-.c28 {
-  padding-left: 8px;
-  width: 8.125rem;
-}
-
-.c31 {
-  color: #666687;
-}
-
-.c8 {
+.c10 {
   font-weight: 600;
   color: #32324d;
   font-size: 0.875rem;
   line-height: 1.43;
 }
 
-.c10 {
+.c11 {
   color: #666687;
   font-size: 0.75rem;
   line-height: 1.33;
 }
 
-.c20 {
+.c21 {
   color: #32324d;
   font-size: 0.875rem;
   line-height: 1.43;
 }
 
-.c23 {
+.c24 {
   color: #666687;
   font-weight: 600;
   font-size: 0.6875rem;
@@ -22204,7 +24992,7 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
   text-transform: uppercase;
 }
 
-.c29 {
+.c30 {
   color: #666687;
   display: block;
   white-space: nowrap;
@@ -22214,7 +25002,62 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
   line-height: 1.43;
 }
 
-.c4 {
+.c1 {
+  background: #f6f6f9;
+  padding: 56px;
+}
+
+.c5 {
+  padding-top: 16px;
+  padding-right: 12px;
+  padding-bottom: 16px;
+  padding-left: 12px;
+}
+
+.c8 {
+  padding-left: 8px;
+}
+
+.c12 {
+  background: #eaeaef;
+}
+
+.c14 {
+  padding-top: 12px;
+  padding-right: 8px;
+  padding-left: 12px;
+}
+
+.c19 {
+  padding-right: 12px;
+}
+
+.c23 {
+  background: #ffffff;
+  padding-top: 4px;
+  padding-right: 12px;
+  padding-bottom: 4px;
+  padding-left: 12px;
+  border-radius: 4px;
+}
+
+.c25 {
+  padding-top: 12px;
+  padding-right: 20px;
+  padding-bottom: 12px;
+  padding-left: 20px;
+}
+
+.c29 {
+  padding-left: 8px;
+  width: 8.125rem;
+}
+
+.c32 {
+  color: #666687;
+}
+
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -22228,7 +25071,7 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
   align-items: center;
 }
 
-.c16 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -22246,7 +25089,7 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
   align-items: center;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -22256,16 +25099,16 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
   flex-direction: column;
 }
 
-.c14 > * {
+.c15 > * {
   margin-top: 0;
   margin-bottom: 0;
 }
 
-.c14 > * + * {
+.c15 > * + * {
   margin-top: 16px;
 }
 
-.c21 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -22275,32 +25118,36 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
   flex-direction: column;
 }
 
-.c21 > * {
+.c22 > * {
   margin-top: 0;
   margin-bottom: 0;
 }
 
-.c21 > * + * {
+.c22 > * + * {
   margin-top: 8px;
 }
 
-.c27 {
+.c33 path {
+  fill: #666687;
+}
+
+.c3 {
+  cursor: pointer;
+}
+
+.c28 {
   border-radius: 50%;
   display: block;
   position: relative;
 }
 
-.c26 {
+.c27 {
   position: relative;
   width: 26px;
   height: 26px;
 }
 
-.c32 path {
-  fill: #666687;
-}
-
-.c12 {
+.c13 {
   height: 1px;
   border: none;
   margin: 0;
@@ -22317,7 +25164,7 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
   border-right: 1px solid #eaeaef;
 }
 
-.c30 {
+.c31 {
   background: #ffffff;
   border: 1px solid #eaeaef;
   border-radius: 4px;
@@ -22341,17 +25188,17 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
   height: 1.5625rem;
 }
 
-.c30 svg {
+.c31 svg {
   width: 0.375rem;
   height: 0.5625rem;
 }
 
-.c19 svg {
+.c20 svg {
   width: 1rem;
   height: 1rem;
 }
 
-.c15 {
+.c16 {
   position: relative;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -22360,44 +25207,44 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
   background: #ffffff;
 }
 
-.c15 .c7 {
+.c16 .c9 {
   color: #666687;
 }
 
-.c15 svg path {
+.c16 svg path {
   fill: #8e8ea9;
 }
 
-.c15:hover {
+.c16:hover {
   background: #f6f6f9;
 }
 
-.c15:hover .c7 {
+.c16:hover .c9 {
   color: #4a4a6a;
 }
 
-.c15:hover svg path {
+.c16:hover svg path {
   fill: #666687;
 }
 
-.c15.active {
+.c16.active {
   background: #f0f0ff;
 }
 
-.c15.active svg path {
+.c16.active svg path {
   fill: #4945ff;
 }
 
-.c15.active .c7 {
+.c16.active .c9 {
   color: #4945ff;
   font-weight: 500;
 }
 
-.c17 {
+.c18 {
   padding: 8px 12px;
 }
 
-.c25 {
+.c26 {
   -webkit-text-decoration: none;
   text-decoration: none;
   position: absolute;
@@ -22406,17 +25253,17 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
   border-top: 1px solid #eaeaef;
 }
 
-.c5 {
+.c7 {
   border-radius: 4px;
 }
 
-.c5 svg,
-.c5 img {
+.c7 svg,
+.c7 img {
   height: 2rem;
   width: 2rem;
 }
 
-.c9 {
+.c4 {
   -webkit-text-decoration: unset;
   text-decoration: unset;
   color: inherit;
@@ -22437,34 +25284,31 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
     <nav
       class="c2"
     >
-      <div
-        class="c3"
+      <a
+        class="c3 c4"
+        to="/"
       >
         <div
-          class="c4"
+          class="c5"
         >
-          <a
-            aria-current="page"
-            aria-hidden="true"
-            class="c5 active"
-            href="/"
-            tabindex="-1"
-          >
-            <img
-              alt=""
-              src="test-file-stub"
-            />
-          </a>
           <div
             class="c6"
           >
-            <span
-              class="c7 c8"
+            <div
+              aria-hidden="true"
+              class="c7"
+              tabindex="-1"
             >
-              <a
-                aria-current="page"
-                class="c9 active"
-                href="/"
+              <img
+                alt=""
+                src="test-file-stub"
+              />
+            </div>
+            <div
+              class="c8"
+            >
+              <span
+                class="c9 c10"
               >
                 Strapi Dashboard
                 <span
@@ -22472,40 +25316,40 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
                 >
                   Workplace
                 </span>
-              </a>
-            </span>
-            <p
-              aria-hidden="true"
-              class="c7 c10"
-            >
-              Workplace
-            </p>
+              </span>
+              <p
+                aria-hidden="true"
+                class="c9 c11"
+              >
+                Workplace
+              </p>
+            </div>
           </div>
         </div>
-      </div>
+      </a>
       <hr
-        class="c11 c12"
+        class="c12 c13"
       />
       <div
-        class="c13"
+        class="c14"
       >
         <ul
-          class="c14"
+          class="c15"
         >
           <li>
             <a
-              class="c15 active"
-              href="/cm"
+              class="c3 c16 active"
+              to="/cm"
             >
               <span
-                class="c16 c17"
+                class="c17 c18"
               >
                 <div
-                  class="c4"
+                  class="c6"
                 >
                   <span
                     aria-hidden="true"
-                    class="c18 c19"
+                    class="c19 c20"
                   >
                     <svg
                       fill="none"
@@ -22523,7 +25367,7 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
                     </svg>
                   </span>
                   <span
-                    class="c7 c20"
+                    class="c9 c21"
                   >
                     Content-type-builder
                   </span>
@@ -22531,38 +25375,36 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
               </span>
             </a>
           </li>
-          <li
-            class=""
-          >
+          <li>
             <div
-              class="c21"
+              class="c22"
             >
               <span
-                class="c22"
+                class="c23"
               >
                 <span
-                  class="c7 c23"
+                  class="c9 c24"
                 >
                   Plugins
                 </span>
               </span>
               <ul
-                class="c21"
+                class="c22"
               >
                 <li>
                   <a
-                    class="c15"
-                    href="/builder"
+                    class="c3 c16"
+                    to="/builder"
                   >
                     <span
-                      class="c16 c17"
+                      class="c17 c18"
                     >
                       <div
-                        class="c4"
+                        class="c6"
                       >
                         <span
                           aria-hidden="true"
-                          class="c18 c19"
+                          class="c19 c20"
                         >
                           <svg
                             fill="none"
@@ -22578,7 +25420,7 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c7 c20"
+                          class="c9 c21"
                         >
                           Builder
                         </span>
@@ -22588,18 +25430,18 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
                 </li>
                 <li>
                   <a
-                    class="c15"
-                    href="/content"
+                    class="c3 c16"
+                    to="/content"
                   >
                     <span
-                      class="c16 c17"
+                      class="c17 c18"
                     >
                       <div
-                        class="c4"
+                        class="c6"
                       >
                         <span
                           aria-hidden="true"
-                          class="c18 c19"
+                          class="c19 c20"
                         >
                           <svg
                             fill="none"
@@ -22617,7 +25459,7 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c7 c20"
+                          class="c9 c21"
                         >
                           Media library
                         </span>
@@ -22627,18 +25469,18 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
                 </li>
                 <li>
                   <a
-                    class="c15"
-                    href="/content"
+                    class="c3 c16"
+                    to="/content"
                   >
                     <span
-                      class="c16 c17"
+                      class="c17 c18"
                     >
                       <div
-                        class="c4"
+                        class="c6"
                       >
                         <span
                           aria-hidden="true"
-                          class="c18 c19"
+                          class="c19 c20"
                         >
                           <svg
                             fill="none"
@@ -22654,7 +25496,7 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c7 c20"
+                          class="c9 c21"
                         >
                           Documentation
                         </span>
@@ -22665,38 +25507,36 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
               </ul>
             </div>
           </li>
-          <li
-            class=""
-          >
+          <li>
             <div
-              class="c21"
+              class="c22"
             >
               <span
-                class="c22"
+                class="c23"
               >
                 <span
-                  class="c7 c23"
+                  class="c9 c24"
                 >
                   General
                 </span>
               </span>
               <ul
-                class="c21"
+                class="c22"
               >
                 <li>
                   <a
-                    class="c15"
-                    href="/builder"
+                    class="c3 c16"
+                    to="/builder"
                   >
                     <span
-                      class="c16 c17"
+                      class="c17 c18"
                     >
                       <div
-                        class="c4"
+                        class="c6"
                       >
                         <span
                           aria-hidden="true"
-                          class="c18 c19"
+                          class="c19 c20"
                         >
                           <svg
                             fill="none"
@@ -22714,7 +25554,7 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c7 c20"
+                          class="c9 c21"
                         >
                           Plugins
                         </span>
@@ -22724,18 +25564,18 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
                 </li>
                 <li>
                   <a
-                    class="c15"
-                    href="/content"
+                    class="c3 c16"
+                    to="/content"
                   >
                     <span
-                      class="c16 c17"
+                      class="c17 c18"
                     >
                       <div
-                        class="c4"
+                        class="c6"
                       >
                         <span
                           aria-hidden="true"
-                          class="c18 c19"
+                          class="c19 c20"
                         >
                           <svg
                             fill="none"
@@ -22753,7 +25593,7 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c7 c20"
+                          class="c9 c21"
                         >
                           Marketplace
                         </span>
@@ -22763,18 +25603,18 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
                 </li>
                 <li>
                   <a
-                    class="c15"
-                    href="/content"
+                    class="c3 c16"
+                    to="/content"
                   >
                     <span
-                      class="c16 c17"
+                      class="c17 c18"
                     >
                       <div
-                        class="c4"
+                        class="c6"
                       >
                         <span
                           aria-hidden="true"
-                          class="c18 c19"
+                          class="c19 c20"
                         >
                           <svg
                             fill="none"
@@ -22792,7 +25632,7 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c7 c20"
+                          class="c9 c21"
                         >
                           Settings
                         </span>
@@ -22806,19 +25646,19 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
         </ul>
       </div>
       <div
-        class="c24 c25"
+        class="c25 c26"
         to="/somewhere-i-belong"
       >
         <button
-          class="c4"
+          class="c6"
         >
           <span>
             <div
-              class="c26"
+              class="c27"
             >
               <img
                 alt=""
-                class="c27"
+                class="c28"
                 height="26px"
                 src="https://avatars.githubusercontent.com/u/3874873?v=4"
                 width="26px"
@@ -22826,11 +25666,11 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
             </div>
           </span>
           <span
-            class="c28"
+            class="c29"
             width="8.125rem"
           >
             <span
-              class="c7 c29"
+              class="c9 c30"
             >
               John Duff
             </span>
@@ -22838,11 +25678,11 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
         </button>
       </div>
       <button
-        class="c30"
+        class="c31"
       >
         <svg
           aria-hidden="true"
-          class="c31 c32"
+          class="c32 c33"
           fill="none"
           height="1em"
           viewBox="0 0 10 16"
@@ -22878,88 +25718,26 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
   width: 1px;
 }
 
-.c1 {
-  background: #f6f6f9;
-  padding: 56px;
-}
-
-.c3 {
-  padding-top: 16px;
-  padding-right: 12px;
-  padding-bottom: 16px;
-  padding-left: 12px;
-}
-
-.c6 {
-  padding-left: 8px;
-}
-
-.c11 {
-  background: #eaeaef;
-}
-
-.c13 {
-  padding-top: 12px;
-  padding-right: 8px;
-  padding-left: 12px;
-}
-
-.c18 {
-  padding-right: 12px;
-}
-
-.c22 {
-  background: #ffffff;
-  padding-top: 4px;
-  padding-right: 12px;
-  padding-bottom: 4px;
-  padding-left: 12px;
-  border-radius: 4px;
-}
-
-.c24 {
-  background: #f6f6f9;
-  padding: 4px;
-  border-radius: 4px;
-  min-width: 20px;
-}
-
-.c27 {
-  padding-top: 12px;
-  padding-right: 20px;
-  padding-bottom: 12px;
-  padding-left: 20px;
-}
-
-.c32 {
-  padding-left: 8px;
-  width: 8.125rem;
-}
-
-.c35 {
-  color: #666687;
-}
-
-.c8 {
+.c10 {
   font-weight: 600;
   color: #32324d;
   font-size: 0.875rem;
   line-height: 1.43;
 }
 
-.c10 {
+.c11 {
   color: #666687;
   font-size: 0.75rem;
   line-height: 1.33;
 }
 
-.c20 {
+.c21 {
   color: #32324d;
   font-size: 0.875rem;
   line-height: 1.43;
 }
 
-.c23 {
+.c24 {
   color: #666687;
   font-weight: 600;
   font-size: 0.6875rem;
@@ -22967,7 +25745,7 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
   text-transform: uppercase;
 }
 
-.c31 {
+.c32 {
   font-weight: 600;
   font-size: 0.6875rem;
   color: #ffffff;
@@ -22976,7 +25754,7 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
   line-height: 1.43;
 }
 
-.c33 {
+.c34 {
   color: #666687;
   display: block;
   white-space: nowrap;
@@ -22986,7 +25764,69 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
   line-height: 1.43;
 }
 
-.c4 {
+.c1 {
+  background: #f6f6f9;
+  padding: 56px;
+}
+
+.c5 {
+  padding-top: 16px;
+  padding-right: 12px;
+  padding-bottom: 16px;
+  padding-left: 12px;
+}
+
+.c8 {
+  padding-left: 8px;
+}
+
+.c12 {
+  background: #eaeaef;
+}
+
+.c14 {
+  padding-top: 12px;
+  padding-right: 8px;
+  padding-left: 12px;
+}
+
+.c19 {
+  padding-right: 12px;
+}
+
+.c23 {
+  background: #ffffff;
+  padding-top: 4px;
+  padding-right: 12px;
+  padding-bottom: 4px;
+  padding-left: 12px;
+  border-radius: 4px;
+}
+
+.c25 {
+  background: #f6f6f9;
+  padding: 4px;
+  border-radius: 4px;
+  min-width: 20px;
+}
+
+.c28 {
+  padding-top: 12px;
+  padding-right: 20px;
+  padding-bottom: 12px;
+  padding-left: 20px;
+}
+
+.c33 {
+  padding-left: 8px;
+  width: 8.125rem;
+}
+
+.c36 {
+  color: #666687;
+}
+
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -23000,7 +25840,7 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
   align-items: center;
 }
 
-.c16 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -23018,7 +25858,7 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
   align-items: center;
 }
 
-.c25 {
+.c26 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -23036,7 +25876,7 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
   align-items: center;
 }
 
-.c29 {
+.c30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -23054,7 +25894,7 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
   align-items: center;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -23064,16 +25904,16 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
   flex-direction: column;
 }
 
-.c14 > * {
+.c15 > * {
   margin-top: 0;
   margin-bottom: 0;
 }
 
-.c14 > * + * {
+.c15 > * + * {
   margin-top: 16px;
 }
 
-.c21 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -23083,31 +25923,35 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
   flex-direction: column;
 }
 
-.c21 > * {
+.c22 > * {
   margin-top: 0;
   margin-bottom: 0;
 }
 
-.c21 > * + * {
+.c22 > * + * {
   margin-top: 8px;
 }
 
-.c30 {
+.c37 path {
+  fill: #666687;
+}
+
+.c3 {
+  cursor: pointer;
+}
+
+.c31 {
   width: 26px;
   height: 26px;
   border-radius: 50%;
   background: linear-gradient( 157deg, #4945ff 0%, #7b79ff 50%, #d9d8ff 81%, #f0f0ff 96% );
 }
 
-.c30 span {
+.c31 span {
   line-height: 0;
 }
 
-.c36 path {
-  fill: #666687;
-}
-
-.c12 {
+.c13 {
   height: 1px;
   border: none;
   margin: 0;
@@ -23124,7 +25968,7 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
   border-right: 1px solid #eaeaef;
 }
 
-.c34 {
+.c35 {
   background: #ffffff;
   border: 1px solid #eaeaef;
   border-radius: 4px;
@@ -23148,17 +25992,17 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
   height: 1.5625rem;
 }
 
-.c34 svg {
+.c35 svg {
   width: 0.375rem;
   height: 0.5625rem;
 }
 
-.c19 svg {
+.c20 svg {
   width: 1rem;
   height: 1rem;
 }
 
-.c15 {
+.c16 {
   position: relative;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -23167,44 +26011,44 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
   background: #ffffff;
 }
 
-.c15 .c7 {
+.c16 .c9 {
   color: #666687;
 }
 
-.c15 svg path {
+.c16 svg path {
   fill: #8e8ea9;
 }
 
-.c15:hover {
+.c16:hover {
   background: #f6f6f9;
 }
 
-.c15:hover .c7 {
+.c16:hover .c9 {
   color: #4a4a6a;
 }
 
-.c15:hover svg path {
+.c16:hover svg path {
   fill: #666687;
 }
 
-.c15.active {
+.c16.active {
   background: #f0f0ff;
 }
 
-.c15.active svg path {
+.c16.active svg path {
   fill: #4945ff;
 }
 
-.c15.active .c7 {
+.c16.active .c9 {
   color: #4945ff;
   font-weight: 500;
 }
 
-.c17 {
+.c18 {
   padding: 8px 12px;
 }
 
-.c26 {
+.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -23224,12 +26068,12 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
   background: #4945ff;
 }
 
-.c26 .c7 {
+.c27 .c9 {
   color: #ffffff !important;
   line-height: 0;
 }
 
-.c28 {
+.c29 {
   -webkit-text-decoration: none;
   text-decoration: none;
   position: absolute;
@@ -23238,17 +26082,17 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
   border-top: 1px solid #eaeaef;
 }
 
-.c5 {
+.c7 {
   border-radius: 4px;
 }
 
-.c5 svg,
-.c5 img {
+.c7 svg,
+.c7 img {
   height: 2rem;
   width: 2rem;
 }
 
-.c9 {
+.c4 {
   -webkit-text-decoration: unset;
   text-decoration: unset;
   color: inherit;
@@ -23269,34 +26113,31 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
     <nav
       class="c2"
     >
-      <div
-        class="c3"
+      <a
+        class="c3 c4"
+        to="/"
       >
         <div
-          class="c4"
+          class="c5"
         >
-          <a
-            aria-current="page"
-            aria-hidden="true"
-            class="c5 active"
-            href="/"
-            tabindex="-1"
-          >
-            <img
-              alt=""
-              src="test-file-stub"
-            />
-          </a>
           <div
             class="c6"
           >
-            <span
-              class="c7 c8"
+            <div
+              aria-hidden="true"
+              class="c7"
+              tabindex="-1"
             >
-              <a
-                aria-current="page"
-                class="c9 active"
-                href="/"
+              <img
+                alt=""
+                src="test-file-stub"
+              />
+            </div>
+            <div
+              class="c8"
+            >
+              <span
+                class="c9 c10"
               >
                 Strapi Dashboard
                 <span
@@ -23304,40 +26145,40 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
                 >
                   Workplace
                 </span>
-              </a>
-            </span>
-            <p
-              aria-hidden="true"
-              class="c7 c10"
-            >
-              Workplace
-            </p>
+              </span>
+              <p
+                aria-hidden="true"
+                class="c9 c11"
+              >
+                Workplace
+              </p>
+            </div>
           </div>
         </div>
-      </div>
+      </a>
       <hr
-        class="c11 c12"
+        class="c12 c13"
       />
       <div
-        class="c13"
+        class="c14"
       >
         <ul
-          class="c14"
+          class="c15"
         >
           <li>
             <a
-              class="c15 active"
-              href="/cm"
+              class="c3 c16 active"
+              to="/cm"
             >
               <span
-                class="c16 c17"
+                class="c17 c18"
               >
                 <div
-                  class="c4"
+                  class="c6"
                 >
                   <span
                     aria-hidden="true"
-                    class="c18 c19"
+                    class="c19 c20"
                   >
                     <svg
                       fill="none"
@@ -23355,7 +26196,7 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
                     </svg>
                   </span>
                   <span
-                    class="c7 c20"
+                    class="c9 c21"
                   >
                     Content
                   </span>
@@ -23363,38 +26204,36 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
               </span>
             </a>
           </li>
-          <li
-            class=""
-          >
+          <li>
             <div
-              class="c21"
+              class="c22"
             >
               <span
-                class="c22"
+                class="c23"
               >
                 <span
-                  class="c7 c23"
+                  class="c9 c24"
                 >
                   Plugins
                 </span>
               </span>
               <ul
-                class="c21"
+                class="c22"
               >
                 <li>
                   <a
-                    class="c15"
-                    href="/builder"
+                    class="c3 c16"
+                    to="/builder"
                   >
                     <span
-                      class="c16 c17"
+                      class="c17 c18"
                     >
                       <div
-                        class="c4"
+                        class="c6"
                       >
                         <span
                           aria-hidden="true"
-                          class="c18 c19"
+                          class="c19 c20"
                         >
                           <svg
                             fill="none"
@@ -23410,7 +26249,7 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c7 c20"
+                          class="c9 c21"
                         >
                           Builder
                         </span>
@@ -23420,18 +26259,18 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
                 </li>
                 <li>
                   <a
-                    class="c15"
-                    href="/content"
+                    class="c3 c16"
+                    to="/content"
                   >
                     <span
-                      class="c16 c17"
+                      class="c17 c18"
                     >
                       <div
-                        class="c4"
+                        class="c6"
                       >
                         <span
                           aria-hidden="true"
-                          class="c18 c19"
+                          class="c19 c20"
                         >
                           <svg
                             fill="none"
@@ -23449,7 +26288,7 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c7 c20"
+                          class="c9 c21"
                         >
                           Media library
                         </span>
@@ -23459,18 +26298,18 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
                 </li>
                 <li>
                   <a
-                    class="c15"
-                    href="/content"
+                    class="c3 c16"
+                    to="/content"
                   >
                     <span
-                      class="c16 c17"
+                      class="c17 c18"
                     >
                       <div
-                        class="c4"
+                        class="c6"
                       >
                         <span
                           aria-hidden="true"
-                          class="c18 c19"
+                          class="c19 c20"
                         >
                           <svg
                             fill="none"
@@ -23486,7 +26325,7 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c7 c20"
+                          class="c9 c21"
                         >
                           Documentation
                         </span>
@@ -23497,38 +26336,36 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
               </ul>
             </div>
           </li>
-          <li
-            class=""
-          >
+          <li>
             <div
-              class="c21"
+              class="c22"
             >
               <span
-                class="c22"
+                class="c23"
               >
                 <span
-                  class="c7 c23"
+                  class="c9 c24"
                 >
                   General
                 </span>
               </span>
               <ul
-                class="c21"
+                class="c22"
               >
                 <li>
                   <a
-                    class="c15"
-                    href="/builder"
+                    class="c3 c16"
+                    to="/builder"
                   >
                     <span
-                      class="c16 c17"
+                      class="c17 c18"
                     >
                       <div
-                        class="c4"
+                        class="c6"
                       >
                         <span
                           aria-hidden="true"
-                          class="c18 c19"
+                          class="c19 c20"
                         >
                           <svg
                             fill="none"
@@ -23546,7 +26383,7 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c7 c20"
+                          class="c9 c21"
                         >
                           Plugins
                         </span>
@@ -23556,18 +26393,18 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
                 </li>
                 <li>
                   <a
-                    class="c15"
-                    href="/content"
+                    class="c3 c16"
+                    to="/content"
                   >
                     <span
-                      class="c16 c17"
+                      class="c17 c18"
                     >
                       <div
-                        class="c4"
+                        class="c6"
                       >
                         <span
                           aria-hidden="true"
-                          class="c18 c19"
+                          class="c19 c20"
                         >
                           <svg
                             fill="none"
@@ -23585,17 +26422,17 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c7 c20"
+                          class="c9 c21"
                         >
                           Marketplace
                         </span>
                       </div>
                       <div
                         aria-label="new content"
-                        class="c24 c25 c26"
+                        class="c25 c26 c27"
                       >
                         <span
-                          class="c7 c23"
+                          class="c9 c24"
                         >
                           new
                         </span>
@@ -23605,18 +26442,18 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
                 </li>
                 <li>
                   <a
-                    class="c15"
-                    href="/content"
+                    class="c3 c16"
+                    to="/content"
                   >
                     <span
-                      class="c16 c17"
+                      class="c17 c18"
                     >
                       <div
-                        class="c4"
+                        class="c6"
                       >
                         <span
                           aria-hidden="true"
-                          class="c18 c19"
+                          class="c19 c20"
                         >
                           <svg
                             fill="none"
@@ -23634,17 +26471,17 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c7 c20"
+                          class="c9 c21"
                         >
                           Settings
                         </span>
                       </div>
                       <div
                         aria-label="2 notifications"
-                        class="c24 c25 c26"
+                        class="c25 c26 c27"
                       >
                         <span
-                          class="c7 c23"
+                          class="c9 c24"
                         >
                           2
                         </span>
@@ -23658,26 +26495,26 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
         </ul>
       </div>
       <div
-        class="c27 c28"
+        class="c28 c29"
       >
         <button
-          class="c4"
+          class="c6"
         >
           <div
-            class="c29 c30"
+            class="c30 c31"
           >
             <span
-              class="c7 c31"
+              class="c9 c32"
             >
               MD
             </span>
           </div>
           <span
-            class="c32"
+            class="c33"
             width="8.125rem"
           >
             <span
-              class="c7 c33"
+              class="c9 c34"
             >
               Michka des Ronronscelestes
             </span>
@@ -23685,11 +26522,11 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
         </button>
       </div>
       <button
-        class="c34"
+        class="c35"
       >
         <svg
           aria-hidden="true"
-          class="c35 c36"
+          class="c36 c37"
           fill="none"
           height="1em"
           viewBox="0 0 10 16"
@@ -23884,6 +26721,19 @@ exports[`Storyshots Design System/Components/NumberInput base 1`] = `
   width: 1px;
 }
 
+.c4 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c14 {
+  color: #666687;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
 .c1 {
   padding: 56px;
 }
@@ -23904,19 +26754,6 @@ exports[`Storyshots Design System/Components/NumberInput base 1`] = `
 .c15 {
   background: #f6f6f9;
   padding: 16px;
-}
-
-.c4 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c14 {
-  color: #666687;
-  font-size: 0.75rem;
-  line-height: 1.33;
 }
 
 .c3 {
@@ -24097,7 +26934,7 @@ exports[`Storyshots Design System/Components/NumberInput base 1`] = `
         >
           <label
             class="c4"
-            for="numberinput-97"
+            for="numberinput-109"
           >
             Content
           </label>
@@ -24106,7 +26943,7 @@ exports[`Storyshots Design System/Components/NumberInput base 1`] = `
           >
             <span>
               <button
-                aria-describedby="tooltip-98"
+                aria-describedby="tooltip-110"
                 aria-label="Information about the email"
                 style="padding: 0px; background: transparent;"
                 tabindex="0"
@@ -24132,11 +26969,11 @@ exports[`Storyshots Design System/Components/NumberInput base 1`] = `
           class="c6 c7"
         >
           <input
-            aria-describedby="numberinput-97-hint"
+            aria-describedby="numberinput-109-hint"
             aria-disabled="false"
             aria-invalid="false"
             class="c8"
-            id="numberinput-97"
+            id="numberinput-109"
             name="content"
             placeholder="This is a content placeholder"
             type="text"
@@ -24195,7 +27032,7 @@ exports[`Storyshots Design System/Components/NumberInput base 1`] = `
         </div>
         <p
           class="c14"
-          id="numberinput-97-hint"
+          id="numberinput-109-hint"
         >
           Description line
         </p>
@@ -24226,19 +27063,6 @@ exports[`Storyshots Design System/Components/NumberInput disabled 1`] = `
   width: 1px;
 }
 
-.c1 {
-  padding: 56px;
-}
-
-.c8 {
-  padding-right: 12px;
-  padding-left: 8px;
-}
-
-.c10 {
-  color: #8e8ea9;
-}
-
 .c4 {
   font-weight: 600;
   color: #32324d;
@@ -24250,6 +27074,19 @@ exports[`Storyshots Design System/Components/NumberInput disabled 1`] = `
   color: #666687;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c1 {
+  padding: 56px;
+}
+
+.c8 {
+  padding-right: 12px;
+  padding-left: 8px;
+}
+
+.c10 {
+  color: #8e8ea9;
 }
 
 .c3 {
@@ -24435,7 +27272,7 @@ exports[`Storyshots Design System/Components/NumberInput disabled 1`] = `
         >
           <label
             class="c4"
-            for="numberinput-100"
+            for="numberinput-112"
           >
             Content
           </label>
@@ -24445,11 +27282,11 @@ exports[`Storyshots Design System/Components/NumberInput disabled 1`] = `
           disabled=""
         >
           <input
-            aria-describedby="numberinput-100-hint"
+            aria-describedby="numberinput-112-hint"
             aria-disabled="true"
             aria-invalid="false"
             class="c7"
-            id="numberinput-100"
+            id="numberinput-112"
             name="content"
             placeholder="This is a content placeholder"
             type="text"
@@ -24510,7 +27347,7 @@ exports[`Storyshots Design System/Components/NumberInput disabled 1`] = `
         </div>
         <p
           class="c13"
-          id="numberinput-100-hint"
+          id="numberinput-112-hint"
         >
           Description line
         </p>
@@ -24533,19 +27370,6 @@ exports[`Storyshots Design System/Components/NumberInput required 1`] = `
   width: 1px;
 }
 
-.c1 {
-  padding: 56px;
-}
-
-.c10 {
-  padding-right: 12px;
-  padding-left: 8px;
-}
-
-.c12 {
-  color: #8e8ea9;
-}
-
 .c4 {
   font-weight: 600;
   color: #32324d;
@@ -24563,6 +27387,19 @@ exports[`Storyshots Design System/Components/NumberInput required 1`] = `
   color: #666687;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c1 {
+  padding: 56px;
+}
+
+.c10 {
+  padding-right: 12px;
+  padding-left: 8px;
+}
+
+.c12 {
+  color: #8e8ea9;
 }
 
 .c3 {
@@ -24747,7 +27584,7 @@ exports[`Storyshots Design System/Components/NumberInput required 1`] = `
         >
           <label
             class="c4"
-            for="numberinput-101"
+            for="numberinput-113"
             required=""
           >
             Content
@@ -24762,11 +27599,11 @@ exports[`Storyshots Design System/Components/NumberInput required 1`] = `
           class="c7 c8"
         >
           <input
-            aria-describedby="numberinput-101-hint"
+            aria-describedby="numberinput-113-hint"
             aria-disabled="false"
             aria-invalid="false"
             class="c9"
-            id="numberinput-101"
+            id="numberinput-113"
             name="content"
             placeholder="This is a content placeholder"
             type="text"
@@ -24825,7 +27662,7 @@ exports[`Storyshots Design System/Components/NumberInput required 1`] = `
         </div>
         <p
           class="c15"
-          id="numberinput-101-hint"
+          id="numberinput-113-hint"
         >
           Description line
         </p>
@@ -24848,6 +27685,19 @@ exports[`Storyshots Design System/Components/NumberInput size S 1`] = `
   width: 1px;
 }
 
+.c4 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c14 {
+  color: #666687;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
 .c1 {
   padding: 56px;
 }
@@ -24868,19 +27718,6 @@ exports[`Storyshots Design System/Components/NumberInput size S 1`] = `
 .c15 {
   background: #f6f6f9;
   padding: 16px;
-}
-
-.c4 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c14 {
-  color: #666687;
-  font-size: 0.75rem;
-  line-height: 1.33;
 }
 
 .c3 {
@@ -25061,7 +27898,7 @@ exports[`Storyshots Design System/Components/NumberInput size S 1`] = `
         >
           <label
             class="c4"
-            for="numberinput-102"
+            for="numberinput-114"
           >
             Content
           </label>
@@ -25070,7 +27907,7 @@ exports[`Storyshots Design System/Components/NumberInput size S 1`] = `
           >
             <span>
               <button
-                aria-describedby="tooltip-103"
+                aria-describedby="tooltip-115"
                 aria-label="Information about the email"
                 style="padding: 0px; background: transparent;"
                 tabindex="0"
@@ -25096,11 +27933,11 @@ exports[`Storyshots Design System/Components/NumberInput size S 1`] = `
           class="c6 c7"
         >
           <input
-            aria-describedby="numberinput-102-hint"
+            aria-describedby="numberinput-114-hint"
             aria-disabled="false"
             aria-invalid="false"
             class="c8"
-            id="numberinput-102"
+            id="numberinput-114"
             name="content"
             placeholder="This is a content placeholder"
             type="text"
@@ -25159,7 +27996,7 @@ exports[`Storyshots Design System/Components/NumberInput size S 1`] = `
         </div>
         <p
           class="c14"
-          id="numberinput-102-hint"
+          id="numberinput-114-hint"
         >
           Description line
         </p>
@@ -25190,6 +28027,19 @@ exports[`Storyshots Design System/Components/NumberInput with initial 0 1`] = `
   width: 1px;
 }
 
+.c4 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c14 {
+  color: #666687;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
 .c1 {
   padding: 56px;
 }
@@ -25210,19 +28060,6 @@ exports[`Storyshots Design System/Components/NumberInput with initial 0 1`] = `
 .c15 {
   background: #f6f6f9;
   padding: 16px;
-}
-
-.c4 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c14 {
-  color: #666687;
-  font-size: 0.75rem;
-  line-height: 1.33;
 }
 
 .c3 {
@@ -25403,7 +28240,7 @@ exports[`Storyshots Design System/Components/NumberInput with initial 0 1`] = `
         >
           <label
             class="c4"
-            for="numberinput-105"
+            for="numberinput-117"
           >
             Content
           </label>
@@ -25412,7 +28249,7 @@ exports[`Storyshots Design System/Components/NumberInput with initial 0 1`] = `
           >
             <span>
               <button
-                aria-describedby="tooltip-106"
+                aria-describedby="tooltip-118"
                 aria-label="Information about the email"
                 style="padding: 0px; background: transparent;"
                 tabindex="0"
@@ -25438,11 +28275,11 @@ exports[`Storyshots Design System/Components/NumberInput with initial 0 1`] = `
           class="c6 c7"
         >
           <input
-            aria-describedby="numberinput-105-hint"
+            aria-describedby="numberinput-117-hint"
             aria-disabled="false"
             aria-invalid="false"
             class="c8"
-            id="numberinput-105"
+            id="numberinput-117"
             name="content"
             placeholder="This is a content placeholder"
             type="text"
@@ -25501,7 +28338,7 @@ exports[`Storyshots Design System/Components/NumberInput with initial 0 1`] = `
         </div>
         <p
           class="c14"
-          id="numberinput-105-hint"
+          id="numberinput-117-hint"
         >
           Description line
         </p>
@@ -25532,6 +28369,12 @@ exports[`Storyshots Design System/Components/NumberInput withoutLabel 1`] = `
   width: 1px;
 }
 
+.c11 {
+  color: #666687;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
 .c1 {
   padding: 56px;
 }
@@ -25548,12 +28391,6 @@ exports[`Storyshots Design System/Components/NumberInput withoutLabel 1`] = `
 .c12 {
   background: #f6f6f9;
   padding: 16px;
-}
-
-.c11 {
-  color: #666687;
-  font-size: 0.75rem;
-  line-height: 1.33;
 }
 
 .c3 {
@@ -25719,12 +28556,12 @@ exports[`Storyshots Design System/Components/NumberInput withoutLabel 1`] = `
           class="c3 c4"
         >
           <input
-            aria-describedby="numberinput-108-hint"
+            aria-describedby="numberinput-120-hint"
             aria-disabled="false"
             aria-invalid="false"
             aria-label="Content"
             class="c5"
-            id="numberinput-108"
+            id="numberinput-120"
             name="content"
             placeholder="This is a content placeholder"
             type="text"
@@ -25783,7 +28620,7 @@ exports[`Storyshots Design System/Components/NumberInput withoutLabel 1`] = `
         </div>
         <p
           class="c11"
-          id="numberinput-108-hint"
+          id="numberinput-120-hint"
         >
           Description line
         </p>
@@ -25814,14 +28651,14 @@ exports[`Storyshots Design System/Components/Pagination base 1`] = `
   width: 1px;
 }
 
-.c7 {
+.c8 {
   font-weight: 600;
   color: #32324d;
   font-size: 0.75rem;
   line-height: 1.33;
 }
 
-.c10 {
+.c11 {
   color: #32324d;
   font-size: 0.75rem;
   line-height: 1.33;
@@ -25841,15 +28678,19 @@ exports[`Storyshots Design System/Components/Pagination base 1`] = `
   align-items: center;
 }
 
+.c3 {
+  cursor: pointer;
+}
+
 .c2 > * + * {
   margin-left: 4px;
 }
 
-.c8 {
+.c9 {
   line-height: revert;
 }
 
-.c3 {
+.c4 {
   padding: 12px;
   border-radius: 4px;
   -webkit-text-decoration: none;
@@ -25862,7 +28703,7 @@ exports[`Storyshots Design System/Components/Pagination base 1`] = `
   outline: none;
 }
 
-.c3:after {
+.c4:after {
   -webkit-transition-property: all;
   transition-property: all;
   -webkit-transition-duration: 0.2s;
@@ -25877,55 +28718,11 @@ exports[`Storyshots Design System/Components/Pagination base 1`] = `
   border: 2px solid transparent;
 }
 
-.c3:focus-visible {
+.c4:focus-visible {
   outline: none;
 }
 
-.c3:focus-visible:after {
-  border-radius: 8px;
-  content: '';
-  position: absolute;
-  top: -5px;
-  bottom: -5px;
-  left: -5px;
-  right: -5px;
-  border: 2px solid #4945ff;
-}
-
-.c5 {
-  padding: 12px;
-  border-radius: 4px;
-  box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  position: relative;
-  outline: none;
-}
-
-.c5:after {
-  -webkit-transition-property: all;
-  transition-property: all;
-  -webkit-transition-duration: 0.2s;
-  transition-duration: 0.2s;
-  border-radius: 8px;
-  content: '';
-  position: absolute;
-  top: -4px;
-  bottom: -4px;
-  left: -4px;
-  right: -4px;
-  border: 2px solid transparent;
-}
-
-.c5:focus-visible {
-  outline: none;
-}
-
-.c5:focus-visible:after {
+.c4:focus-visible:after {
   border-radius: 8px;
   content: '';
   position: absolute;
@@ -25937,50 +28734,94 @@ exports[`Storyshots Design System/Components/Pagination base 1`] = `
 }
 
 .c6 {
+  padding: 12px;
+  border-radius: 4px;
+  box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  outline: none;
+}
+
+.c6:after {
+  -webkit-transition-property: all;
+  transition-property: all;
+  -webkit-transition-duration: 0.2s;
+  transition-duration: 0.2s;
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  left: -4px;
+  right: -4px;
+  border: 2px solid transparent;
+}
+
+.c6:focus-visible {
+  outline: none;
+}
+
+.c6:focus-visible:after {
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -5px;
+  bottom: -5px;
+  left: -5px;
+  right: -5px;
+  border: 2px solid #4945ff;
+}
+
+.c7 {
   color: #271fe0;
   background: #ffffff;
 }
 
-.c6:hover {
+.c7:hover {
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
 }
 
-.c9 {
+.c10 {
   color: #32324d;
 }
 
-.c9:hover {
+.c10:hover {
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
 }
 
-.c4 {
+.c5 {
   font-size: 0.7rem;
   pointer-events: none;
 }
 
-.c4 svg path {
+.c5 svg path {
   fill: #c0c0cf;
 }
 
-.c4:focus svg path,
-.c4:hover svg path {
+.c5:focus svg path,
+.c5:hover svg path {
   fill: #c0c0cf;
 }
 
-.c12 {
+.c13 {
   font-size: 0.7rem;
 }
 
-.c12 svg path {
+.c13 svg path {
   fill: #666687;
 }
 
-.c12:focus svg path,
-.c12:hover svg path {
+.c13:focus svg path,
+.c13:hover svg path {
   fill: #4a4a6a;
 }
 
-.c11 {
+.c12 {
   color: #32324d;
 }
 
@@ -26001,11 +28842,10 @@ exports[`Storyshots Design System/Components/Pagination base 1`] = `
     >
       <li>
         <a
-          aria-current="page"
           aria-disabled="true"
-          class="c3 c4 active"
-          href="/"
+          class="c3 c4 c5"
           tabindex="-1"
+          to="#"
         >
           <div
             class="c0"
@@ -26029,8 +28869,8 @@ exports[`Storyshots Design System/Components/Pagination base 1`] = `
       </li>
       <li>
         <a
-          class="c5 c6"
-          href="/1"
+          class="c3 c6 c7"
+          to="/1"
         >
           <div
             class="c0"
@@ -26039,7 +28879,7 @@ exports[`Storyshots Design System/Components/Pagination base 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="c7 c8"
+            class="c8 c9"
           >
             1
           </span>
@@ -26047,8 +28887,8 @@ exports[`Storyshots Design System/Components/Pagination base 1`] = `
       </li>
       <li>
         <a
-          class="c3 c9"
-          href="/2"
+          class="c3 c4 c10"
+          to="/2"
         >
           <div
             class="c0"
@@ -26057,7 +28897,7 @@ exports[`Storyshots Design System/Components/Pagination base 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="c10 c8"
+            class="c11 c9"
           >
             2
           </span>
@@ -26065,7 +28905,7 @@ exports[`Storyshots Design System/Components/Pagination base 1`] = `
       </li>
       <li>
         <div
-          class="c3 c11"
+          class="c4 c12"
         >
           <div
             class="c0"
@@ -26074,7 +28914,7 @@ exports[`Storyshots Design System/Components/Pagination base 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="c10 c8"
+            class="c11 c9"
           >
             …
           </span>
@@ -26082,8 +28922,8 @@ exports[`Storyshots Design System/Components/Pagination base 1`] = `
       </li>
       <li>
         <a
-          class="c3 c9"
-          href="/25"
+          class="c3 c4 c10"
+          to="/25"
         >
           <div
             class="c0"
@@ -26092,7 +28932,7 @@ exports[`Storyshots Design System/Components/Pagination base 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="c10 c8"
+            class="c11 c9"
           >
             25
           </span>
@@ -26100,8 +28940,8 @@ exports[`Storyshots Design System/Components/Pagination base 1`] = `
       </li>
       <li>
         <a
-          class="c3 c9"
-          href="/26"
+          class="c3 c4 c10"
+          to="/26"
         >
           <div
             class="c0"
@@ -26110,7 +28950,7 @@ exports[`Storyshots Design System/Components/Pagination base 1`] = `
           </div>
           <span
             aria-hidden="true"
-            class="c10 c8"
+            class="c11 c9"
           >
             26
           </span>
@@ -26119,8 +28959,8 @@ exports[`Storyshots Design System/Components/Pagination base 1`] = `
       <li>
         <a
           aria-disabled="false"
-          class="c3 c12"
-          href="/3"
+          class="c3 c4 c13"
+          to="/3"
         >
           <div
             class="c0"
@@ -26407,14 +29247,14 @@ exports[`Storyshots Design System/Components/Radio base 1`] = `
   width: 1px;
 }
 
-.c4 {
-  padding-left: 8px;
-}
-
 .c1 {
   color: #32324d;
   font-size: 0.875rem;
   line-height: 1.43;
+}
+
+.c4 {
+  padding-left: 8px;
 }
 
 .c3 {
@@ -26530,16 +29370,16 @@ exports[`Storyshots Design System/Components/Searchbar base 1`] = `
   width: 1px;
 }
 
-.c6 {
-  padding-right: 8px;
-  padding-left: 12px;
-}
-
 .c2 {
   font-weight: 600;
   color: #32324d;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c6 {
+  padding-right: 8px;
+  padding-left: 12px;
 }
 
 .c4 {
@@ -26686,7 +29526,7 @@ exports[`Storyshots Design System/Components/Searchbar base 1`] = `
         >
           <label
             class="c2"
-            for="field-109"
+            for="field-121"
           >
             Searching for a plugin
           </label>
@@ -26721,7 +29561,7 @@ exports[`Storyshots Design System/Components/Searchbar base 1`] = `
             aria-disabled="false"
             aria-invalid="false"
             class="c10"
-            id="field-109"
+            id="field-121"
             name="searchbar"
             placeholder="e.g: strapi-plugin-abcd"
             value=""
@@ -26746,16 +29586,16 @@ exports[`Storyshots Design System/Components/Searchbar disabled 1`] = `
   width: 1px;
 }
 
-.c6 {
-  padding-right: 8px;
-  padding-left: 12px;
-}
-
 .c2 {
   font-weight: 600;
   color: #32324d;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c6 {
+  padding-right: 8px;
+  padding-left: 12px;
 }
 
 .c4 {
@@ -26902,7 +29742,7 @@ exports[`Storyshots Design System/Components/Searchbar disabled 1`] = `
       >
         <label
           class="c2"
-          for="field-110"
+          for="field-122"
         >
           Searching for a plugin
         </label>
@@ -26938,7 +29778,7 @@ exports[`Storyshots Design System/Components/Searchbar disabled 1`] = `
           aria-disabled="true"
           aria-invalid="false"
           class="c10"
-          id="field-110"
+          id="field-122"
           name="searchbar"
           placeholder="e.g: strapi-plugin-abcd"
           value=""
@@ -26962,16 +29802,16 @@ exports[`Storyshots Design System/Components/Searchbar size S 1`] = `
   width: 1px;
 }
 
-.c6 {
-  padding-right: 8px;
-  padding-left: 12px;
-}
-
 .c2 {
   font-weight: 600;
   color: #32324d;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c6 {
+  padding-right: 8px;
+  padding-left: 12px;
 }
 
 .c4 {
@@ -27118,7 +29958,7 @@ exports[`Storyshots Design System/Components/Searchbar size S 1`] = `
         >
           <label
             class="c2"
-            for="field-111"
+            for="field-123"
           >
             Searching for a plugin
           </label>
@@ -27153,7 +29993,7 @@ exports[`Storyshots Design System/Components/Searchbar size S 1`] = `
             aria-disabled="false"
             aria-invalid="false"
             class="c10"
-            id="field-111"
+            id="field-123"
             name="searchbar"
             placeholder="e.g: strapi-plugin-abcd"
             value=""
@@ -27176,15 +30016,6 @@ exports[`Storyshots Design System/Components/Select base 1`] = `
   padding: 0;
   position: absolute;
   width: 1px;
-}
-
-.c11 {
-  padding-left: 12px;
-}
-
-.c12 {
-  padding-right: 16px;
-  padding-left: 16px;
 }
 
 .c3 {
@@ -27214,6 +30045,15 @@ exports[`Storyshots Design System/Components/Select base 1`] = `
   color: #666687;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c11 {
+  padding-left: 12px;
+}
+
+.c12 {
+  padding-right: 16px;
+  padding-left: 16px;
 }
 
 .c6 {
@@ -27499,15 +30339,6 @@ exports[`Storyshots Design System/Components/Select multi 1`] = `
   width: 1px;
 }
 
-.c9 {
-  padding-right: 16px;
-  padding-left: 16px;
-}
-
-.c11 {
-  padding-left: 12px;
-}
-
 .c3 {
   font-weight: 600;
   color: #32324d;
@@ -27529,6 +30360,15 @@ exports[`Storyshots Design System/Components/Select multi 1`] = `
   color: #666687;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c9 {
+  padding-right: 16px;
+  padding-left: 16px;
+}
+
+.c11 {
+  padding-left: 12px;
 }
 
 .c4 {
@@ -27791,15 +30631,6 @@ exports[`Storyshots Design System/Components/Select multi-nested 1`] = `
   width: 1px;
 }
 
-.c9 {
-  padding-right: 16px;
-  padding-left: 16px;
-}
-
-.c11 {
-  padding-left: 12px;
-}
-
 .c3 {
   font-weight: 600;
   color: #32324d;
@@ -27821,6 +30652,15 @@ exports[`Storyshots Design System/Components/Select multi-nested 1`] = `
   color: #666687;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c9 {
+  padding-right: 16px;
+  padding-left: 16px;
+}
+
+.c11 {
+  padding-left: 12px;
 }
 
 .c4 {
@@ -28083,15 +30923,6 @@ exports[`Storyshots Design System/Components/Select multi-withTags 1`] = `
   width: 1px;
 }
 
-.c11 {
-  padding-right: 16px;
-  padding-left: 16px;
-}
-
-.c13 {
-  padding-left: 12px;
-}
-
 .c3 {
   font-weight: 600;
   color: #32324d;
@@ -28113,6 +30944,15 @@ exports[`Storyshots Design System/Components/Select multi-withTags 1`] = `
   color: #666687;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c11 {
+  padding-right: 16px;
+  padding-left: 16px;
+}
+
+.c13 {
+  padding-left: 12px;
 }
 
 .c4 {
@@ -28408,15 +31248,6 @@ exports[`Storyshots Design System/Components/Select size-S 1`] = `
   width: 1px;
 }
 
-.c9 {
-  padding-right: 16px;
-  padding-left: 16px;
-}
-
-.c12 {
-  padding-left: 12px;
-}
-
 .c3 {
   font-weight: 600;
   color: #32324d;
@@ -28438,6 +31269,15 @@ exports[`Storyshots Design System/Components/Select size-S 1`] = `
   color: #666687;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c9 {
+  padding-right: 16px;
+  padding-left: 16px;
+}
+
+.c12 {
+  padding-left: 12px;
 }
 
 .c4 {
@@ -28705,15 +31545,6 @@ exports[`Storyshots Design System/Components/Select withoutLabel 1`] = `
   width: 1px;
 }
 
-.c8 {
-  padding-left: 12px;
-}
-
-.c9 {
-  padding-right: 16px;
-  padding-left: 16px;
-}
-
 .c10 {
   color: #666687;
   display: block;
@@ -28728,6 +31559,15 @@ exports[`Storyshots Design System/Components/Select withoutLabel 1`] = `
   color: #666687;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c8 {
+  padding-left: 12px;
+}
+
+.c9 {
+  padding-right: 16px;
+  padding-left: 16px;
 }
 
 .c3 {
@@ -28997,15 +31837,15 @@ exports[`Storyshots Design System/Components/SimpleMenu base 1`] = `
   width: 1px;
 }
 
-.c6 {
-  padding-left: 8px;
-}
-
 .c4 {
   font-weight: 600;
   color: #32324d;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c6 {
+  padding-left: 8px;
 }
 
 .c1 {
@@ -29220,15 +32060,15 @@ exports[`Storyshots Design System/Components/SimpleMenu with-custom-label 1`] = 
   width: 1px;
 }
 
-.c6 {
-  padding-left: 8px;
-}
-
 .c4 {
   font-weight: 600;
   color: #32324d;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c6 {
+  padding-left: 8px;
 }
 
 .c1 {
@@ -29388,7 +32228,7 @@ exports[`Storyshots Design System/Components/SimpleMenu with-custom-label 1`] = 
   </div>
   <div>
     <button
-      aria-controls="simplemenu-112"
+      aria-controls="simplemenu-124"
       aria-disabled="false"
       aria-expanded="false"
       aria-haspopup="true"
@@ -29555,11 +32395,11 @@ exports[`Storyshots Design System/Components/SimpleMenu with-iconbutton 1`] = `
   <div>
     <span>
       <button
-        aria-controls="simplemenu-113"
+        aria-controls="simplemenu-125"
         aria-disabled="false"
         aria-expanded="false"
         aria-haspopup="true"
-        aria-labelledby="tooltip-114"
+        aria-labelledby="tooltip-126"
         class="c1 c2"
         tabindex="0"
         type="button"
@@ -29597,15 +32437,15 @@ exports[`Storyshots Design System/Components/SimpleMenu with-links 1`] = `
   width: 1px;
 }
 
-.c6 {
-  padding-left: 8px;
-}
-
 .c4 {
   font-weight: 600;
   color: #32324d;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c6 {
+  padding-left: 8px;
 }
 
 .c1 {
@@ -29765,7 +32605,7 @@ exports[`Storyshots Design System/Components/SimpleMenu with-links 1`] = `
   </div>
   <div>
     <button
-      aria-controls="simplemenu-116"
+      aria-controls="simplemenu-128"
       aria-disabled="false"
       aria-expanded="false"
       aria-haspopup="true"
@@ -29820,6 +32660,19 @@ exports[`Storyshots Design System/Components/Status base 1`] = `
   width: 1px;
 }
 
+.c7 {
+  color: #32324d;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
+.c8 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
 .c2 {
   background: #eafbe7;
   padding-top: 16px;
@@ -29840,19 +32693,6 @@ exports[`Storyshots Design System/Components/Status base 1`] = `
   border-radius: 4px;
   border-color: #b8e1ff;
   border: 1px solid #b8e1ff;
-}
-
-.c7 {
-  color: #32324d;
-  font-size: 0.875rem;
-  line-height: 1.43;
-}
-
-.c8 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.875rem;
-  line-height: 1.43;
 }
 
 .c4 {
@@ -29982,6 +32822,40 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   width: 1px;
 }
 
+.c7 {
+  color: #32324d;
+  font-weight: 600;
+  font-size: 1.125rem;
+  line-height: 1.22;
+}
+
+.c21 {
+  color: #666687;
+  font-weight: 600;
+  font-size: 0.6875rem;
+  line-height: 1.45;
+  text-transform: uppercase;
+}
+
+.c30 {
+  color: #32324d;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
+.c34 {
+  color: #4945ff;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c39 {
+  font-weight: 500;
+  color: #32324d;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
 .c2 {
   padding: 56px;
 }
@@ -30054,40 +32928,6 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   padding-right: 16px;
 }
 
-.c7 {
-  color: #32324d;
-  font-weight: 600;
-  font-size: 1.125rem;
-  line-height: 1.22;
-}
-
-.c21 {
-  color: #666687;
-  font-weight: 600;
-  font-size: 0.6875rem;
-  line-height: 1.45;
-  text-transform: uppercase;
-}
-
-.c30 {
-  color: #32324d;
-  font-size: 0.875rem;
-  line-height: 1.43;
-}
-
-.c34 {
-  color: #4945ff;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c39 {
-  font-weight: 500;
-  color: #32324d;
-  font-size: 0.875rem;
-  line-height: 1.43;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -30154,6 +32994,63 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c32 {
+  background: transparent;
+  border: none;
+  position: relative;
+  outline: none;
+}
+
+.c32[aria-disabled='true'] {
+  pointer-events: none;
+}
+
+.c32[aria-disabled='true'] svg path {
+  fill: #666687;
+}
+
+.c32 svg {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 0.625rem;
+}
+
+.c32 svg path {
+  fill: #4945ff;
+}
+
+.c32:after {
+  -webkit-transition-property: all;
+  transition-property: all;
+  -webkit-transition-duration: 0.2s;
+  transition-duration: 0.2s;
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  left: -4px;
+  right: -4px;
+  border: 2px solid transparent;
+}
+
+.c32:focus-visible {
+  outline: none;
+}
+
+.c32:focus-visible:after {
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -5px;
+  bottom: -5px;
+  left: -5px;
+  right: -5px;
+  border: 2px solid #4945ff;
 }
 
 .c15 {
@@ -30443,63 +33340,6 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   align-items: center;
 }
 
-.c32 {
-  background: transparent;
-  border: none;
-  position: relative;
-  outline: none;
-}
-
-.c32[aria-disabled='true'] {
-  pointer-events: none;
-}
-
-.c32[aria-disabled='true'] svg path {
-  fill: #666687;
-}
-
-.c32 svg {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  font-size: 0.625rem;
-}
-
-.c32 svg path {
-  fill: #4945ff;
-}
-
-.c32:after {
-  -webkit-transition-property: all;
-  transition-property: all;
-  -webkit-transition-duration: 0.2s;
-  transition-duration: 0.2s;
-  border-radius: 8px;
-  content: '';
-  position: absolute;
-  top: -4px;
-  bottom: -4px;
-  left: -4px;
-  right: -4px;
-  border: 2px solid transparent;
-}
-
-.c32:focus-visible {
-  outline: none;
-}
-
-.c32:focus-visible:after {
-  border-radius: 8px;
-  content: '';
-  position: absolute;
-  top: -5px;
-  bottom: -5px;
-  left: -5px;
-  right: -5px;
-  border: 2px solid #4945ff;
-}
-
 <main>
   <div
     class="c0"
@@ -30533,7 +33373,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
             <span>
               <button
                 aria-disabled="false"
-                aria-labelledby="tooltip-118"
+                aria-labelledby="tooltip-130"
                 class="c8 c9"
                 tabindex="0"
                 type="button"
@@ -30571,509 +33411,525 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
           >
             <li>
               <div
-                class="c16 c17"
+                class=""
               >
                 <div
-                  class="c18"
+                  class="c16 c17"
                 >
-                  <button
-                    aria-controls="subnav-list-120"
-                    aria-expanded="true"
-                    class="c1 c19"
+                  <div
+                    class="c18"
                   >
+                    <button
+                      aria-controls="subnav-list-132"
+                      aria-expanded="true"
+                      class="c1 c19"
+                    >
+                      <div
+                        class="c20"
+                      >
+                        <span
+                          class="c6 c21"
+                        >
+                          Collection Type
+                        </span>
+                      </div>
+                      <div
+                        class="c22"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          fill="none"
+                          height="1em"
+                          viewBox="0 0 14 8"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
+                            fill="#32324D"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
                     <div
-                      class="c20"
+                      class="c23 c24 c25"
                     >
                       <span
                         class="c6 c21"
                       >
-                        Collection Type
+                        4
                       </span>
                     </div>
-                    <div
-                      class="c22"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        fill="none"
-                        height="1em"
-                        viewBox="0 0 14 8"
-                        width="1em"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          clip-rule="evenodd"
-                          d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
-                          fill="#32324D"
-                          fill-rule="evenodd"
-                        />
-                      </svg>
-                    </div>
-                  </button>
-                  <div
-                    class="c23 c24 c25"
-                  >
-                    <span
-                      class="c6 c21"
-                    >
-                      4
-                    </span>
                   </div>
                 </div>
-              </div>
-              <ul
-                id="subnav-list-120"
-              >
-                <li>
-                  <a
-                    class="c26 c27"
-                    href="/address"
-                  >
-                    <div
-                      class="c1"
-                    >
-                      <svg
-                        class="c28"
-                        fill="none"
-                        height="1em"
-                        viewBox="0 0 4 4"
-                        width="1em"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="#A5A5BA"
-                          height="4"
-                          rx="2"
-                          width="4"
-                        />
-                      </svg>
-                      <div
-                        class="c29"
-                      >
-                        <span
-                          class="c6 c30"
-                        >
-                          Addresses
-                        </span>
-                      </div>
-                    </div>
-                  </a>
-                </li>
-                <li>
-                  <a
-                    class="c26 c27"
-                    href="/category"
-                  >
-                    <div
-                      class="c1"
-                    >
-                      <svg
-                        class="c28"
-                        fill="none"
-                        height="1em"
-                        viewBox="0 0 4 4"
-                        width="1em"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="#A5A5BA"
-                          height="4"
-                          rx="2"
-                          width="4"
-                        />
-                      </svg>
-                      <div
-                        class="c29"
-                      >
-                        <span
-                          class="c6 c30"
-                        >
-                          Categories
-                        </span>
-                      </div>
-                    </div>
-                  </a>
-                </li>
-                <li>
-                  <a
-                    class="c26 c27"
-                    href="/city"
-                  >
-                    <div
-                      class="c1"
-                    >
-                      <svg
-                        class="c28"
-                        fill="none"
-                        height="1em"
-                        viewBox="0 0 4 4"
-                        width="1em"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="#A5A5BA"
-                          height="4"
-                          rx="2"
-                          width="4"
-                        />
-                      </svg>
-                      <div
-                        class="c29"
-                      >
-                        <span
-                          class="c6 c30"
-                        >
-                          Cities
-                        </span>
-                      </div>
-                    </div>
-                  </a>
-                </li>
-                <li>
-                  <a
-                    class="c26 c27"
-                    href="/country"
-                  >
-                    <div
-                      class="c1"
-                    >
-                      <svg
-                        class="c28"
-                        fill="none"
-                        height="1em"
-                        viewBox="0 0 4 4"
-                        width="1em"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="#A5A5BA"
-                          height="4"
-                          rx="2"
-                          width="4"
-                        />
-                      </svg>
-                      <div
-                        class="c29"
-                      >
-                        <span
-                          class="c6 c30"
-                        >
-                          Countries
-                        </span>
-                      </div>
-                    </div>
-                  </a>
-                </li>
-              </ul>
-            </li>
-            <li
-              class="c31"
-            >
-              <button
-                aria-disabled="false"
-                class="c1 c32"
-                type="button"
-              >
-                <span
-                  aria-hidden="true"
-                  class="c33"
+                <ul
+                  id="subnav-list-132"
                 >
-                  <svg
-                    fill="none"
-                    height="1em"
-                    viewBox="0 0 24 24"
-                    width="1em"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M24 13.604a.3.3 0 01-.3.3h-9.795V23.7a.3.3 0 01-.3.3h-3.21a.3.3 0 01-.3-.3v-9.795H.3a.3.3 0 01-.3-.3v-3.21a.3.3 0 01.3-.3h9.795V.3a.3.3 0 01.3-.3h3.21a.3.3 0 01.3.3v9.795H23.7a.3.3 0 01.3.3v3.21z"
-                      fill="#212134"
-                    />
-                  </svg>
-                </span>
-                <span
-                  class="c6 c34"
-                >
-                  Click on me
-                </span>
-              </button>
-            </li>
-            <li>
-              <div
-                class="c16 c17"
-              >
-                <div
-                  class="c18"
-                >
-                  <button
-                    aria-controls="subnav-list-121"
-                    aria-expanded="true"
-                    class="c1 c19"
-                  >
+                  <li>
                     <div
-                      class="c20"
+                      class="c26 c27"
+                      to="/address"
                     >
-                      <span
-                        class="c6 c21"
+                      <div
+                        class="c1"
                       >
-                        Single Type
-                      </span>
-                    </div>
-                    <div
-                      class="c22"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        fill="none"
-                        height="1em"
-                        viewBox="0 0 14 8"
-                        width="1em"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          clip-rule="evenodd"
-                          d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
-                          fill="#32324D"
-                          fill-rule="evenodd"
-                        />
-                      </svg>
-                    </div>
-                  </button>
-                  <div
-                    class="c23 c24 c25"
-                  >
-                    <span
-                      class="c6 c21"
-                    >
-                      4
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <ul
-                id="subnav-list-121"
-              >
-                <li>
-                  <div
-                    class="c35 c36"
-                  >
-                    <div
-                      class="c18"
-                    >
-                      <button
-                        aria-controls="subnav-list-122"
-                        aria-expanded="true"
-                        class="c37"
-                      >
-                        <div
-                          class="c38"
+                        <svg
+                          class="c28"
+                          fill="none"
+                          height="1em"
+                          viewBox="0 0 4 4"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <svg
-                            aria-hidden="true"
-                            fill="none"
-                            height="1em"
-                            viewBox="0 0 14 8"
-                            width="1em"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              clip-rule="evenodd"
-                              d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
-                              fill="#32324D"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
+                          <rect
+                            fill="#A5A5BA"
+                            height="4"
+                            rx="2"
+                            width="4"
+                          />
+                        </svg>
                         <div
                           class="c29"
                         >
                           <span
-                            class="c6 c39"
+                            class="c6 c30"
                           >
-                            Default
+                            Addresses
                           </span>
                         </div>
-                      </button>
+                      </div>
+                    </div>
+                  </li>
+                  <li>
+                    <div
+                      class="c26 c27"
+                      to="/category"
+                    >
+                      <div
+                        class="c1"
+                      >
+                        <svg
+                          class="c28"
+                          fill="none"
+                          height="1em"
+                          viewBox="0 0 4 4"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            fill="#A5A5BA"
+                            height="4"
+                            rx="2"
+                            width="4"
+                          />
+                        </svg>
+                        <div
+                          class="c29"
+                        >
+                          <span
+                            class="c6 c30"
+                          >
+                            Categories
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </li>
+                  <li>
+                    <div
+                      class="c26 c27"
+                      to="/city"
+                    >
+                      <div
+                        class="c1"
+                      >
+                        <svg
+                          class="c28"
+                          fill="none"
+                          height="1em"
+                          viewBox="0 0 4 4"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            fill="#A5A5BA"
+                            height="4"
+                            rx="2"
+                            width="4"
+                          />
+                        </svg>
+                        <div
+                          class="c29"
+                        >
+                          <span
+                            class="c6 c30"
+                          >
+                            Cities
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </li>
+                  <li>
+                    <div
+                      class="c26 c27"
+                      to="/country"
+                    >
+                      <div
+                        class="c1"
+                      >
+                        <svg
+                          class="c28"
+                          fill="none"
+                          height="1em"
+                          viewBox="0 0 4 4"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            fill="#A5A5BA"
+                            height="4"
+                            rx="2"
+                            width="4"
+                          />
+                        </svg>
+                        <div
+                          class="c29"
+                        >
+                          <span
+                            class="c6 c30"
+                          >
+                            Countries
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li>
+              <div
+                class="c31"
+              >
+                <button
+                  aria-disabled="false"
+                  class="c1 c32"
+                  type="button"
+                >
+                  <span
+                    aria-hidden="true"
+                    class="c33"
+                  >
+                    <svg
+                      fill="none"
+                      height="1em"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M24 13.604a.3.3 0 01-.3.3h-9.795V23.7a.3.3 0 01-.3.3h-3.21a.3.3 0 01-.3-.3v-9.795H.3a.3.3 0 01-.3-.3v-3.21a.3.3 0 01.3-.3h9.795V.3a.3.3 0 01.3-.3h3.21a.3.3 0 01.3.3v9.795H23.7a.3.3 0 01.3.3v3.21z"
+                        fill="#212134"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="c6 c34"
+                  >
+                    Click on me
+                  </span>
+                </button>
+              </div>
+            </li>
+            <li>
+              <div
+                class=""
+              >
+                <div
+                  class="c16 c17"
+                >
+                  <div
+                    class="c18"
+                  >
+                    <button
+                      aria-controls="subnav-list-133"
+                      aria-expanded="true"
+                      class="c1 c19"
+                    >
+                      <div
+                        class="c20"
+                      >
+                        <span
+                          class="c6 c21"
+                        >
+                          Single Type
+                        </span>
+                      </div>
+                      <div
+                        class="c22"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          fill="none"
+                          height="1em"
+                          viewBox="0 0 14 8"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
+                            fill="#32324D"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                    <div
+                      class="c23 c24 c25"
+                    >
+                      <span
+                        class="c6 c21"
+                      >
+                        4
+                      </span>
                     </div>
                   </div>
-                  <ul
-                    id="subnav-list-122"
-                  >
-                    <li>
-                      <a
-                        class="c26 c27"
-                        href="/address"
+                </div>
+                <ul
+                  id="subnav-list-133"
+                >
+                  <li>
+                    <div
+                      class=""
+                    >
+                      <div
+                        class="c35 c36"
                       >
                         <div
-                          class="c1"
+                          class="c18"
                         >
-                          <svg
-                            class="c28"
-                            fill="none"
-                            height="1em"
-                            viewBox="0 0 4 4"
-                            width="1em"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <button
+                            aria-controls="subnav-list-134"
+                            aria-expanded="true"
+                            class="c37"
                           >
-                            <rect
-                              fill="#A5A5BA"
-                              height="4"
-                              rx="2"
-                              width="4"
-                            />
-                          </svg>
-                          <div
-                            class="c29"
-                          >
-                            <span
-                              class="c6 c30"
+                            <div
+                              class="c38"
                             >
-                              Addresses
-                            </span>
-                          </div>
+                              <svg
+                                aria-hidden="true"
+                                fill="none"
+                                height="1em"
+                                viewBox="0 0 14 8"
+                                width="1em"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
+                                  fill="#32324D"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="c29"
+                            >
+                              <span
+                                class="c6 c39"
+                              >
+                                Default
+                              </span>
+                            </div>
+                          </button>
                         </div>
-                      </a>
-                    </li>
-                    <li>
-                      <a
-                        class="c26 c27"
-                        href="/category"
+                      </div>
+                      <ul
+                        id="subnav-list-134"
                       >
-                        <div
-                          class="c1"
-                        >
-                          <svg
-                            class="c28"
-                            fill="none"
-                            height="1em"
-                            viewBox="0 0 4 4"
-                            width="1em"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <rect
-                              fill="#A5A5BA"
-                              height="4"
-                              rx="2"
-                              width="4"
-                            />
-                          </svg>
+                        <li>
                           <div
-                            class="c29"
+                            class="c26 c27"
+                            to="/address"
                           >
-                            <span
-                              class="c6 c30"
+                            <div
+                              class="c1"
                             >
-                              Categories
-                            </span>
+                              <svg
+                                class="c28"
+                                fill="none"
+                                height="1em"
+                                viewBox="0 0 4 4"
+                                width="1em"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <rect
+                                  fill="#A5A5BA"
+                                  height="4"
+                                  rx="2"
+                                  width="4"
+                                />
+                              </svg>
+                              <div
+                                class="c29"
+                              >
+                                <span
+                                  class="c6 c30"
+                                >
+                                  Addresses
+                                </span>
+                              </div>
+                            </div>
                           </div>
-                        </div>
-                      </a>
-                    </li>
-                    <li>
-                      <a
-                        class="c26 c27"
-                        href="/city"
-                      >
-                        <div
-                          class="c1"
-                        >
-                          <svg
-                            class="c28"
-                            fill="none"
-                            height="1em"
-                            viewBox="0 0 4 4"
-                            width="1em"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <rect
-                              fill="#A5A5BA"
-                              height="4"
-                              rx="2"
-                              width="4"
-                            />
-                          </svg>
+                        </li>
+                        <li>
                           <div
-                            class="c29"
+                            class="c26 c27"
+                            to="/category"
                           >
-                            <span
-                              class="c6 c30"
+                            <div
+                              class="c1"
                             >
-                              Cities
-                            </span>
+                              <svg
+                                class="c28"
+                                fill="none"
+                                height="1em"
+                                viewBox="0 0 4 4"
+                                width="1em"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <rect
+                                  fill="#A5A5BA"
+                                  height="4"
+                                  rx="2"
+                                  width="4"
+                                />
+                              </svg>
+                              <div
+                                class="c29"
+                              >
+                                <span
+                                  class="c6 c30"
+                                >
+                                  Categories
+                                </span>
+                              </div>
+                            </div>
                           </div>
-                        </div>
-                      </a>
-                    </li>
-                    <li>
-                      <a
-                        class="c26 c27"
-                        href="/country"
-                      >
-                        <div
-                          class="c1"
-                        >
-                          <svg
-                            class="c28"
-                            fill="none"
-                            height="1em"
-                            viewBox="0 0 4 4"
-                            width="1em"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <rect
-                              fill="#A5A5BA"
-                              height="4"
-                              rx="2"
-                              width="4"
-                            />
-                          </svg>
+                        </li>
+                        <li>
                           <div
-                            class="c29"
+                            class="c26 c27"
+                            to="/city"
                           >
-                            <span
-                              class="c6 c30"
+                            <div
+                              class="c1"
                             >
-                              Countries
-                            </span>
+                              <svg
+                                class="c28"
+                                fill="none"
+                                height="1em"
+                                viewBox="0 0 4 4"
+                                width="1em"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <rect
+                                  fill="#A5A5BA"
+                                  height="4"
+                                  rx="2"
+                                  width="4"
+                                />
+                              </svg>
+                              <div
+                                class="c29"
+                              >
+                                <span
+                                  class="c6 c30"
+                                >
+                                  Cities
+                                </span>
+                              </div>
+                            </div>
                           </div>
-                        </div>
-                      </a>
-                    </li>
-                  </ul>
-                </li>
-              </ul>
+                        </li>
+                        <li>
+                          <div
+                            class="c26 c27"
+                            to="/country"
+                          >
+                            <div
+                              class="c1"
+                            >
+                              <svg
+                                class="c28"
+                                fill="none"
+                                height="1em"
+                                viewBox="0 0 4 4"
+                                width="1em"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <rect
+                                  fill="#A5A5BA"
+                                  height="4"
+                                  rx="2"
+                                  width="4"
+                                />
+                              </svg>
+                              <div
+                                class="c29"
+                              >
+                                <span
+                                  class="c6 c30"
+                                >
+                                  Countries
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </li>
+                      </ul>
+                    </div>
+                  </li>
+                </ul>
+              </div>
             </li>
-            <li
-              class="c31"
-            >
-              <button
-                aria-disabled="false"
-                class="c1 c32"
-                type="button"
+            <li>
+              <div
+                class="c31"
               >
-                <span
-                  aria-hidden="true"
-                  class="c33"
+                <button
+                  aria-disabled="false"
+                  class="c1 c32"
+                  type="button"
                 >
-                  <svg
-                    fill="none"
-                    height="1em"
-                    viewBox="0 0 24 24"
-                    width="1em"
-                    xmlns="http://www.w3.org/2000/svg"
+                  <span
+                    aria-hidden="true"
+                    class="c33"
                   >
-                    <path
-                      d="M24 13.604a.3.3 0 01-.3.3h-9.795V23.7a.3.3 0 01-.3.3h-3.21a.3.3 0 01-.3-.3v-9.795H.3a.3.3 0 01-.3-.3v-3.21a.3.3 0 01.3-.3h9.795V.3a.3.3 0 01.3-.3h3.21a.3.3 0 01.3.3v9.795H23.7a.3.3 0 01.3.3v3.21z"
-                      fill="#212134"
-                    />
-                  </svg>
-                </span>
-                <span
-                  class="c6 c34"
-                >
-                  Click on me
-                </span>
-              </button>
+                    <svg
+                      fill="none"
+                      height="1em"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M24 13.604a.3.3 0 01-.3.3h-9.795V23.7a.3.3 0 01-.3.3h-3.21a.3.3 0 01-.3-.3v-9.795H.3a.3.3 0 01-.3-.3v-3.21a.3.3 0 01.3-.3h9.795V.3a.3.3 0 01.3-.3h3.21a.3.3 0 01.3.3v9.795H23.7a.3.3 0 01.3.3v3.21z"
+                        fill="#212134"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="c6 c34"
+                  >
+                    Click on me
+                  </span>
+                </button>
+              </div>
             </li>
           </ul>
         </div>
@@ -31114,9 +33970,9 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
             class="c15"
           >
             <li>
-              <a
+              <div
                 class="c26 c27 active"
-                href="/blabla"
+                to="/blabla"
               >
                 <div
                   class="c1"
@@ -31148,7 +34004,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c1 sc-gsDKAQ c41"
+                  class="c1 sc-dkPtRN c41"
                 >
                   <svg
                     class="c42"
@@ -31166,205 +34022,217 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                     />
                   </svg>
                 </div>
-              </a>
+              </div>
             </li>
             <li>
               <div
-                class="c16 c17"
+                class=""
               >
                 <div
-                  class="c18"
+                  class="c16 c17"
                 >
                   <div
-                    class="c1 c19"
+                    class="c18"
                   >
                     <div
-                      class="c20"
+                      class="c1 c19"
                     >
-                      <span
-                        class="c6 c21"
+                      <div
+                        class="c20"
                       >
-                        Global Settings
-                      </span>
+                        <span
+                          class="c6 c21"
+                        >
+                          Global Settings
+                        </span>
+                      </div>
                     </div>
                   </div>
                 </div>
+                <ul
+                  id="subnav-list-136"
+                >
+                  <li>
+                    <div
+                      class="c26 c27"
+                      to="/address"
+                    >
+                      <div
+                        class="c1"
+                      >
+                        <div
+                          class="c40"
+                        >
+                          <svg
+                            fill="none"
+                            height="1em"
+                            viewBox="0 0 24 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M12 0C5.383 0 0 5.383 0 12s5.383 12 12 12 12-5.383 12-12S18.617 0 12 0zm1.154 18.456h-2.308V16.15h2.308v2.307zm-.23-3.687h-1.847l-.346-9.23h2.538l-.346 9.23z"
+                              fill="#212134"
+                            />
+                          </svg>
+                        </div>
+                        <div
+                          class="c29"
+                        >
+                          <span
+                            class="c6 c30"
+                          >
+                            Addresses
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </li>
+                  <li />
+                  <li>
+                    <div
+                      class="c26 c27"
+                      to="/city"
+                    >
+                      <div
+                        class="c1"
+                      >
+                        <div
+                          class="c40"
+                        >
+                          <svg
+                            fill="none"
+                            height="1em"
+                            viewBox="0 0 24 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M14 10v4h-4v-4h4zm2 0h5v4h-5v-4zm-2 11h-4v-5h4v5zm2 0v-5h5v4a1 1 0 01-1 1h-4zM14 3v5h-4V3h4zm2 0h4a1 1 0 011 1v4h-5V3zm-8 7v4H3v-4h5zm0 11H4a1 1 0 01-1-1v-4h5v5zM8 3v5H3V4a1 1 0 011-1h4z"
+                              fill="#8E8EA9"
+                            />
+                          </svg>
+                        </div>
+                        <div
+                          class="c29"
+                        >
+                          <span
+                            class="c6 c30"
+                          >
+                            Cities
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </li>
+                  <li />
+                </ul>
               </div>
-              <ul
-                id="subnav-list-124"
-              >
-                <li>
-                  <a
-                    class="c26 c27"
-                    href="/address"
-                  >
-                    <div
-                      class="c1"
-                    >
-                      <div
-                        class="c40"
-                      >
-                        <svg
-                          fill="none"
-                          height="1em"
-                          viewBox="0 0 24 24"
-                          width="1em"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M12 0C5.383 0 0 5.383 0 12s5.383 12 12 12 12-5.383 12-12S18.617 0 12 0zm1.154 18.456h-2.308V16.15h2.308v2.307zm-.23-3.687h-1.847l-.346-9.23h2.538l-.346 9.23z"
-                            fill="#212134"
-                          />
-                        </svg>
-                      </div>
-                      <div
-                        class="c29"
-                      >
-                        <span
-                          class="c6 c30"
-                        >
-                          Addresses
-                        </span>
-                      </div>
-                    </div>
-                  </a>
-                </li>
-                <li>
-                  <a
-                    class="c26 c27"
-                    href="/city"
-                  >
-                    <div
-                      class="c1"
-                    >
-                      <div
-                        class="c40"
-                      >
-                        <svg
-                          fill="none"
-                          height="1em"
-                          viewBox="0 0 24 24"
-                          width="1em"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M14 10v4h-4v-4h4zm2 0h5v4h-5v-4zm-2 11h-4v-5h4v5zm2 0v-5h5v4a1 1 0 01-1 1h-4zM14 3v5h-4V3h4zm2 0h4a1 1 0 011 1v4h-5V3zm-8 7v4H3v-4h5zm0 11H4a1 1 0 01-1-1v-4h5v5zM8 3v5H3V4a1 1 0 011-1h4z"
-                            fill="#8E8EA9"
-                          />
-                        </svg>
-                      </div>
-                      <div
-                        class="c29"
-                      >
-                        <span
-                          class="c6 c30"
-                        >
-                          Cities
-                        </span>
-                      </div>
-                    </div>
-                  </a>
-                </li>
-              </ul>
             </li>
             <li>
               <div
-                class="c16 c17"
+                class=""
               >
                 <div
-                  class="c18"
+                  class="c16 c17"
                 >
                   <div
-                    class="c1 c19"
+                    class="c18"
                   >
                     <div
-                      class="c20"
+                      class="c1 c19"
                     >
-                      <span
-                        class="c6 c21"
+                      <div
+                        class="c20"
                       >
-                        Permissions
-                      </span>
+                        <span
+                          class="c6 c21"
+                        >
+                          Permissions
+                        </span>
+                      </div>
                     </div>
                   </div>
                 </div>
+                <ul
+                  id="subnav-list-137"
+                >
+                  <li>
+                    <div
+                      class="c26 c27"
+                      to="/address"
+                    >
+                      <div
+                        class="c1"
+                      >
+                        <div
+                          class="c40"
+                        >
+                          <svg
+                            fill="none"
+                            height="1em"
+                            viewBox="0 0 24 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M12 0C5.383 0 0 5.383 0 12s5.383 12 12 12 12-5.383 12-12S18.617 0 12 0zm1.154 18.456h-2.308V16.15h2.308v2.307zm-.23-3.687h-1.847l-.346-9.23h2.538l-.346 9.23z"
+                              fill="#212134"
+                            />
+                          </svg>
+                        </div>
+                        <div
+                          class="c29"
+                        >
+                          <span
+                            class="c6 c30"
+                          >
+                            Addresses
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </li>
+                  <li />
+                  <li>
+                    <div
+                      class="c26 c27"
+                      to="/city"
+                    >
+                      <div
+                        class="c1"
+                      >
+                        <div
+                          class="c40"
+                        >
+                          <svg
+                            fill="none"
+                            height="1em"
+                            viewBox="0 0 24 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M14 10v4h-4v-4h4zm2 0h5v4h-5v-4zm-2 11h-4v-5h4v5zm2 0v-5h5v4a1 1 0 01-1 1h-4zM14 3v5h-4V3h4zm2 0h4a1 1 0 011 1v4h-5V3zm-8 7v4H3v-4h5zm0 11H4a1 1 0 01-1-1v-4h5v5zM8 3v5H3V4a1 1 0 011-1h4z"
+                              fill="#8E8EA9"
+                            />
+                          </svg>
+                        </div>
+                        <div
+                          class="c29"
+                        >
+                          <span
+                            class="c6 c30"
+                          >
+                            Cities
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </li>
+                  <li />
+                </ul>
               </div>
-              <ul
-                id="subnav-list-125"
-              >
-                <li>
-                  <a
-                    class="c26 c27"
-                    href="/address"
-                  >
-                    <div
-                      class="c1"
-                    >
-                      <div
-                        class="c40"
-                      >
-                        <svg
-                          fill="none"
-                          height="1em"
-                          viewBox="0 0 24 24"
-                          width="1em"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M12 0C5.383 0 0 5.383 0 12s5.383 12 12 12 12-5.383 12-12S18.617 0 12 0zm1.154 18.456h-2.308V16.15h2.308v2.307zm-.23-3.687h-1.847l-.346-9.23h2.538l-.346 9.23z"
-                            fill="#212134"
-                          />
-                        </svg>
-                      </div>
-                      <div
-                        class="c29"
-                      >
-                        <span
-                          class="c6 c30"
-                        >
-                          Addresses
-                        </span>
-                      </div>
-                    </div>
-                  </a>
-                </li>
-                <li>
-                  <a
-                    class="c26 c27"
-                    href="/city"
-                  >
-                    <div
-                      class="c1"
-                    >
-                      <div
-                        class="c40"
-                      >
-                        <svg
-                          fill="none"
-                          height="1em"
-                          viewBox="0 0 24 24"
-                          width="1em"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M14 10v4h-4v-4h4zm2 0h5v4h-5v-4zm-2 11h-4v-5h4v5zm2 0v-5h5v4a1 1 0 01-1 1h-4zM14 3v5h-4V3h4zm2 0h4a1 1 0 011 1v4h-5V3zm-8 7v4H3v-4h5zm0 11H4a1 1 0 01-1-1v-4h5v5zM8 3v5H3V4a1 1 0 011-1h4z"
-                            fill="#8E8EA9"
-                          />
-                        </svg>
-                      </div>
-                      <div
-                        class="c29"
-                      >
-                        <span
-                          class="c6 c30"
-                        >
-                          Cities
-                        </span>
-                      </div>
-                    </div>
-                  </a>
-                </li>
-              </ul>
             </li>
           </ul>
         </div>
@@ -31405,9 +34273,9 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
             class="c15"
           >
             <li>
-              <a
+              <div
                 class="c26 c27"
-                href="/blabla"
+                to="/blabla"
               >
                 <div
                   class="c1"
@@ -31439,7 +34307,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c1 sc-gsDKAQ c41"
+                  class="c1 sc-dkPtRN c41"
                 >
                   <svg
                     class="c42"
@@ -31457,61 +34325,282 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                     />
                   </svg>
                 </div>
-              </a>
+              </div>
             </li>
             <li>
               <div
-                class="c16 c17"
+                class=""
               >
                 <div
-                  class="c18"
+                  class="c16 c17"
                 >
                   <div
-                    class="c1 c19"
+                    class="c18"
                   >
                     <div
-                      class="c20"
+                      class="c1 c19"
                     >
-                      <span
-                        class="c6 c21"
+                      <div
+                        class="c20"
                       >
-                        Global Settings
-                      </span>
+                        <span
+                          class="c6 c21"
+                        >
+                          Global Settings
+                        </span>
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
-              <ul
-                id="subnav-list-127"
-              >
-                <li>
-                  <div
-                    class="c35 c36"
-                  >
+                <ul
+                  id="subnav-list-139"
+                >
+                  <li>
                     <div
-                      class="c18"
+                      class=""
                     >
-                      <button
-                        aria-controls="subnav-list-128"
-                        aria-expanded="true"
-                        class="c37"
+                      <div
+                        class="c35 c36"
                       >
                         <div
-                          class="c38"
+                          class="c18"
+                        >
+                          <button
+                            aria-controls="subnav-list-140"
+                            aria-expanded="true"
+                            class="c37"
+                          >
+                            <div
+                              class="c38"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                fill="none"
+                                height="1em"
+                                viewBox="0 0 14 8"
+                                width="1em"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
+                                  fill="#32324D"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              class="c29"
+                            >
+                              <span
+                                class="c6 c39"
+                              >
+                                Sub section
+                              </span>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                      <ul
+                        id="subnav-list-140"
+                      >
+                        <li>
+                          <div
+                            class="c26 c27"
+                            to="/address"
+                          >
+                            <div
+                              class="c1"
+                            >
+                              <div
+                                class="c40"
+                              >
+                                <svg
+                                  fill="none"
+                                  height="1em"
+                                  viewBox="0 0 24 24"
+                                  width="1em"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 0C5.383 0 0 5.383 0 12s5.383 12 12 12 12-5.383 12-12S18.617 0 12 0zm1.154 18.456h-2.308V16.15h2.308v2.307zm-.23-3.687h-1.847l-.346-9.23h2.538l-.346 9.23z"
+                                    fill="#212134"
+                                  />
+                                </svg>
+                              </div>
+                              <div
+                                class="c29"
+                              >
+                                <span
+                                  class="c6 c30"
+                                >
+                                  Addresses
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </li>
+                        <li>
+                          <div
+                            class="c26 c27"
+                            to="/category"
+                          >
+                            <div
+                              class="c1"
+                            >
+                              <svg
+                                class="c28"
+                                fill="none"
+                                height="1em"
+                                viewBox="0 0 4 4"
+                                width="1em"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <rect
+                                  fill="#A5A5BA"
+                                  height="4"
+                                  rx="2"
+                                  width="4"
+                                />
+                              </svg>
+                              <div
+                                class="c29"
+                              >
+                                <span
+                                  class="c6 c30"
+                                >
+                                  Categories
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </li>
+                        <li>
+                          <div
+                            class="c26 c27"
+                            to="/city"
+                          >
+                            <div
+                              class="c1"
+                            >
+                              <div
+                                class="c40"
+                              >
+                                <svg
+                                  fill="none"
+                                  height="1em"
+                                  viewBox="0 0 24 24"
+                                  width="1em"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M14 10v4h-4v-4h4zm2 0h5v4h-5v-4zm-2 11h-4v-5h4v5zm2 0v-5h5v4a1 1 0 01-1 1h-4zM14 3v5h-4V3h4zm2 0h4a1 1 0 011 1v4h-5V3zm-8 7v4H3v-4h5zm0 11H4a1 1 0 01-1-1v-4h5v5zM8 3v5H3V4a1 1 0 011-1h4z"
+                                    fill="#8E8EA9"
+                                  />
+                                </svg>
+                              </div>
+                              <div
+                                class="c29"
+                              >
+                                <span
+                                  class="c6 c30"
+                                >
+                                  Cities
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </li>
+                        <li>
+                          <div
+                            class="c26 c27"
+                            to="/country"
+                          >
+                            <div
+                              class="c1"
+                            >
+                              <svg
+                                class="c28"
+                                fill="none"
+                                height="1em"
+                                viewBox="0 0 4 4"
+                                width="1em"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <rect
+                                  fill="#A5A5BA"
+                                  height="4"
+                                  rx="2"
+                                  width="4"
+                                />
+                              </svg>
+                              <div
+                                class="c29"
+                              >
+                                <span
+                                  class="c6 c30"
+                                >
+                                  Countries
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </li>
+                      </ul>
+                    </div>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li>
+              <div
+                class=""
+              >
+                <div
+                  class="c16 c17"
+                >
+                  <div
+                    class="c18"
+                  >
+                    <div
+                      class="c1 c19"
+                    >
+                      <div
+                        class="c20"
+                      >
+                        <span
+                          class="c6 c21"
+                        >
+                          Permissions
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <ul
+                  id="subnav-list-141"
+                >
+                  <li>
+                    <div
+                      class="c26 c27"
+                      to="/address"
+                    >
+                      <div
+                        class="c1"
+                      >
+                        <div
+                          class="c40"
                         >
                           <svg
-                            aria-hidden="true"
                             fill="none"
                             height="1em"
-                            viewBox="0 0 14 8"
+                            viewBox="0 0 24 24"
                             width="1em"
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             <path
-                              clip-rule="evenodd"
-                              d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
-                              fill="#32324D"
-                              fill-rule="evenodd"
+                              d="M12 0C5.383 0 0 5.383 0 12s5.383 12 12 12 12-5.383 12-12S18.617 0 12 0zm1.154 18.456h-2.308V16.15h2.308v2.307zm-.23-3.687h-1.847l-.346-9.23h2.538l-.346 9.23z"
+                              fill="#212134"
                             />
                           </svg>
                         </div>
@@ -31519,331 +34608,122 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           class="c29"
                         >
                           <span
-                            class="c6 c39"
+                            class="c6 c30"
                           >
-                            Sub section
+                            Addresses
                           </span>
                         </div>
-                      </button>
+                      </div>
                     </div>
-                  </div>
-                  <ul
-                    id="subnav-list-128"
-                  >
-                    <li>
-                      <a
-                        class="c26 c27"
-                        href="/address"
-                      >
-                        <div
-                          class="c1"
-                        >
-                          <div
-                            class="c40"
-                          >
-                            <svg
-                              fill="none"
-                              height="1em"
-                              viewBox="0 0 24 24"
-                              width="1em"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M12 0C5.383 0 0 5.383 0 12s5.383 12 12 12 12-5.383 12-12S18.617 0 12 0zm1.154 18.456h-2.308V16.15h2.308v2.307zm-.23-3.687h-1.847l-.346-9.23h2.538l-.346 9.23z"
-                                fill="#212134"
-                              />
-                            </svg>
-                          </div>
-                          <div
-                            class="c29"
-                          >
-                            <span
-                              class="c6 c30"
-                            >
-                              Addresses
-                            </span>
-                          </div>
-                        </div>
-                      </a>
-                    </li>
-                    <li>
-                      <a
-                        class="c26 c27"
-                        href="/category"
-                      >
-                        <div
-                          class="c1"
-                        >
-                          <svg
-                            class="c28"
-                            fill="none"
-                            height="1em"
-                            viewBox="0 0 4 4"
-                            width="1em"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <rect
-                              fill="#A5A5BA"
-                              height="4"
-                              rx="2"
-                              width="4"
-                            />
-                          </svg>
-                          <div
-                            class="c29"
-                          >
-                            <span
-                              class="c6 c30"
-                            >
-                              Categories
-                            </span>
-                          </div>
-                        </div>
-                      </a>
-                    </li>
-                    <li>
-                      <a
-                        class="c26 c27"
-                        href="/city"
-                      >
-                        <div
-                          class="c1"
-                        >
-                          <div
-                            class="c40"
-                          >
-                            <svg
-                              fill="none"
-                              height="1em"
-                              viewBox="0 0 24 24"
-                              width="1em"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M14 10v4h-4v-4h4zm2 0h5v4h-5v-4zm-2 11h-4v-5h4v5zm2 0v-5h5v4a1 1 0 01-1 1h-4zM14 3v5h-4V3h4zm2 0h4a1 1 0 011 1v4h-5V3zm-8 7v4H3v-4h5zm0 11H4a1 1 0 01-1-1v-4h5v5zM8 3v5H3V4a1 1 0 011-1h4z"
-                                fill="#8E8EA9"
-                              />
-                            </svg>
-                          </div>
-                          <div
-                            class="c29"
-                          >
-                            <span
-                              class="c6 c30"
-                            >
-                              Cities
-                            </span>
-                          </div>
-                        </div>
-                      </a>
-                    </li>
-                    <li>
-                      <a
-                        class="c26 c27"
-                        href="/country"
-                      >
-                        <div
-                          class="c1"
-                        >
-                          <svg
-                            class="c28"
-                            fill="none"
-                            height="1em"
-                            viewBox="0 0 4 4"
-                            width="1em"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <rect
-                              fill="#A5A5BA"
-                              height="4"
-                              rx="2"
-                              width="4"
-                            />
-                          </svg>
-                          <div
-                            class="c29"
-                          >
-                            <span
-                              class="c6 c30"
-                            >
-                              Countries
-                            </span>
-                          </div>
-                        </div>
-                      </a>
-                    </li>
-                  </ul>
-                </li>
-              </ul>
-            </li>
-            <li>
-              <div
-                class="c16 c17"
-              >
-                <div
-                  class="c18"
-                >
-                  <div
-                    class="c1 c19"
-                  >
+                  </li>
+                  <li>
                     <div
-                      class="c20"
+                      class="c26 c27"
+                      to="/category"
                     >
-                      <span
-                        class="c6 c21"
+                      <div
+                        class="c1"
                       >
-                        Permissions
-                      </span>
+                        <svg
+                          class="c28"
+                          fill="none"
+                          height="1em"
+                          viewBox="0 0 4 4"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            fill="#A5A5BA"
+                            height="4"
+                            rx="2"
+                            width="4"
+                          />
+                        </svg>
+                        <div
+                          class="c29"
+                        >
+                          <span
+                            class="c6 c30"
+                          >
+                            Categories
+                          </span>
+                        </div>
+                      </div>
                     </div>
-                  </div>
-                </div>
+                  </li>
+                  <li>
+                    <div
+                      class="c26 c27"
+                      to="/city"
+                    >
+                      <div
+                        class="c1"
+                      >
+                        <div
+                          class="c40"
+                        >
+                          <svg
+                            fill="none"
+                            height="1em"
+                            viewBox="0 0 24 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M14 10v4h-4v-4h4zm2 0h5v4h-5v-4zm-2 11h-4v-5h4v5zm2 0v-5h5v4a1 1 0 01-1 1h-4zM14 3v5h-4V3h4zm2 0h4a1 1 0 011 1v4h-5V3zm-8 7v4H3v-4h5zm0 11H4a1 1 0 01-1-1v-4h5v5zM8 3v5H3V4a1 1 0 011-1h4z"
+                              fill="#8E8EA9"
+                            />
+                          </svg>
+                        </div>
+                        <div
+                          class="c29"
+                        >
+                          <span
+                            class="c6 c30"
+                          >
+                            Cities
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </li>
+                  <li>
+                    <div
+                      class="c26 c27"
+                      to="/country"
+                    >
+                      <div
+                        class="c1"
+                      >
+                        <svg
+                          class="c28"
+                          fill="none"
+                          height="1em"
+                          viewBox="0 0 4 4"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <rect
+                            fill="#A5A5BA"
+                            height="4"
+                            rx="2"
+                            width="4"
+                          />
+                        </svg>
+                        <div
+                          class="c29"
+                        >
+                          <span
+                            class="c6 c30"
+                          >
+                            Countries
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </li>
+                </ul>
               </div>
-              <ul
-                id="subnav-list-129"
-              >
-                <li>
-                  <a
-                    class="c26 c27"
-                    href="/address"
-                  >
-                    <div
-                      class="c1"
-                    >
-                      <div
-                        class="c40"
-                      >
-                        <svg
-                          fill="none"
-                          height="1em"
-                          viewBox="0 0 24 24"
-                          width="1em"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M12 0C5.383 0 0 5.383 0 12s5.383 12 12 12 12-5.383 12-12S18.617 0 12 0zm1.154 18.456h-2.308V16.15h2.308v2.307zm-.23-3.687h-1.847l-.346-9.23h2.538l-.346 9.23z"
-                            fill="#212134"
-                          />
-                        </svg>
-                      </div>
-                      <div
-                        class="c29"
-                      >
-                        <span
-                          class="c6 c30"
-                        >
-                          Addresses
-                        </span>
-                      </div>
-                    </div>
-                  </a>
-                </li>
-                <li>
-                  <a
-                    class="c26 c27"
-                    href="/category"
-                  >
-                    <div
-                      class="c1"
-                    >
-                      <svg
-                        class="c28"
-                        fill="none"
-                        height="1em"
-                        viewBox="0 0 4 4"
-                        width="1em"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="#A5A5BA"
-                          height="4"
-                          rx="2"
-                          width="4"
-                        />
-                      </svg>
-                      <div
-                        class="c29"
-                      >
-                        <span
-                          class="c6 c30"
-                        >
-                          Categories
-                        </span>
-                      </div>
-                    </div>
-                  </a>
-                </li>
-                <li>
-                  <a
-                    class="c26 c27"
-                    href="/city"
-                  >
-                    <div
-                      class="c1"
-                    >
-                      <div
-                        class="c40"
-                      >
-                        <svg
-                          fill="none"
-                          height="1em"
-                          viewBox="0 0 24 24"
-                          width="1em"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M14 10v4h-4v-4h4zm2 0h5v4h-5v-4zm-2 11h-4v-5h4v5zm2 0v-5h5v4a1 1 0 01-1 1h-4zM14 3v5h-4V3h4zm2 0h4a1 1 0 011 1v4h-5V3zm-8 7v4H3v-4h5zm0 11H4a1 1 0 01-1-1v-4h5v5zM8 3v5H3V4a1 1 0 011-1h4z"
-                            fill="#8E8EA9"
-                          />
-                        </svg>
-                      </div>
-                      <div
-                        class="c29"
-                      >
-                        <span
-                          class="c6 c30"
-                        >
-                          Cities
-                        </span>
-                      </div>
-                    </div>
-                  </a>
-                </li>
-                <li>
-                  <a
-                    class="c26 c27"
-                    href="/country"
-                  >
-                    <div
-                      class="c1"
-                    >
-                      <svg
-                        class="c28"
-                        fill="none"
-                        height="1em"
-                        viewBox="0 0 4 4"
-                        width="1em"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <rect
-                          fill="#A5A5BA"
-                          height="4"
-                          rx="2"
-                          width="4"
-                        />
-                      </svg>
-                      <div
-                        class="c29"
-                      >
-                        <span
-                          class="c6 c30"
-                        >
-                          Countries
-                        </span>
-                      </div>
-                    </div>
-                  </a>
-                </li>
-              </ul>
             </li>
           </ul>
         </div>
@@ -32106,6 +34986,27 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
   width: 1px;
 }
 
+.c14 {
+  color: #32324d;
+  font-weight: 600;
+  font-size: 0.6875rem;
+  line-height: 1.45;
+  text-transform: uppercase;
+}
+
+.c16 {
+  color: #32324d;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
+.c29 {
+  font-weight: 600;
+  color: #4945ff;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
 .c1 {
   background: #f6f6f9;
   padding: 40px;
@@ -32143,27 +35044,6 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
   padding-left: 12px;
 }
 
-.c14 {
-  color: #32324d;
-  font-weight: 600;
-  font-size: 0.6875rem;
-  line-height: 1.45;
-  text-transform: uppercase;
-}
-
-.c16 {
-  color: #32324d;
-  font-size: 0.875rem;
-  line-height: 1.43;
-}
-
-.c29 {
-  font-weight: 600;
-  color: #4945ff;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
 .c11 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -32176,18 +35056,6 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-}
-
-.c18 {
-  border-radius: 50%;
-  display: block;
-  position: relative;
-}
-
-.c17 {
-  position: relative;
-  width: 26px;
-  height: 26px;
 }
 
 .c19 {
@@ -32246,6 +35114,59 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
   left: -5px;
   right: -5px;
   border: 2px solid #4945ff;
+}
+
+.c20 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  height: 2rem;
+  width: 2rem;
+  border: none;
+}
+
+.c20 svg > g,
+.c20 svg path {
+  fill: #8e8ea9;
+}
+
+.c20:hover svg > g,
+.c20:hover svg path {
+  fill: #666687;
+}
+
+.c20:active svg > g,
+.c20:active svg path {
+  fill: #a5a5ba;
+}
+
+.c20[aria-disabled='true'] {
+  background-color: #eaeaef;
+}
+
+.c20[aria-disabled='true'] svg path {
+  fill: #666687;
+}
+
+.c18 {
+  border-radius: 50%;
+  display: block;
+  position: relative;
+}
+
+.c17 {
+  position: relative;
+  width: 26px;
+  height: 26px;
 }
 
 .c12 {
@@ -32314,47 +35235,6 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
 
 .c12:indeterminate:disabled:after {
   background-color: #8e8ea9;
-}
-
-.c20 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  height: 2rem;
-  width: 2rem;
-  border: none;
-}
-
-.c20 svg > g,
-.c20 svg path {
-  fill: #8e8ea9;
-}
-
-.c20:hover svg > g,
-.c20:hover svg path {
-  fill: #666687;
-}
-
-.c20:active svg > g,
-.c20:active svg path {
-  fill: #a5a5ba;
-}
-
-.c20[aria-disabled='true'] {
-  background-color: #eaeaef;
-}
-
-.c20[aria-disabled='true'] svg path {
-  fill: #666687;
 }
 
 .c23 {
@@ -32729,420 +35609,6 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                     <span>
                       <button
                         aria-disabled="false"
-                        aria-labelledby="tooltip-130"
-                        class="c19 c20"
-                        tabindex="-1"
-                        type="button"
-                      >
-                        <svg
-                          fill="none"
-                          height="1em"
-                          viewBox="0 0 24 24"
-                          width="1em"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            clip-rule="evenodd"
-                            d="M23.604 3.514c.528.528.528 1.36 0 1.887l-2.622 2.607-4.99-4.99L18.6.396a1.322 1.322 0 011.887 0l3.118 3.118zM0 24v-4.99l14.2-14.2 4.99 4.99L4.99 24H0z"
-                            fill="#212134"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </button>
-                    </span>
-                    <div
-                      class="c21"
-                    >
-                      <span>
-                        <button
-                          aria-disabled="false"
-                          aria-labelledby="tooltip-132"
-                          class="c19 c20"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          <svg
-                            fill="none"
-                            height="1em"
-                            viewBox="0 0 24 24"
-                            width="1em"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M3.236 6.149a.2.2 0 00-.197.233L6 24h12l2.96-17.618a.2.2 0 00-.196-.233H3.236zM21.8 1.983c.11 0 .2.09.2.2v1.584a.2.2 0 01-.2.2H2.2a.2.2 0 01-.2-.2V2.183c0-.11.09-.2.2-.2h5.511c.9 0 1.631-1.09 1.631-1.983h5.316c0 .894.73 1.983 1.631 1.983H21.8z"
-                              fill="#32324D"
-                            />
-                          </svg>
-                        </button>
-                      </span>
-                    </div>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                aria-rowindex="3"
-                class="c9"
-              >
-                <td
-                  aria-colindex="1"
-                  class="c10"
-                >
-                  <input
-                    aria-label="Select Leon Lafrite"
-                    class="c12"
-                    tabindex="-1"
-                    type="checkbox"
-                  />
-                </td>
-                <td
-                  aria-colindex="2"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c16"
-                  >
-                    1
-                  </span>
-                </td>
-                <td
-                  aria-colindex="3"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span>
-                    <div
-                      class="c17"
-                    >
-                      <img
-                        alt="Leon Lafrite"
-                        class="c18"
-                        height="26px"
-                        src="https://avatars.githubusercontent.com/u/3874873?v=4"
-                        width="26px"
-                      />
-                    </div>
-                  </span>
-                </td>
-                <td
-                  aria-colindex="4"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c16"
-                  >
-                    Chez Léon is a human sized Parisian
-                  </span>
-                </td>
-                <td
-                  aria-colindex="5"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c16"
-                  >
-                    French cuisine
-                  </span>
-                </td>
-                <td
-                  aria-colindex="6"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c16"
-                  >
-                    Leon Lafrite
-                  </span>
-                </td>
-                <td
-                  aria-colindex="7"
-                  class="c10"
-                >
-                  <div
-                    class="c11"
-                  >
-                    <span>
-                      <button
-                        aria-disabled="false"
-                        aria-labelledby="tooltip-134"
-                        class="c19 c20"
-                        tabindex="-1"
-                        type="button"
-                      >
-                        <svg
-                          fill="none"
-                          height="1em"
-                          viewBox="0 0 24 24"
-                          width="1em"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            clip-rule="evenodd"
-                            d="M23.604 3.514c.528.528.528 1.36 0 1.887l-2.622 2.607-4.99-4.99L18.6.396a1.322 1.322 0 011.887 0l3.118 3.118zM0 24v-4.99l14.2-14.2 4.99 4.99L4.99 24H0z"
-                            fill="#212134"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </button>
-                    </span>
-                    <div
-                      class="c21"
-                    >
-                      <span>
-                        <button
-                          aria-disabled="false"
-                          aria-labelledby="tooltip-136"
-                          class="c19 c20"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          <svg
-                            fill="none"
-                            height="1em"
-                            viewBox="0 0 24 24"
-                            width="1em"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M3.236 6.149a.2.2 0 00-.197.233L6 24h12l2.96-17.618a.2.2 0 00-.196-.233H3.236zM21.8 1.983c.11 0 .2.09.2.2v1.584a.2.2 0 01-.2.2H2.2a.2.2 0 01-.2-.2V2.183c0-.11.09-.2.2-.2h5.511c.9 0 1.631-1.09 1.631-1.983h5.316c0 .894.73 1.983 1.631 1.983H21.8z"
-                              fill="#32324D"
-                            />
-                          </svg>
-                        </button>
-                      </span>
-                    </div>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                aria-rowindex="4"
-                class="c9"
-              >
-                <td
-                  aria-colindex="1"
-                  class="c10"
-                >
-                  <input
-                    aria-label="Select Leon Lafrite"
-                    class="c12"
-                    tabindex="-1"
-                    type="checkbox"
-                  />
-                </td>
-                <td
-                  aria-colindex="2"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c16"
-                  >
-                    2
-                  </span>
-                </td>
-                <td
-                  aria-colindex="3"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span>
-                    <div
-                      class="c17"
-                    >
-                      <img
-                        alt="Leon Lafrite"
-                        class="c18"
-                        height="26px"
-                        src="https://avatars.githubusercontent.com/u/3874873?v=4"
-                        width="26px"
-                      />
-                    </div>
-                  </span>
-                </td>
-                <td
-                  aria-colindex="4"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c16"
-                  >
-                    Chez Léon is a human sized Parisian
-                  </span>
-                </td>
-                <td
-                  aria-colindex="5"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c16"
-                  >
-                    French cuisine
-                  </span>
-                </td>
-                <td
-                  aria-colindex="6"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c16"
-                  >
-                    Leon Lafrite
-                  </span>
-                </td>
-                <td
-                  aria-colindex="7"
-                  class="c10"
-                >
-                  <div
-                    class="c11"
-                  >
-                    <span>
-                      <button
-                        aria-disabled="false"
-                        aria-labelledby="tooltip-138"
-                        class="c19 c20"
-                        tabindex="-1"
-                        type="button"
-                      >
-                        <svg
-                          fill="none"
-                          height="1em"
-                          viewBox="0 0 24 24"
-                          width="1em"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            clip-rule="evenodd"
-                            d="M23.604 3.514c.528.528.528 1.36 0 1.887l-2.622 2.607-4.99-4.99L18.6.396a1.322 1.322 0 011.887 0l3.118 3.118zM0 24v-4.99l14.2-14.2 4.99 4.99L4.99 24H0z"
-                            fill="#212134"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </button>
-                    </span>
-                    <div
-                      class="c21"
-                    >
-                      <span>
-                        <button
-                          aria-disabled="false"
-                          aria-labelledby="tooltip-140"
-                          class="c19 c20"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          <svg
-                            fill="none"
-                            height="1em"
-                            viewBox="0 0 24 24"
-                            width="1em"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M3.236 6.149a.2.2 0 00-.197.233L6 24h12l2.96-17.618a.2.2 0 00-.196-.233H3.236zM21.8 1.983c.11 0 .2.09.2.2v1.584a.2.2 0 01-.2.2H2.2a.2.2 0 01-.2-.2V2.183c0-.11.09-.2.2-.2h5.511c.9 0 1.631-1.09 1.631-1.983h5.316c0 .894.73 1.983 1.631 1.983H21.8z"
-                              fill="#32324D"
-                            />
-                          </svg>
-                        </button>
-                      </span>
-                    </div>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                aria-rowindex="5"
-                class="c9"
-              >
-                <td
-                  aria-colindex="1"
-                  class="c10"
-                >
-                  <input
-                    aria-label="Select Leon Lafrite"
-                    class="c12"
-                    tabindex="-1"
-                    type="checkbox"
-                  />
-                </td>
-                <td
-                  aria-colindex="2"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c16"
-                  >
-                    3
-                  </span>
-                </td>
-                <td
-                  aria-colindex="3"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span>
-                    <div
-                      class="c17"
-                    >
-                      <img
-                        alt="Leon Lafrite"
-                        class="c18"
-                        height="26px"
-                        src="https://avatars.githubusercontent.com/u/3874873?v=4"
-                        width="26px"
-                      />
-                    </div>
-                  </span>
-                </td>
-                <td
-                  aria-colindex="4"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c16"
-                  >
-                    Chez Léon is a human sized Parisian
-                  </span>
-                </td>
-                <td
-                  aria-colindex="5"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c16"
-                  >
-                    French cuisine
-                  </span>
-                </td>
-                <td
-                  aria-colindex="6"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c16"
-                  >
-                    Leon Lafrite
-                  </span>
-                </td>
-                <td
-                  aria-colindex="7"
-                  class="c10"
-                >
-                  <div
-                    class="c11"
-                  >
-                    <span>
-                      <button
-                        aria-disabled="false"
                         aria-labelledby="tooltip-142"
                         class="c19 c20"
                         tabindex="-1"
@@ -33194,7 +35660,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                 </td>
               </tr>
               <tr
-                aria-rowindex="6"
+                aria-rowindex="3"
                 class="c9"
               >
                 <td
@@ -33216,7 +35682,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                   <span
                     class="c16"
                   >
-                    4
+                    1
                   </span>
                 </td>
                 <td
@@ -33331,6 +35797,420 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                   </div>
                 </td>
               </tr>
+              <tr
+                aria-rowindex="4"
+                class="c9"
+              >
+                <td
+                  aria-colindex="1"
+                  class="c10"
+                >
+                  <input
+                    aria-label="Select Leon Lafrite"
+                    class="c12"
+                    tabindex="-1"
+                    type="checkbox"
+                  />
+                </td>
+                <td
+                  aria-colindex="2"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c16"
+                  >
+                    2
+                  </span>
+                </td>
+                <td
+                  aria-colindex="3"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span>
+                    <div
+                      class="c17"
+                    >
+                      <img
+                        alt="Leon Lafrite"
+                        class="c18"
+                        height="26px"
+                        src="https://avatars.githubusercontent.com/u/3874873?v=4"
+                        width="26px"
+                      />
+                    </div>
+                  </span>
+                </td>
+                <td
+                  aria-colindex="4"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c16"
+                  >
+                    Chez Léon is a human sized Parisian
+                  </span>
+                </td>
+                <td
+                  aria-colindex="5"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c16"
+                  >
+                    French cuisine
+                  </span>
+                </td>
+                <td
+                  aria-colindex="6"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c16"
+                  >
+                    Leon Lafrite
+                  </span>
+                </td>
+                <td
+                  aria-colindex="7"
+                  class="c10"
+                >
+                  <div
+                    class="c11"
+                  >
+                    <span>
+                      <button
+                        aria-disabled="false"
+                        aria-labelledby="tooltip-150"
+                        class="c19 c20"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          fill="none"
+                          height="1em"
+                          viewBox="0 0 24 24"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M23.604 3.514c.528.528.528 1.36 0 1.887l-2.622 2.607-4.99-4.99L18.6.396a1.322 1.322 0 011.887 0l3.118 3.118zM0 24v-4.99l14.2-14.2 4.99 4.99L4.99 24H0z"
+                            fill="#212134"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </button>
+                    </span>
+                    <div
+                      class="c21"
+                    >
+                      <span>
+                        <button
+                          aria-disabled="false"
+                          aria-labelledby="tooltip-152"
+                          class="c19 c20"
+                          tabindex="-1"
+                          type="button"
+                        >
+                          <svg
+                            fill="none"
+                            height="1em"
+                            viewBox="0 0 24 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M3.236 6.149a.2.2 0 00-.197.233L6 24h12l2.96-17.618a.2.2 0 00-.196-.233H3.236zM21.8 1.983c.11 0 .2.09.2.2v1.584a.2.2 0 01-.2.2H2.2a.2.2 0 01-.2-.2V2.183c0-.11.09-.2.2-.2h5.511c.9 0 1.631-1.09 1.631-1.983h5.316c0 .894.73 1.983 1.631 1.983H21.8z"
+                              fill="#32324D"
+                            />
+                          </svg>
+                        </button>
+                      </span>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+              <tr
+                aria-rowindex="5"
+                class="c9"
+              >
+                <td
+                  aria-colindex="1"
+                  class="c10"
+                >
+                  <input
+                    aria-label="Select Leon Lafrite"
+                    class="c12"
+                    tabindex="-1"
+                    type="checkbox"
+                  />
+                </td>
+                <td
+                  aria-colindex="2"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c16"
+                  >
+                    3
+                  </span>
+                </td>
+                <td
+                  aria-colindex="3"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span>
+                    <div
+                      class="c17"
+                    >
+                      <img
+                        alt="Leon Lafrite"
+                        class="c18"
+                        height="26px"
+                        src="https://avatars.githubusercontent.com/u/3874873?v=4"
+                        width="26px"
+                      />
+                    </div>
+                  </span>
+                </td>
+                <td
+                  aria-colindex="4"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c16"
+                  >
+                    Chez Léon is a human sized Parisian
+                  </span>
+                </td>
+                <td
+                  aria-colindex="5"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c16"
+                  >
+                    French cuisine
+                  </span>
+                </td>
+                <td
+                  aria-colindex="6"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c16"
+                  >
+                    Leon Lafrite
+                  </span>
+                </td>
+                <td
+                  aria-colindex="7"
+                  class="c10"
+                >
+                  <div
+                    class="c11"
+                  >
+                    <span>
+                      <button
+                        aria-disabled="false"
+                        aria-labelledby="tooltip-154"
+                        class="c19 c20"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          fill="none"
+                          height="1em"
+                          viewBox="0 0 24 24"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M23.604 3.514c.528.528.528 1.36 0 1.887l-2.622 2.607-4.99-4.99L18.6.396a1.322 1.322 0 011.887 0l3.118 3.118zM0 24v-4.99l14.2-14.2 4.99 4.99L4.99 24H0z"
+                            fill="#212134"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </button>
+                    </span>
+                    <div
+                      class="c21"
+                    >
+                      <span>
+                        <button
+                          aria-disabled="false"
+                          aria-labelledby="tooltip-156"
+                          class="c19 c20"
+                          tabindex="-1"
+                          type="button"
+                        >
+                          <svg
+                            fill="none"
+                            height="1em"
+                            viewBox="0 0 24 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M3.236 6.149a.2.2 0 00-.197.233L6 24h12l2.96-17.618a.2.2 0 00-.196-.233H3.236zM21.8 1.983c.11 0 .2.09.2.2v1.584a.2.2 0 01-.2.2H2.2a.2.2 0 01-.2-.2V2.183c0-.11.09-.2.2-.2h5.511c.9 0 1.631-1.09 1.631-1.983h5.316c0 .894.73 1.983 1.631 1.983H21.8z"
+                              fill="#32324D"
+                            />
+                          </svg>
+                        </button>
+                      </span>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+              <tr
+                aria-rowindex="6"
+                class="c9"
+              >
+                <td
+                  aria-colindex="1"
+                  class="c10"
+                >
+                  <input
+                    aria-label="Select Leon Lafrite"
+                    class="c12"
+                    tabindex="-1"
+                    type="checkbox"
+                  />
+                </td>
+                <td
+                  aria-colindex="2"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c16"
+                  >
+                    4
+                  </span>
+                </td>
+                <td
+                  aria-colindex="3"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span>
+                    <div
+                      class="c17"
+                    >
+                      <img
+                        alt="Leon Lafrite"
+                        class="c18"
+                        height="26px"
+                        src="https://avatars.githubusercontent.com/u/3874873?v=4"
+                        width="26px"
+                      />
+                    </div>
+                  </span>
+                </td>
+                <td
+                  aria-colindex="4"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c16"
+                  >
+                    Chez Léon is a human sized Parisian
+                  </span>
+                </td>
+                <td
+                  aria-colindex="5"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c16"
+                  >
+                    French cuisine
+                  </span>
+                </td>
+                <td
+                  aria-colindex="6"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c16"
+                  >
+                    Leon Lafrite
+                  </span>
+                </td>
+                <td
+                  aria-colindex="7"
+                  class="c10"
+                >
+                  <div
+                    class="c11"
+                  >
+                    <span>
+                      <button
+                        aria-disabled="false"
+                        aria-labelledby="tooltip-158"
+                        class="c19 c20"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          fill="none"
+                          height="1em"
+                          viewBox="0 0 24 24"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M23.604 3.514c.528.528.528 1.36 0 1.887l-2.622 2.607-4.99-4.99L18.6.396a1.322 1.322 0 011.887 0l3.118 3.118zM0 24v-4.99l14.2-14.2 4.99 4.99L4.99 24H0z"
+                            fill="#212134"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </button>
+                    </span>
+                    <div
+                      class="c21"
+                    >
+                      <span>
+                        <button
+                          aria-disabled="false"
+                          aria-labelledby="tooltip-160"
+                          class="c19 c20"
+                          tabindex="-1"
+                          type="button"
+                        >
+                          <svg
+                            fill="none"
+                            height="1em"
+                            viewBox="0 0 24 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M3.236 6.149a.2.2 0 00-.197.233L6 24h12l2.96-17.618a.2.2 0 00-.196-.233H3.236zM21.8 1.983c.11 0 .2.09.2.2v1.584a.2.2 0 01-.2.2H2.2a.2.2 0 01-.2-.2V2.183c0-.11.09-.2.2-.2h5.511c.9 0 1.631-1.09 1.631-1.983h5.316c0 .894.73 1.983 1.631 1.983H21.8z"
+                              fill="#32324D"
+                            />
+                          </svg>
+                        </button>
+                      </span>
+                    </div>
+                  </div>
+                </td>
+              </tr>
             </tbody>
           </table>
         </div>
@@ -33392,6 +36272,20 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
   width: 1px;
 }
 
+.c14 {
+  color: #32324d;
+  font-weight: 600;
+  font-size: 0.6875rem;
+  line-height: 1.45;
+  text-transform: uppercase;
+}
+
+.c16 {
+  color: #32324d;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
 .c1 {
   background: #f6f6f9;
   padding: 40px;
@@ -33412,20 +36306,6 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
   padding-left: 4px;
 }
 
-.c14 {
-  color: #32324d;
-  font-weight: 600;
-  font-size: 0.6875rem;
-  line-height: 1.45;
-  text-transform: uppercase;
-}
-
-.c16 {
-  color: #32324d;
-  font-size: 0.875rem;
-  line-height: 1.43;
-}
-
 .c11 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -33438,18 +36318,6 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-}
-
-.c18 {
-  border-radius: 50%;
-  display: block;
-  position: relative;
-}
-
-.c17 {
-  position: relative;
-  width: 26px;
-  height: 26px;
 }
 
 .c19 {
@@ -33508,6 +36376,59 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
   left: -5px;
   right: -5px;
   border: 2px solid #4945ff;
+}
+
+.c20 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  height: 2rem;
+  width: 2rem;
+  border: none;
+}
+
+.c20 svg > g,
+.c20 svg path {
+  fill: #8e8ea9;
+}
+
+.c20:hover svg > g,
+.c20:hover svg path {
+  fill: #666687;
+}
+
+.c20:active svg > g,
+.c20:active svg path {
+  fill: #a5a5ba;
+}
+
+.c20[aria-disabled='true'] {
+  background-color: #eaeaef;
+}
+
+.c20[aria-disabled='true'] svg path {
+  fill: #666687;
+}
+
+.c18 {
+  border-radius: 50%;
+  display: block;
+  position: relative;
+}
+
+.c17 {
+  position: relative;
+  width: 26px;
+  height: 26px;
 }
 
 .c12 {
@@ -33576,47 +36497,6 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
 
 .c12:indeterminate:disabled:after {
   background-color: #8e8ea9;
-}
-
-.c20 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  height: 2rem;
-  width: 2rem;
-  border: none;
-}
-
-.c20 svg > g,
-.c20 svg path {
-  fill: #8e8ea9;
-}
-
-.c20:hover svg > g,
-.c20:hover svg path {
-  fill: #666687;
-}
-
-.c20:active svg > g,
-.c20:active svg path {
-  fill: #a5a5ba;
-}
-
-.c20[aria-disabled='true'] {
-  background-color: #eaeaef;
-}
-
-.c20[aria-disabled='true'] svg path {
-  fill: #666687;
 }
 
 .c3 {
@@ -33951,420 +36831,6 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                     <span>
                       <button
                         aria-disabled="false"
-                        aria-labelledby="tooltip-150"
-                        class="c19 c20"
-                        tabindex="-1"
-                        type="button"
-                      >
-                        <svg
-                          fill="none"
-                          height="1em"
-                          viewBox="0 0 24 24"
-                          width="1em"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            clip-rule="evenodd"
-                            d="M23.604 3.514c.528.528.528 1.36 0 1.887l-2.622 2.607-4.99-4.99L18.6.396a1.322 1.322 0 011.887 0l3.118 3.118zM0 24v-4.99l14.2-14.2 4.99 4.99L4.99 24H0z"
-                            fill="#212134"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </button>
-                    </span>
-                    <div
-                      class="c21"
-                    >
-                      <span>
-                        <button
-                          aria-disabled="false"
-                          aria-labelledby="tooltip-152"
-                          class="c19 c20"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          <svg
-                            fill="none"
-                            height="1em"
-                            viewBox="0 0 24 24"
-                            width="1em"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M3.236 6.149a.2.2 0 00-.197.233L6 24h12l2.96-17.618a.2.2 0 00-.196-.233H3.236zM21.8 1.983c.11 0 .2.09.2.2v1.584a.2.2 0 01-.2.2H2.2a.2.2 0 01-.2-.2V2.183c0-.11.09-.2.2-.2h5.511c.9 0 1.631-1.09 1.631-1.983h5.316c0 .894.73 1.983 1.631 1.983H21.8z"
-                              fill="#32324D"
-                            />
-                          </svg>
-                        </button>
-                      </span>
-                    </div>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                aria-rowindex="3"
-                class="c9"
-              >
-                <td
-                  aria-colindex="1"
-                  class="c10"
-                >
-                  <input
-                    aria-label="Select Leon Lafrite"
-                    class="c12"
-                    tabindex="-1"
-                    type="checkbox"
-                  />
-                </td>
-                <td
-                  aria-colindex="2"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c16"
-                  >
-                    1
-                  </span>
-                </td>
-                <td
-                  aria-colindex="3"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span>
-                    <div
-                      class="c17"
-                    >
-                      <img
-                        alt="Leon Lafrite"
-                        class="c18"
-                        height="26px"
-                        src="https://avatars.githubusercontent.com/u/3874873?v=4"
-                        width="26px"
-                      />
-                    </div>
-                  </span>
-                </td>
-                <td
-                  aria-colindex="4"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c16"
-                  >
-                    Chez Léon is a human sized Parisian
-                  </span>
-                </td>
-                <td
-                  aria-colindex="5"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c16"
-                  >
-                    French cuisine
-                  </span>
-                </td>
-                <td
-                  aria-colindex="6"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c16"
-                  >
-                    Leon Lafrite
-                  </span>
-                </td>
-                <td
-                  aria-colindex="7"
-                  class="c10"
-                >
-                  <div
-                    class="c11"
-                  >
-                    <span>
-                      <button
-                        aria-disabled="false"
-                        aria-labelledby="tooltip-154"
-                        class="c19 c20"
-                        tabindex="-1"
-                        type="button"
-                      >
-                        <svg
-                          fill="none"
-                          height="1em"
-                          viewBox="0 0 24 24"
-                          width="1em"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            clip-rule="evenodd"
-                            d="M23.604 3.514c.528.528.528 1.36 0 1.887l-2.622 2.607-4.99-4.99L18.6.396a1.322 1.322 0 011.887 0l3.118 3.118zM0 24v-4.99l14.2-14.2 4.99 4.99L4.99 24H0z"
-                            fill="#212134"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </button>
-                    </span>
-                    <div
-                      class="c21"
-                    >
-                      <span>
-                        <button
-                          aria-disabled="false"
-                          aria-labelledby="tooltip-156"
-                          class="c19 c20"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          <svg
-                            fill="none"
-                            height="1em"
-                            viewBox="0 0 24 24"
-                            width="1em"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M3.236 6.149a.2.2 0 00-.197.233L6 24h12l2.96-17.618a.2.2 0 00-.196-.233H3.236zM21.8 1.983c.11 0 .2.09.2.2v1.584a.2.2 0 01-.2.2H2.2a.2.2 0 01-.2-.2V2.183c0-.11.09-.2.2-.2h5.511c.9 0 1.631-1.09 1.631-1.983h5.316c0 .894.73 1.983 1.631 1.983H21.8z"
-                              fill="#32324D"
-                            />
-                          </svg>
-                        </button>
-                      </span>
-                    </div>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                aria-rowindex="4"
-                class="c9"
-              >
-                <td
-                  aria-colindex="1"
-                  class="c10"
-                >
-                  <input
-                    aria-label="Select Leon Lafrite"
-                    class="c12"
-                    tabindex="-1"
-                    type="checkbox"
-                  />
-                </td>
-                <td
-                  aria-colindex="2"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c16"
-                  >
-                    2
-                  </span>
-                </td>
-                <td
-                  aria-colindex="3"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span>
-                    <div
-                      class="c17"
-                    >
-                      <img
-                        alt="Leon Lafrite"
-                        class="c18"
-                        height="26px"
-                        src="https://avatars.githubusercontent.com/u/3874873?v=4"
-                        width="26px"
-                      />
-                    </div>
-                  </span>
-                </td>
-                <td
-                  aria-colindex="4"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c16"
-                  >
-                    Chez Léon is a human sized Parisian
-                  </span>
-                </td>
-                <td
-                  aria-colindex="5"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c16"
-                  >
-                    French cuisine
-                  </span>
-                </td>
-                <td
-                  aria-colindex="6"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c16"
-                  >
-                    Leon Lafrite
-                  </span>
-                </td>
-                <td
-                  aria-colindex="7"
-                  class="c10"
-                >
-                  <div
-                    class="c11"
-                  >
-                    <span>
-                      <button
-                        aria-disabled="false"
-                        aria-labelledby="tooltip-158"
-                        class="c19 c20"
-                        tabindex="-1"
-                        type="button"
-                      >
-                        <svg
-                          fill="none"
-                          height="1em"
-                          viewBox="0 0 24 24"
-                          width="1em"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            clip-rule="evenodd"
-                            d="M23.604 3.514c.528.528.528 1.36 0 1.887l-2.622 2.607-4.99-4.99L18.6.396a1.322 1.322 0 011.887 0l3.118 3.118zM0 24v-4.99l14.2-14.2 4.99 4.99L4.99 24H0z"
-                            fill="#212134"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </button>
-                    </span>
-                    <div
-                      class="c21"
-                    >
-                      <span>
-                        <button
-                          aria-disabled="false"
-                          aria-labelledby="tooltip-160"
-                          class="c19 c20"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          <svg
-                            fill="none"
-                            height="1em"
-                            viewBox="0 0 24 24"
-                            width="1em"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M3.236 6.149a.2.2 0 00-.197.233L6 24h12l2.96-17.618a.2.2 0 00-.196-.233H3.236zM21.8 1.983c.11 0 .2.09.2.2v1.584a.2.2 0 01-.2.2H2.2a.2.2 0 01-.2-.2V2.183c0-.11.09-.2.2-.2h5.511c.9 0 1.631-1.09 1.631-1.983h5.316c0 .894.73 1.983 1.631 1.983H21.8z"
-                              fill="#32324D"
-                            />
-                          </svg>
-                        </button>
-                      </span>
-                    </div>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                aria-rowindex="5"
-                class="c9"
-              >
-                <td
-                  aria-colindex="1"
-                  class="c10"
-                >
-                  <input
-                    aria-label="Select Leon Lafrite"
-                    class="c12"
-                    tabindex="-1"
-                    type="checkbox"
-                  />
-                </td>
-                <td
-                  aria-colindex="2"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c16"
-                  >
-                    3
-                  </span>
-                </td>
-                <td
-                  aria-colindex="3"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span>
-                    <div
-                      class="c17"
-                    >
-                      <img
-                        alt="Leon Lafrite"
-                        class="c18"
-                        height="26px"
-                        src="https://avatars.githubusercontent.com/u/3874873?v=4"
-                        width="26px"
-                      />
-                    </div>
-                  </span>
-                </td>
-                <td
-                  aria-colindex="4"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c16"
-                  >
-                    Chez Léon is a human sized Parisian
-                  </span>
-                </td>
-                <td
-                  aria-colindex="5"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c16"
-                  >
-                    French cuisine
-                  </span>
-                </td>
-                <td
-                  aria-colindex="6"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c16"
-                  >
-                    Leon Lafrite
-                  </span>
-                </td>
-                <td
-                  aria-colindex="7"
-                  class="c10"
-                >
-                  <div
-                    class="c11"
-                  >
-                    <span>
-                      <button
-                        aria-disabled="false"
                         aria-labelledby="tooltip-162"
                         class="c19 c20"
                         tabindex="-1"
@@ -34416,7 +36882,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                 </td>
               </tr>
               <tr
-                aria-rowindex="6"
+                aria-rowindex="3"
                 class="c9"
               >
                 <td
@@ -34438,7 +36904,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                   <span
                     class="c16"
                   >
-                    4
+                    1
                   </span>
                 </td>
                 <td
@@ -34553,6 +37019,420 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                   </div>
                 </td>
               </tr>
+              <tr
+                aria-rowindex="4"
+                class="c9"
+              >
+                <td
+                  aria-colindex="1"
+                  class="c10"
+                >
+                  <input
+                    aria-label="Select Leon Lafrite"
+                    class="c12"
+                    tabindex="-1"
+                    type="checkbox"
+                  />
+                </td>
+                <td
+                  aria-colindex="2"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c16"
+                  >
+                    2
+                  </span>
+                </td>
+                <td
+                  aria-colindex="3"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span>
+                    <div
+                      class="c17"
+                    >
+                      <img
+                        alt="Leon Lafrite"
+                        class="c18"
+                        height="26px"
+                        src="https://avatars.githubusercontent.com/u/3874873?v=4"
+                        width="26px"
+                      />
+                    </div>
+                  </span>
+                </td>
+                <td
+                  aria-colindex="4"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c16"
+                  >
+                    Chez Léon is a human sized Parisian
+                  </span>
+                </td>
+                <td
+                  aria-colindex="5"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c16"
+                  >
+                    French cuisine
+                  </span>
+                </td>
+                <td
+                  aria-colindex="6"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c16"
+                  >
+                    Leon Lafrite
+                  </span>
+                </td>
+                <td
+                  aria-colindex="7"
+                  class="c10"
+                >
+                  <div
+                    class="c11"
+                  >
+                    <span>
+                      <button
+                        aria-disabled="false"
+                        aria-labelledby="tooltip-170"
+                        class="c19 c20"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          fill="none"
+                          height="1em"
+                          viewBox="0 0 24 24"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M23.604 3.514c.528.528.528 1.36 0 1.887l-2.622 2.607-4.99-4.99L18.6.396a1.322 1.322 0 011.887 0l3.118 3.118zM0 24v-4.99l14.2-14.2 4.99 4.99L4.99 24H0z"
+                            fill="#212134"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </button>
+                    </span>
+                    <div
+                      class="c21"
+                    >
+                      <span>
+                        <button
+                          aria-disabled="false"
+                          aria-labelledby="tooltip-172"
+                          class="c19 c20"
+                          tabindex="-1"
+                          type="button"
+                        >
+                          <svg
+                            fill="none"
+                            height="1em"
+                            viewBox="0 0 24 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M3.236 6.149a.2.2 0 00-.197.233L6 24h12l2.96-17.618a.2.2 0 00-.196-.233H3.236zM21.8 1.983c.11 0 .2.09.2.2v1.584a.2.2 0 01-.2.2H2.2a.2.2 0 01-.2-.2V2.183c0-.11.09-.2.2-.2h5.511c.9 0 1.631-1.09 1.631-1.983h5.316c0 .894.73 1.983 1.631 1.983H21.8z"
+                              fill="#32324D"
+                            />
+                          </svg>
+                        </button>
+                      </span>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+              <tr
+                aria-rowindex="5"
+                class="c9"
+              >
+                <td
+                  aria-colindex="1"
+                  class="c10"
+                >
+                  <input
+                    aria-label="Select Leon Lafrite"
+                    class="c12"
+                    tabindex="-1"
+                    type="checkbox"
+                  />
+                </td>
+                <td
+                  aria-colindex="2"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c16"
+                  >
+                    3
+                  </span>
+                </td>
+                <td
+                  aria-colindex="3"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span>
+                    <div
+                      class="c17"
+                    >
+                      <img
+                        alt="Leon Lafrite"
+                        class="c18"
+                        height="26px"
+                        src="https://avatars.githubusercontent.com/u/3874873?v=4"
+                        width="26px"
+                      />
+                    </div>
+                  </span>
+                </td>
+                <td
+                  aria-colindex="4"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c16"
+                  >
+                    Chez Léon is a human sized Parisian
+                  </span>
+                </td>
+                <td
+                  aria-colindex="5"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c16"
+                  >
+                    French cuisine
+                  </span>
+                </td>
+                <td
+                  aria-colindex="6"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c16"
+                  >
+                    Leon Lafrite
+                  </span>
+                </td>
+                <td
+                  aria-colindex="7"
+                  class="c10"
+                >
+                  <div
+                    class="c11"
+                  >
+                    <span>
+                      <button
+                        aria-disabled="false"
+                        aria-labelledby="tooltip-174"
+                        class="c19 c20"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          fill="none"
+                          height="1em"
+                          viewBox="0 0 24 24"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M23.604 3.514c.528.528.528 1.36 0 1.887l-2.622 2.607-4.99-4.99L18.6.396a1.322 1.322 0 011.887 0l3.118 3.118zM0 24v-4.99l14.2-14.2 4.99 4.99L4.99 24H0z"
+                            fill="#212134"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </button>
+                    </span>
+                    <div
+                      class="c21"
+                    >
+                      <span>
+                        <button
+                          aria-disabled="false"
+                          aria-labelledby="tooltip-176"
+                          class="c19 c20"
+                          tabindex="-1"
+                          type="button"
+                        >
+                          <svg
+                            fill="none"
+                            height="1em"
+                            viewBox="0 0 24 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M3.236 6.149a.2.2 0 00-.197.233L6 24h12l2.96-17.618a.2.2 0 00-.196-.233H3.236zM21.8 1.983c.11 0 .2.09.2.2v1.584a.2.2 0 01-.2.2H2.2a.2.2 0 01-.2-.2V2.183c0-.11.09-.2.2-.2h5.511c.9 0 1.631-1.09 1.631-1.983h5.316c0 .894.73 1.983 1.631 1.983H21.8z"
+                              fill="#32324D"
+                            />
+                          </svg>
+                        </button>
+                      </span>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+              <tr
+                aria-rowindex="6"
+                class="c9"
+              >
+                <td
+                  aria-colindex="1"
+                  class="c10"
+                >
+                  <input
+                    aria-label="Select Leon Lafrite"
+                    class="c12"
+                    tabindex="-1"
+                    type="checkbox"
+                  />
+                </td>
+                <td
+                  aria-colindex="2"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c16"
+                  >
+                    4
+                  </span>
+                </td>
+                <td
+                  aria-colindex="3"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span>
+                    <div
+                      class="c17"
+                    >
+                      <img
+                        alt="Leon Lafrite"
+                        class="c18"
+                        height="26px"
+                        src="https://avatars.githubusercontent.com/u/3874873?v=4"
+                        width="26px"
+                      />
+                    </div>
+                  </span>
+                </td>
+                <td
+                  aria-colindex="4"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c16"
+                  >
+                    Chez Léon is a human sized Parisian
+                  </span>
+                </td>
+                <td
+                  aria-colindex="5"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c16"
+                  >
+                    French cuisine
+                  </span>
+                </td>
+                <td
+                  aria-colindex="6"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c16"
+                  >
+                    Leon Lafrite
+                  </span>
+                </td>
+                <td
+                  aria-colindex="7"
+                  class="c10"
+                >
+                  <div
+                    class="c11"
+                  >
+                    <span>
+                      <button
+                        aria-disabled="false"
+                        aria-labelledby="tooltip-178"
+                        class="c19 c20"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          fill="none"
+                          height="1em"
+                          viewBox="0 0 24 24"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M23.604 3.514c.528.528.528 1.36 0 1.887l-2.622 2.607-4.99-4.99L18.6.396a1.322 1.322 0 011.887 0l3.118 3.118zM0 24v-4.99l14.2-14.2 4.99 4.99L4.99 24H0z"
+                            fill="#212134"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </button>
+                    </span>
+                    <div
+                      class="c21"
+                    >
+                      <span>
+                        <button
+                          aria-disabled="false"
+                          aria-labelledby="tooltip-180"
+                          class="c19 c20"
+                          tabindex="-1"
+                          type="button"
+                        >
+                          <svg
+                            fill="none"
+                            height="1em"
+                            viewBox="0 0 24 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M3.236 6.149a.2.2 0 00-.197.233L6 24h12l2.96-17.618a.2.2 0 00-.196-.233H3.236zM21.8 1.983c.11 0 .2.09.2.2v1.584a.2.2 0 01-.2.2H2.2a.2.2 0 01-.2-.2V2.183c0-.11.09-.2.2-.2h5.511c.9 0 1.631-1.09 1.631-1.983h5.316c0 .894.73 1.983 1.631 1.983H21.8z"
+                              fill="#32324D"
+                            />
+                          </svg>
+                        </button>
+                      </span>
+                    </div>
+                  </div>
+                </td>
+              </tr>
             </tbody>
           </table>
         </div>
@@ -34573,6 +37453,27 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
   padding: 0;
   position: absolute;
   width: 1px;
+}
+
+.c14 {
+  color: #32324d;
+  font-weight: 600;
+  font-size: 0.6875rem;
+  line-height: 1.45;
+  text-transform: uppercase;
+}
+
+.c18 {
+  color: #32324d;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
+.c29 {
+  font-weight: 600;
+  color: #4945ff;
+  font-size: 0.75rem;
+  line-height: 1.33;
 }
 
 .c1 {
@@ -34612,27 +37513,6 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
   padding-left: 12px;
 }
 
-.c14 {
-  color: #32324d;
-  font-weight: 600;
-  font-size: 0.6875rem;
-  line-height: 1.45;
-  text-transform: uppercase;
-}
-
-.c18 {
-  color: #32324d;
-  font-size: 0.875rem;
-  line-height: 1.43;
-}
-
-.c29 {
-  font-weight: 600;
-  color: #4945ff;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
 .c11 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -34645,18 +37525,6 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-}
-
-.c20 {
-  border-radius: 50%;
-  display: block;
-  position: relative;
-}
-
-.c19 {
-  position: relative;
-  width: 26px;
-  height: 26px;
 }
 
 .c15 {
@@ -34715,6 +37583,59 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
   left: -5px;
   right: -5px;
   border: 2px solid #4945ff;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  height: 2rem;
+  width: 2rem;
+  border: none;
+}
+
+.c16 svg > g,
+.c16 svg path {
+  fill: #8e8ea9;
+}
+
+.c16:hover svg > g,
+.c16:hover svg path {
+  fill: #666687;
+}
+
+.c16:active svg > g,
+.c16:active svg path {
+  fill: #a5a5ba;
+}
+
+.c16[aria-disabled='true'] {
+  background-color: #eaeaef;
+}
+
+.c16[aria-disabled='true'] svg path {
+  fill: #666687;
+}
+
+.c20 {
+  border-radius: 50%;
+  display: block;
+  position: relative;
+}
+
+.c19 {
+  position: relative;
+  width: 26px;
+  height: 26px;
 }
 
 .c12 {
@@ -34783,47 +37704,6 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
 
 .c12:indeterminate:disabled:after {
   background-color: #8e8ea9;
-}
-
-.c16 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  height: 2rem;
-  width: 2rem;
-  border: none;
-}
-
-.c16 svg > g,
-.c16 svg path {
-  fill: #8e8ea9;
-}
-
-.c16:hover svg > g,
-.c16:hover svg path {
-  fill: #666687;
-}
-
-.c16:active svg > g,
-.c16:active svg path {
-  fill: #a5a5ba;
-}
-
-.c16[aria-disabled='true'] {
-  background-color: #eaeaef;
-}
-
-.c16[aria-disabled='true'] svg path {
-  fill: #666687;
 }
 
 .c23 {
@@ -35015,7 +37895,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                       <span>
                         <button
                           aria-disabled="false"
-                          aria-labelledby="tooltip-170"
+                          aria-labelledby="tooltip-182"
                           class="c15 c16"
                           tabindex="-1"
                           type="button"
@@ -35222,420 +38102,6 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                     <span>
                       <button
                         aria-disabled="false"
-                        aria-labelledby="tooltip-172"
-                        class="c15 c16"
-                        tabindex="-1"
-                        type="button"
-                      >
-                        <svg
-                          fill="none"
-                          height="1em"
-                          viewBox="0 0 24 24"
-                          width="1em"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            clip-rule="evenodd"
-                            d="M23.604 3.514c.528.528.528 1.36 0 1.887l-2.622 2.607-4.99-4.99L18.6.396a1.322 1.322 0 011.887 0l3.118 3.118zM0 24v-4.99l14.2-14.2 4.99 4.99L4.99 24H0z"
-                            fill="#212134"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </button>
-                    </span>
-                    <div
-                      class="c21"
-                    >
-                      <span>
-                        <button
-                          aria-disabled="false"
-                          aria-labelledby="tooltip-174"
-                          class="c15 c16"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          <svg
-                            fill="none"
-                            height="1em"
-                            viewBox="0 0 24 24"
-                            width="1em"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M3.236 6.149a.2.2 0 00-.197.233L6 24h12l2.96-17.618a.2.2 0 00-.196-.233H3.236zM21.8 1.983c.11 0 .2.09.2.2v1.584a.2.2 0 01-.2.2H2.2a.2.2 0 01-.2-.2V2.183c0-.11.09-.2.2-.2h5.511c.9 0 1.631-1.09 1.631-1.983h5.316c0 .894.73 1.983 1.631 1.983H21.8z"
-                              fill="#32324D"
-                            />
-                          </svg>
-                        </button>
-                      </span>
-                    </div>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                aria-rowindex="3"
-                class="c9"
-              >
-                <td
-                  aria-colindex="1"
-                  class="c10"
-                >
-                  <input
-                    aria-label="Select Leon Lafrite"
-                    class="c12"
-                    tabindex="-1"
-                    type="checkbox"
-                  />
-                </td>
-                <td
-                  aria-colindex="2"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c18"
-                  >
-                    1
-                  </span>
-                </td>
-                <td
-                  aria-colindex="3"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span>
-                    <div
-                      class="c19"
-                    >
-                      <img
-                        alt="Leon Lafrite"
-                        class="c20"
-                        height="26px"
-                        src="https://avatars.githubusercontent.com/u/3874873?v=4"
-                        width="26px"
-                      />
-                    </div>
-                  </span>
-                </td>
-                <td
-                  aria-colindex="4"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c18"
-                  >
-                    Chez Léon is a human sized Parisian
-                  </span>
-                </td>
-                <td
-                  aria-colindex="5"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c18"
-                  >
-                    French cuisine
-                  </span>
-                </td>
-                <td
-                  aria-colindex="6"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c18"
-                  >
-                    Leon Lafrite
-                  </span>
-                </td>
-                <td
-                  aria-colindex="7"
-                  class="c10"
-                >
-                  <div
-                    class="c11"
-                  >
-                    <span>
-                      <button
-                        aria-disabled="false"
-                        aria-labelledby="tooltip-176"
-                        class="c15 c16"
-                        tabindex="-1"
-                        type="button"
-                      >
-                        <svg
-                          fill="none"
-                          height="1em"
-                          viewBox="0 0 24 24"
-                          width="1em"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            clip-rule="evenodd"
-                            d="M23.604 3.514c.528.528.528 1.36 0 1.887l-2.622 2.607-4.99-4.99L18.6.396a1.322 1.322 0 011.887 0l3.118 3.118zM0 24v-4.99l14.2-14.2 4.99 4.99L4.99 24H0z"
-                            fill="#212134"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </button>
-                    </span>
-                    <div
-                      class="c21"
-                    >
-                      <span>
-                        <button
-                          aria-disabled="false"
-                          aria-labelledby="tooltip-178"
-                          class="c15 c16"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          <svg
-                            fill="none"
-                            height="1em"
-                            viewBox="0 0 24 24"
-                            width="1em"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M3.236 6.149a.2.2 0 00-.197.233L6 24h12l2.96-17.618a.2.2 0 00-.196-.233H3.236zM21.8 1.983c.11 0 .2.09.2.2v1.584a.2.2 0 01-.2.2H2.2a.2.2 0 01-.2-.2V2.183c0-.11.09-.2.2-.2h5.511c.9 0 1.631-1.09 1.631-1.983h5.316c0 .894.73 1.983 1.631 1.983H21.8z"
-                              fill="#32324D"
-                            />
-                          </svg>
-                        </button>
-                      </span>
-                    </div>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                aria-rowindex="4"
-                class="c9"
-              >
-                <td
-                  aria-colindex="1"
-                  class="c10"
-                >
-                  <input
-                    aria-label="Select Leon Lafrite"
-                    class="c12"
-                    tabindex="-1"
-                    type="checkbox"
-                  />
-                </td>
-                <td
-                  aria-colindex="2"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c18"
-                  >
-                    2
-                  </span>
-                </td>
-                <td
-                  aria-colindex="3"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span>
-                    <div
-                      class="c19"
-                    >
-                      <img
-                        alt="Leon Lafrite"
-                        class="c20"
-                        height="26px"
-                        src="https://avatars.githubusercontent.com/u/3874873?v=4"
-                        width="26px"
-                      />
-                    </div>
-                  </span>
-                </td>
-                <td
-                  aria-colindex="4"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c18"
-                  >
-                    Chez Léon is a human sized Parisian
-                  </span>
-                </td>
-                <td
-                  aria-colindex="5"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c18"
-                  >
-                    French cuisine
-                  </span>
-                </td>
-                <td
-                  aria-colindex="6"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c18"
-                  >
-                    Leon Lafrite
-                  </span>
-                </td>
-                <td
-                  aria-colindex="7"
-                  class="c10"
-                >
-                  <div
-                    class="c11"
-                  >
-                    <span>
-                      <button
-                        aria-disabled="false"
-                        aria-labelledby="tooltip-180"
-                        class="c15 c16"
-                        tabindex="-1"
-                        type="button"
-                      >
-                        <svg
-                          fill="none"
-                          height="1em"
-                          viewBox="0 0 24 24"
-                          width="1em"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            clip-rule="evenodd"
-                            d="M23.604 3.514c.528.528.528 1.36 0 1.887l-2.622 2.607-4.99-4.99L18.6.396a1.322 1.322 0 011.887 0l3.118 3.118zM0 24v-4.99l14.2-14.2 4.99 4.99L4.99 24H0z"
-                            fill="#212134"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </button>
-                    </span>
-                    <div
-                      class="c21"
-                    >
-                      <span>
-                        <button
-                          aria-disabled="false"
-                          aria-labelledby="tooltip-182"
-                          class="c15 c16"
-                          tabindex="-1"
-                          type="button"
-                        >
-                          <svg
-                            fill="none"
-                            height="1em"
-                            viewBox="0 0 24 24"
-                            width="1em"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M3.236 6.149a.2.2 0 00-.197.233L6 24h12l2.96-17.618a.2.2 0 00-.196-.233H3.236zM21.8 1.983c.11 0 .2.09.2.2v1.584a.2.2 0 01-.2.2H2.2a.2.2 0 01-.2-.2V2.183c0-.11.09-.2.2-.2h5.511c.9 0 1.631-1.09 1.631-1.983h5.316c0 .894.73 1.983 1.631 1.983H21.8z"
-                              fill="#32324D"
-                            />
-                          </svg>
-                        </button>
-                      </span>
-                    </div>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                aria-rowindex="5"
-                class="c9"
-              >
-                <td
-                  aria-colindex="1"
-                  class="c10"
-                >
-                  <input
-                    aria-label="Select Leon Lafrite"
-                    class="c12"
-                    tabindex="-1"
-                    type="checkbox"
-                  />
-                </td>
-                <td
-                  aria-colindex="2"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c18"
-                  >
-                    3
-                  </span>
-                </td>
-                <td
-                  aria-colindex="3"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span>
-                    <div
-                      class="c19"
-                    >
-                      <img
-                        alt="Leon Lafrite"
-                        class="c20"
-                        height="26px"
-                        src="https://avatars.githubusercontent.com/u/3874873?v=4"
-                        width="26px"
-                      />
-                    </div>
-                  </span>
-                </td>
-                <td
-                  aria-colindex="4"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c18"
-                  >
-                    Chez Léon is a human sized Parisian
-                  </span>
-                </td>
-                <td
-                  aria-colindex="5"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c18"
-                  >
-                    French cuisine
-                  </span>
-                </td>
-                <td
-                  aria-colindex="6"
-                  class="c10"
-                  tabindex="-1"
-                >
-                  <span
-                    class="c18"
-                  >
-                    Leon Lafrite
-                  </span>
-                </td>
-                <td
-                  aria-colindex="7"
-                  class="c10"
-                >
-                  <div
-                    class="c11"
-                  >
-                    <span>
-                      <button
-                        aria-disabled="false"
                         aria-labelledby="tooltip-184"
                         class="c15 c16"
                         tabindex="-1"
@@ -35687,7 +38153,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                 </td>
               </tr>
               <tr
-                aria-rowindex="6"
+                aria-rowindex="3"
                 class="c9"
               >
                 <td
@@ -35709,7 +38175,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                   <span
                     class="c18"
                   >
-                    4
+                    1
                   </span>
                 </td>
                 <td
@@ -35824,6 +38290,420 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                   </div>
                 </td>
               </tr>
+              <tr
+                aria-rowindex="4"
+                class="c9"
+              >
+                <td
+                  aria-colindex="1"
+                  class="c10"
+                >
+                  <input
+                    aria-label="Select Leon Lafrite"
+                    class="c12"
+                    tabindex="-1"
+                    type="checkbox"
+                  />
+                </td>
+                <td
+                  aria-colindex="2"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c18"
+                  >
+                    2
+                  </span>
+                </td>
+                <td
+                  aria-colindex="3"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span>
+                    <div
+                      class="c19"
+                    >
+                      <img
+                        alt="Leon Lafrite"
+                        class="c20"
+                        height="26px"
+                        src="https://avatars.githubusercontent.com/u/3874873?v=4"
+                        width="26px"
+                      />
+                    </div>
+                  </span>
+                </td>
+                <td
+                  aria-colindex="4"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c18"
+                  >
+                    Chez Léon is a human sized Parisian
+                  </span>
+                </td>
+                <td
+                  aria-colindex="5"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c18"
+                  >
+                    French cuisine
+                  </span>
+                </td>
+                <td
+                  aria-colindex="6"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c18"
+                  >
+                    Leon Lafrite
+                  </span>
+                </td>
+                <td
+                  aria-colindex="7"
+                  class="c10"
+                >
+                  <div
+                    class="c11"
+                  >
+                    <span>
+                      <button
+                        aria-disabled="false"
+                        aria-labelledby="tooltip-192"
+                        class="c15 c16"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          fill="none"
+                          height="1em"
+                          viewBox="0 0 24 24"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M23.604 3.514c.528.528.528 1.36 0 1.887l-2.622 2.607-4.99-4.99L18.6.396a1.322 1.322 0 011.887 0l3.118 3.118zM0 24v-4.99l14.2-14.2 4.99 4.99L4.99 24H0z"
+                            fill="#212134"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </button>
+                    </span>
+                    <div
+                      class="c21"
+                    >
+                      <span>
+                        <button
+                          aria-disabled="false"
+                          aria-labelledby="tooltip-194"
+                          class="c15 c16"
+                          tabindex="-1"
+                          type="button"
+                        >
+                          <svg
+                            fill="none"
+                            height="1em"
+                            viewBox="0 0 24 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M3.236 6.149a.2.2 0 00-.197.233L6 24h12l2.96-17.618a.2.2 0 00-.196-.233H3.236zM21.8 1.983c.11 0 .2.09.2.2v1.584a.2.2 0 01-.2.2H2.2a.2.2 0 01-.2-.2V2.183c0-.11.09-.2.2-.2h5.511c.9 0 1.631-1.09 1.631-1.983h5.316c0 .894.73 1.983 1.631 1.983H21.8z"
+                              fill="#32324D"
+                            />
+                          </svg>
+                        </button>
+                      </span>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+              <tr
+                aria-rowindex="5"
+                class="c9"
+              >
+                <td
+                  aria-colindex="1"
+                  class="c10"
+                >
+                  <input
+                    aria-label="Select Leon Lafrite"
+                    class="c12"
+                    tabindex="-1"
+                    type="checkbox"
+                  />
+                </td>
+                <td
+                  aria-colindex="2"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c18"
+                  >
+                    3
+                  </span>
+                </td>
+                <td
+                  aria-colindex="3"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span>
+                    <div
+                      class="c19"
+                    >
+                      <img
+                        alt="Leon Lafrite"
+                        class="c20"
+                        height="26px"
+                        src="https://avatars.githubusercontent.com/u/3874873?v=4"
+                        width="26px"
+                      />
+                    </div>
+                  </span>
+                </td>
+                <td
+                  aria-colindex="4"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c18"
+                  >
+                    Chez Léon is a human sized Parisian
+                  </span>
+                </td>
+                <td
+                  aria-colindex="5"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c18"
+                  >
+                    French cuisine
+                  </span>
+                </td>
+                <td
+                  aria-colindex="6"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c18"
+                  >
+                    Leon Lafrite
+                  </span>
+                </td>
+                <td
+                  aria-colindex="7"
+                  class="c10"
+                >
+                  <div
+                    class="c11"
+                  >
+                    <span>
+                      <button
+                        aria-disabled="false"
+                        aria-labelledby="tooltip-196"
+                        class="c15 c16"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          fill="none"
+                          height="1em"
+                          viewBox="0 0 24 24"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M23.604 3.514c.528.528.528 1.36 0 1.887l-2.622 2.607-4.99-4.99L18.6.396a1.322 1.322 0 011.887 0l3.118 3.118zM0 24v-4.99l14.2-14.2 4.99 4.99L4.99 24H0z"
+                            fill="#212134"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </button>
+                    </span>
+                    <div
+                      class="c21"
+                    >
+                      <span>
+                        <button
+                          aria-disabled="false"
+                          aria-labelledby="tooltip-198"
+                          class="c15 c16"
+                          tabindex="-1"
+                          type="button"
+                        >
+                          <svg
+                            fill="none"
+                            height="1em"
+                            viewBox="0 0 24 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M3.236 6.149a.2.2 0 00-.197.233L6 24h12l2.96-17.618a.2.2 0 00-.196-.233H3.236zM21.8 1.983c.11 0 .2.09.2.2v1.584a.2.2 0 01-.2.2H2.2a.2.2 0 01-.2-.2V2.183c0-.11.09-.2.2-.2h5.511c.9 0 1.631-1.09 1.631-1.983h5.316c0 .894.73 1.983 1.631 1.983H21.8z"
+                              fill="#32324D"
+                            />
+                          </svg>
+                        </button>
+                      </span>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+              <tr
+                aria-rowindex="6"
+                class="c9"
+              >
+                <td
+                  aria-colindex="1"
+                  class="c10"
+                >
+                  <input
+                    aria-label="Select Leon Lafrite"
+                    class="c12"
+                    tabindex="-1"
+                    type="checkbox"
+                  />
+                </td>
+                <td
+                  aria-colindex="2"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c18"
+                  >
+                    4
+                  </span>
+                </td>
+                <td
+                  aria-colindex="3"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span>
+                    <div
+                      class="c19"
+                    >
+                      <img
+                        alt="Leon Lafrite"
+                        class="c20"
+                        height="26px"
+                        src="https://avatars.githubusercontent.com/u/3874873?v=4"
+                        width="26px"
+                      />
+                    </div>
+                  </span>
+                </td>
+                <td
+                  aria-colindex="4"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c18"
+                  >
+                    Chez Léon is a human sized Parisian
+                  </span>
+                </td>
+                <td
+                  aria-colindex="5"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c18"
+                  >
+                    French cuisine
+                  </span>
+                </td>
+                <td
+                  aria-colindex="6"
+                  class="c10"
+                  tabindex="-1"
+                >
+                  <span
+                    class="c18"
+                  >
+                    Leon Lafrite
+                  </span>
+                </td>
+                <td
+                  aria-colindex="7"
+                  class="c10"
+                >
+                  <div
+                    class="c11"
+                  >
+                    <span>
+                      <button
+                        aria-disabled="false"
+                        aria-labelledby="tooltip-200"
+                        class="c15 c16"
+                        tabindex="-1"
+                        type="button"
+                      >
+                        <svg
+                          fill="none"
+                          height="1em"
+                          viewBox="0 0 24 24"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M23.604 3.514c.528.528.528 1.36 0 1.887l-2.622 2.607-4.99-4.99L18.6.396a1.322 1.322 0 011.887 0l3.118 3.118zM0 24v-4.99l14.2-14.2 4.99 4.99L4.99 24H0z"
+                            fill="#212134"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </button>
+                    </span>
+                    <div
+                      class="c21"
+                    >
+                      <span>
+                        <button
+                          aria-disabled="false"
+                          aria-labelledby="tooltip-202"
+                          class="c15 c16"
+                          tabindex="-1"
+                          type="button"
+                        >
+                          <svg
+                            fill="none"
+                            height="1em"
+                            viewBox="0 0 24 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M3.236 6.149a.2.2 0 00-.197.233L6 24h12l2.96-17.618a.2.2 0 00-.196-.233H3.236zM21.8 1.983c.11 0 .2.09.2.2v1.584a.2.2 0 01-.2.2H2.2a.2.2 0 01-.2-.2V2.183c0-.11.09-.2.2-.2h5.511c.9 0 1.631-1.09 1.631-1.983h5.316c0 .894.73 1.983 1.631 1.983H21.8z"
+                              fill="#32324D"
+                            />
+                          </svg>
+                        </button>
+                      </span>
+                    </div>
+                  </div>
+                </td>
+              </tr>
             </tbody>
           </table>
         </div>
@@ -35885,6 +38765,20 @@ exports[`Storyshots Design System/Components/Tabs base 1`] = `
   width: 1px;
 }
 
+.c9 {
+  font-weight: 600;
+  color: #271fe0;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
+.c12 {
+  font-weight: 600;
+  color: #666687;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
 .c1 {
   background: #f0f0ff;
   padding: 40px;
@@ -35898,20 +38792,6 @@ exports[`Storyshots Design System/Components/Tabs base 1`] = `
 .c10 {
   background: #f6f6f9;
   padding: 12px;
-}
-
-.c9 {
-  font-weight: 600;
-  color: #271fe0;
-  font-size: 0.875rem;
-  line-height: 1.43;
-}
-
-.c12 {
-  font-weight: 600;
-  color: #666687;
-  font-size: 0.875rem;
-  line-height: 1.43;
 }
 
 .c2 {
@@ -36083,20 +38963,6 @@ exports[`Storyshots Design System/Components/Tabs disabled 1`] = `
   width: 1px;
 }
 
-.c1 {
-  background: #ffffff;
-  padding: 40px;
-}
-
-.c3 {
-  padding: 16px;
-}
-
-.c8 {
-  background: #ffffff;
-  padding: 16px;
-}
-
 .c5 {
   color: #4945ff;
   font-weight: 600;
@@ -36111,6 +38977,20 @@ exports[`Storyshots Design System/Components/Tabs disabled 1`] = `
   font-size: 0.6875rem;
   line-height: 1.45;
   text-transform: uppercase;
+}
+
+.c1 {
+  background: #ffffff;
+  padding: 40px;
+}
+
+.c3 {
+  padding: 16px;
+}
+
+.c8 {
+  background: #ffffff;
+  padding: 16px;
 }
 
 .c4 {
@@ -36308,20 +39188,6 @@ exports[`Storyshots Design System/Components/Tabs selected 1`] = `
   width: 1px;
 }
 
-.c1 {
-  background: #ffffff;
-  padding: 40px;
-}
-
-.c3 {
-  padding: 16px;
-}
-
-.c8 {
-  background: #ffffff;
-  padding: 16px;
-}
-
 .c5 {
   color: #666687;
   font-weight: 600;
@@ -36336,6 +39202,20 @@ exports[`Storyshots Design System/Components/Tabs selected 1`] = `
   font-size: 0.6875rem;
   line-height: 1.45;
   text-transform: uppercase;
+}
+
+.c1 {
+  background: #ffffff;
+  padding: 40px;
+}
+
+.c3 {
+  padding: 16px;
+}
+
+.c8 {
+  background: #ffffff;
+  padding: 16px;
 }
 
 .c4 {
@@ -36457,20 +39337,6 @@ exports[`Storyshots Design System/Components/Tabs simple 1`] = `
   width: 1px;
 }
 
-.c1 {
-  background: #ffffff;
-  padding: 40px;
-}
-
-.c3 {
-  padding: 16px;
-}
-
-.c9 {
-  background: #ffffff;
-  padding: 16px;
-}
-
 .c5 {
   color: #4945ff;
   font-weight: 600;
@@ -36493,6 +39359,20 @@ exports[`Storyshots Design System/Components/Tabs simple 1`] = `
   font-size: 0.6875rem;
   line-height: 1.45;
   text-transform: uppercase;
+}
+
+.c1 {
+  background: #ffffff;
+  padding: 40px;
+}
+
+.c3 {
+  padding: 16px;
+}
+
+.c9 {
+  background: #ffffff;
+  padding: 16px;
 }
 
 .c4 {
@@ -36614,6 +39494,13 @@ exports[`Storyshots Design System/Components/Tag base 1`] = `
   width: 1px;
 }
 
+.c4 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
 .c1 {
   background: #f0f0ff;
   color: #4945ff;
@@ -36628,13 +39515,6 @@ exports[`Storyshots Design System/Components/Tag base 1`] = `
 
 .c6 {
   padding-left: 8px;
-}
-
-.c4 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
 }
 
 .c3 {
@@ -36726,6 +39606,13 @@ exports[`Storyshots Design System/Components/Tag disabled 1`] = `
   width: 1px;
 }
 
+.c4 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
 .c1 {
   background: #dcdce4;
   color: #4a4a6a;
@@ -36740,13 +39627,6 @@ exports[`Storyshots Design System/Components/Tag disabled 1`] = `
 
 .c6 {
   padding-left: 8px;
-}
-
-.c4 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
 }
 
 .c3 {
@@ -36839,14 +39719,6 @@ exports[`Storyshots Design System/Components/TextButton base 1`] = `
   width: 1px;
 }
 
-.c3 {
-  padding-right: 8px;
-}
-
-.c5 {
-  padding-left: 8px;
-}
-
 .c4 {
   color: #4945ff;
   font-size: 0.75rem;
@@ -36857,6 +39729,14 @@ exports[`Storyshots Design System/Components/TextButton base 1`] = `
   color: #666687;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c3 {
+  padding-right: 8px;
+}
+
+.c5 {
+  padding-left: 8px;
 }
 
 .c1 {
@@ -37048,14 +39928,6 @@ exports[`Storyshots Design System/Components/TextInput base 1`] = `
   width: 1px;
 }
 
-.c1 {
-  padding: 56px;
-}
-
-.c5 {
-  padding-left: 4px;
-}
-
 .c4 {
   font-weight: 600;
   color: #32324d;
@@ -37067,6 +39939,14 @@ exports[`Storyshots Design System/Components/TextInput base 1`] = `
   color: #666687;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c1 {
+  padding: 56px;
+}
+
+.c5 {
+  padding-left: 4px;
 }
 
 .c3 {
@@ -37205,7 +40085,7 @@ exports[`Storyshots Design System/Components/TextInput base 1`] = `
           >
             <label
               class="c4"
-              for="textinput-192"
+              for="textinput-204"
             >
               Content
             </label>
@@ -37214,7 +40094,7 @@ exports[`Storyshots Design System/Components/TextInput base 1`] = `
             >
               <span>
                 <button
-                  aria-describedby="tooltip-193"
+                  aria-describedby="tooltip-205"
                   aria-label="Information about the email"
                   style="padding: 0px; background: transparent;"
                   tabindex="0"
@@ -37240,11 +40120,11 @@ exports[`Storyshots Design System/Components/TextInput base 1`] = `
             class="c7 c8"
           >
             <input
-              aria-describedby="textinput-192-hint"
+              aria-describedby="textinput-204-hint"
               aria-disabled="false"
               aria-invalid="false"
               class="c9"
-              id="textinput-192"
+              id="textinput-204"
               name="content"
               placeholder="This is a content placeholder"
               value=""
@@ -37252,7 +40132,7 @@ exports[`Storyshots Design System/Components/TextInput base 1`] = `
           </div>
           <p
             class="c10"
-            id="textinput-192-hint"
+            id="textinput-204-hint"
           >
             Description line
           </p>
@@ -37276,14 +40156,6 @@ exports[`Storyshots Design System/Components/TextInput disabled 1`] = `
   width: 1px;
 }
 
-.c1 {
-  padding: 56px;
-}
-
-.c5 {
-  padding-left: 4px;
-}
-
 .c4 {
   font-weight: 600;
   color: #32324d;
@@ -37295,6 +40167,14 @@ exports[`Storyshots Design System/Components/TextInput disabled 1`] = `
   color: #666687;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c1 {
+  padding: 56px;
+}
+
+.c5 {
+  padding-left: 4px;
 }
 
 .c3 {
@@ -37436,7 +40316,7 @@ exports[`Storyshots Design System/Components/TextInput disabled 1`] = `
           >
             <label
               class="c4"
-              for="textinput-195"
+              for="textinput-207"
             >
               Content
             </label>
@@ -37445,7 +40325,7 @@ exports[`Storyshots Design System/Components/TextInput disabled 1`] = `
             >
               <span>
                 <button
-                  aria-describedby="tooltip-196"
+                  aria-describedby="tooltip-208"
                   aria-label="Information about the email"
                   style="padding: 0px; background: transparent;"
                   tabindex="0"
@@ -37472,11 +40352,11 @@ exports[`Storyshots Design System/Components/TextInput disabled 1`] = `
             disabled=""
           >
             <input
-              aria-describedby="textinput-195-hint"
+              aria-describedby="textinput-207-hint"
               aria-disabled="true"
               aria-invalid="false"
               class="c9"
-              id="textinput-195"
+              id="textinput-207"
               name="content"
               placeholder="This is a content placeholder"
               value="Disabled ontent"
@@ -37484,7 +40364,7 @@ exports[`Storyshots Design System/Components/TextInput disabled 1`] = `
           </div>
           <p
             class="c10"
-            id="textinput-195-hint"
+            id="textinput-207-hint"
           >
             Description line
           </p>
@@ -37508,14 +40388,6 @@ exports[`Storyshots Design System/Components/TextInput password 1`] = `
   width: 1px;
 }
 
-.c1 {
-  padding: 56px;
-}
-
-.c5 {
-  padding-left: 4px;
-}
-
 .c4 {
   font-weight: 600;
   color: #32324d;
@@ -37527,6 +40399,14 @@ exports[`Storyshots Design System/Components/TextInput password 1`] = `
   color: #666687;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c1 {
+  padding: 56px;
+}
+
+.c5 {
+  padding-left: 4px;
 }
 
 .c3 {
@@ -37665,7 +40545,7 @@ exports[`Storyshots Design System/Components/TextInput password 1`] = `
           >
             <label
               class="c4"
-              for="textinput-198"
+              for="textinput-210"
             >
               Password
             </label>
@@ -37674,7 +40554,7 @@ exports[`Storyshots Design System/Components/TextInput password 1`] = `
             >
               <span>
                 <button
-                  aria-describedby="tooltip-199"
+                  aria-describedby="tooltip-211"
                   aria-label="Information about the email"
                   style="padding: 0px; background: transparent;"
                   tabindex="0"
@@ -37700,11 +40580,11 @@ exports[`Storyshots Design System/Components/TextInput password 1`] = `
             class="c7 c8"
           >
             <input
-              aria-describedby="textinput-198-hint"
+              aria-describedby="textinput-210-hint"
               aria-disabled="false"
               aria-invalid="false"
               class="c9"
-              id="textinput-198"
+              id="textinput-210"
               name="password"
               placeholder="This is a password placeholder"
               type="password"
@@ -37713,7 +40593,7 @@ exports[`Storyshots Design System/Components/TextInput password 1`] = `
           </div>
           <p
             class="c10"
-            id="textinput-198-hint"
+            id="textinput-210-hint"
           >
             Description line
           </p>
@@ -37737,14 +40617,6 @@ exports[`Storyshots Design System/Components/TextInput size S 1`] = `
   width: 1px;
 }
 
-.c1 {
-  padding: 56px;
-}
-
-.c5 {
-  padding-left: 4px;
-}
-
 .c4 {
   font-weight: 600;
   color: #32324d;
@@ -37756,6 +40628,14 @@ exports[`Storyshots Design System/Components/TextInput size S 1`] = `
   color: #666687;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c1 {
+  padding: 56px;
+}
+
+.c5 {
+  padding-left: 4px;
 }
 
 .c3 {
@@ -37894,7 +40774,7 @@ exports[`Storyshots Design System/Components/TextInput size S 1`] = `
           >
             <label
               class="c4"
-              for="textinput-201"
+              for="textinput-213"
             >
               Content
             </label>
@@ -37903,7 +40783,7 @@ exports[`Storyshots Design System/Components/TextInput size S 1`] = `
             >
               <span>
                 <button
-                  aria-describedby="tooltip-202"
+                  aria-describedby="tooltip-214"
                   aria-label="Information about the email"
                   style="padding: 0px; background: transparent;"
                   tabindex="0"
@@ -37929,11 +40809,11 @@ exports[`Storyshots Design System/Components/TextInput size S 1`] = `
             class="c7 c8"
           >
             <input
-              aria-describedby="textinput-201-hint"
+              aria-describedby="textinput-213-hint"
               aria-disabled="false"
               aria-invalid="false"
               class="c9"
-              id="textinput-201"
+              id="textinput-213"
               name="content"
               placeholder="This is a content placeholder"
               value="size S input"
@@ -37941,7 +40821,7 @@ exports[`Storyshots Design System/Components/TextInput size S 1`] = `
           </div>
           <p
             class="c10"
-            id="textinput-201-hint"
+            id="textinput-213-hint"
           >
             Description line
           </p>
@@ -37965,14 +40845,6 @@ exports[`Storyshots Design System/Components/TextInput with error 1`] = `
   width: 1px;
 }
 
-.c1 {
-  padding: 56px;
-}
-
-.c5 {
-  padding-left: 4px;
-}
-
 .c4 {
   font-weight: 600;
   color: #32324d;
@@ -37984,6 +40856,14 @@ exports[`Storyshots Design System/Components/TextInput with error 1`] = `
   color: #d02b20;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c1 {
+  padding: 56px;
+}
+
+.c5 {
+  padding-left: 4px;
 }
 
 .c3 {
@@ -38122,7 +41002,7 @@ exports[`Storyshots Design System/Components/TextInput with error 1`] = `
           >
             <label
               class="c4"
-              for="textinput-204"
+              for="textinput-216"
             >
               Content
             </label>
@@ -38131,7 +41011,7 @@ exports[`Storyshots Design System/Components/TextInput with error 1`] = `
             >
               <span>
                 <button
-                  aria-describedby="tooltip-205"
+                  aria-describedby="tooltip-217"
                   aria-label="Information about the email"
                   style="padding: 0px; background: transparent;"
                   tabindex="0"
@@ -38157,11 +41037,11 @@ exports[`Storyshots Design System/Components/TextInput with error 1`] = `
             class="c7 c8"
           >
             <input
-              aria-describedby="textinput-204-error"
+              aria-describedby="textinput-216-error"
               aria-disabled="false"
               aria-invalid="true"
               class="c9"
-              id="textinput-204"
+              id="textinput-216"
               name="content"
               placeholder="This is a content placeholder"
               value="content"
@@ -38170,7 +41050,7 @@ exports[`Storyshots Design System/Components/TextInput with error 1`] = `
           <p
             class="c10"
             data-strapi-field-error="true"
-            id="textinput-204-error"
+            id="textinput-216-error"
           >
             Content is too long
           </p>
@@ -38194,14 +41074,14 @@ exports[`Storyshots Design System/Components/TextInput withoutLabel 1`] = `
   width: 1px;
 }
 
-.c1 {
-  padding: 56px;
-}
-
 .c6 {
   color: #666687;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c1 {
+  padding: 56px;
 }
 
 .c3 {
@@ -38321,12 +41201,12 @@ exports[`Storyshots Design System/Components/TextInput withoutLabel 1`] = `
             class="c3 c4"
           >
             <input
-              aria-describedby="textinput-207-hint"
+              aria-describedby="textinput-219-hint"
               aria-disabled="false"
               aria-invalid="false"
               aria-label="Password"
               class="c5"
-              id="textinput-207"
+              id="textinput-219"
               name="password"
               placeholder="This is a password placeholder"
               type="password"
@@ -38335,7 +41215,7 @@ exports[`Storyshots Design System/Components/TextInput withoutLabel 1`] = `
           </div>
           <p
             class="c6"
-            id="textinput-207-hint"
+            id="textinput-219-hint"
           >
             Description line
           </p>
@@ -38359,14 +41239,6 @@ exports[`Storyshots Design System/Components/Textarea base 1`] = `
   width: 1px;
 }
 
-.c1 {
-  padding: 56px;
-}
-
-.c6 {
-  padding-left: 4px;
-}
-
 .c5 {
   font-weight: 600;
   color: #32324d;
@@ -38378,6 +41250,14 @@ exports[`Storyshots Design System/Components/Textarea base 1`] = `
   color: #d02b20;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c1 {
+  padding: 56px;
+}
+
+.c6 {
+  padding-left: 4px;
 }
 
 .c4 {
@@ -38528,7 +41408,7 @@ exports[`Storyshots Design System/Components/Textarea base 1`] = `
           >
             <label
               class="c5"
-              for="textarea-208"
+              for="textarea-220"
             >
               Content
             </label>
@@ -38537,7 +41417,7 @@ exports[`Storyshots Design System/Components/Textarea base 1`] = `
             >
               <span>
                 <button
-                  aria-describedby="tooltip-209"
+                  aria-describedby="tooltip-221"
                   aria-label="Information about the email"
                   style="padding: 0px; background: transparent;"
                   tabindex="0"
@@ -38563,10 +41443,10 @@ exports[`Storyshots Design System/Components/Textarea base 1`] = `
             class="c7"
           >
             <textarea
-              aria-describedby="textarea-208-error"
+              aria-describedby="textarea-220-error"
               aria-invalid="true"
               class="c8"
-              id="textarea-208"
+              id="textarea-220"
               name="content"
               placeholder="This is a content placeholder"
             />
@@ -38574,7 +41454,7 @@ exports[`Storyshots Design System/Components/Textarea base 1`] = `
           <p
             class="c9"
             data-strapi-field-error="true"
-            id="textarea-208-error"
+            id="textarea-220-error"
           >
             Content is too short
           </p>
@@ -38598,14 +41478,6 @@ exports[`Storyshots Design System/Components/Textarea disabled 1`] = `
   width: 1px;
 }
 
-.c1 {
-  padding: 56px;
-}
-
-.c6 {
-  padding-left: 4px;
-}
-
 .c5 {
   font-weight: 600;
   color: #32324d;
@@ -38617,6 +41489,14 @@ exports[`Storyshots Design System/Components/Textarea disabled 1`] = `
   color: #666687;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c1 {
+  padding: 56px;
+}
+
+.c6 {
+  padding-left: 4px;
 }
 
 .c4 {
@@ -38767,7 +41647,7 @@ exports[`Storyshots Design System/Components/Textarea disabled 1`] = `
           >
             <label
               class="c5"
-              for="textarea-211"
+              for="textarea-223"
             >
               Content
             </label>
@@ -38776,7 +41656,7 @@ exports[`Storyshots Design System/Components/Textarea disabled 1`] = `
             >
               <span>
                 <button
-                  aria-describedby="tooltip-212"
+                  aria-describedby="tooltip-224"
                   aria-label="Information about the email"
                   style="padding: 0px; background: transparent;"
                   tabindex="0"
@@ -38803,18 +41683,18 @@ exports[`Storyshots Design System/Components/Textarea disabled 1`] = `
             disabled=""
           >
             <textarea
-              aria-describedby="textarea-211-hint"
+              aria-describedby="textarea-223-hint"
               aria-invalid="false"
               class="c8"
               disabled=""
-              id="textarea-211"
+              id="textarea-223"
               name="content"
               placeholder="This is a content placeholder"
             />
           </div>
           <p
             class="c9"
-            id="textarea-211-hint"
+            id="textarea-223-hint"
           >
             Description line
           </p>
@@ -38838,15 +41718,6 @@ exports[`Storyshots Design System/Components/TimePicker 30-mns-step 1`] = `
   width: 1px;
 }
 
-.c8 {
-  padding-left: 12px;
-}
-
-.c10 {
-  padding-right: 16px;
-  padding-left: 16px;
-}
-
 .c2 {
   font-weight: 600;
   color: #32324d;
@@ -38868,6 +41739,15 @@ exports[`Storyshots Design System/Components/TimePicker 30-mns-step 1`] = `
   color: #666687;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c8 {
+  padding-left: 12px;
+}
+
+.c10 {
+  padding-right: 16px;
+  padding-left: 16px;
 }
 
 .c3 {
@@ -39137,15 +42017,6 @@ exports[`Storyshots Design System/Components/TimePicker base 1`] = `
   width: 1px;
 }
 
-.c8 {
-  padding-left: 12px;
-}
-
-.c10 {
-  padding-right: 16px;
-  padding-left: 16px;
-}
-
 .c2 {
   font-weight: 600;
   color: #32324d;
@@ -39167,6 +42038,15 @@ exports[`Storyshots Design System/Components/TimePicker base 1`] = `
   color: #666687;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c8 {
+  padding-left: 12px;
+}
+
+.c10 {
+  padding-right: 16px;
+  padding-left: 16px;
 }
 
 .c3 {
@@ -39436,15 +42316,6 @@ exports[`Storyshots Design System/Components/TimePicker disabled 1`] = `
   width: 1px;
 }
 
-.c8 {
-  padding-left: 12px;
-}
-
-.c10 {
-  padding-right: 16px;
-  padding-left: 16px;
-}
-
 .c2 {
   font-weight: 600;
   color: #32324d;
@@ -39466,6 +42337,15 @@ exports[`Storyshots Design System/Components/TimePicker disabled 1`] = `
   color: #666687;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c8 {
+  padding-left: 12px;
+}
+
+.c10 {
+  padding-right: 16px;
+  padding-left: 16px;
 }
 
 .c3 {
@@ -39740,19 +42620,6 @@ exports[`Storyshots Design System/Components/TimePicker initial-data 1`] = `
   width: 1px;
 }
 
-.c2 {
-  padding-top: 8px;
-}
-
-.c10 {
-  padding-left: 12px;
-}
-
-.c12 {
-  padding-right: 16px;
-  padding-left: 16px;
-}
-
 .c1 {
   color: #32324d;
   font-size: 0.875rem;
@@ -39780,6 +42647,19 @@ exports[`Storyshots Design System/Components/TimePicker initial-data 1`] = `
   color: #666687;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c2 {
+  padding-top: 8px;
+}
+
+.c10 {
+  padding-left: 12px;
+}
+
+.c12 {
+  padding-right: 16px;
+  padding-left: 16px;
 }
 
 .c5 {
@@ -40077,15 +42957,6 @@ exports[`Storyshots Design System/Components/TimePicker size S 1`] = `
   width: 1px;
 }
 
-.c8 {
-  padding-left: 12px;
-}
-
-.c10 {
-  padding-right: 16px;
-  padding-left: 16px;
-}
-
 .c2 {
   font-weight: 600;
   color: #32324d;
@@ -40107,6 +42978,15 @@ exports[`Storyshots Design System/Components/TimePicker size S 1`] = `
   color: #666687;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c8 {
+  padding-left: 12px;
+}
+
+.c10 {
+  padding-right: 16px;
+  padding-left: 16px;
 }
 
 .c3 {
@@ -40376,6 +43256,20 @@ exports[`Storyshots Design System/Components/ToggleCheckbox activated 1`] = `
   width: 1px;
 }
 
+.c7 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c10 {
+  font-weight: 600;
+  color: #271fe0;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
 .c2 {
   background: #ffffff;
   border-radius: 4px;
@@ -40391,20 +43285,6 @@ exports[`Storyshots Design System/Components/ToggleCheckbox activated 1`] = `
   background: #f0f0ff;
   padding-right: 32px;
   padding-left: 32px;
-}
-
-.c7 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c10 {
-  font-weight: 600;
-  color: #271fe0;
-  font-size: 0.75rem;
-  line-height: 1.33;
 }
 
 .c5 {
@@ -40530,6 +43410,20 @@ exports[`Storyshots Design System/Components/ToggleCheckbox disabled 1`] = `
   width: 1px;
 }
 
+.c7 {
+  font-weight: 600;
+  color: #666687;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c10 {
+  font-weight: 600;
+  color: #4a4a6a;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
 .c2 {
   background: #ffffff;
   border-radius: 4px;
@@ -40545,20 +43439,6 @@ exports[`Storyshots Design System/Components/ToggleCheckbox disabled 1`] = `
   background: #dcdce4;
   padding-right: 32px;
   padding-left: 32px;
-}
-
-.c7 {
-  font-weight: 600;
-  color: #666687;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c10 {
-  font-weight: 600;
-  color: #4a4a6a;
-  font-size: 0.75rem;
-  line-height: 1.33;
 }
 
 .c5 {
@@ -40687,6 +43567,20 @@ exports[`Storyshots Design System/Components/ToggleCheckbox not activated 1`] = 
   width: 1px;
 }
 
+.c7 {
+  font-weight: 600;
+  color: #b72b1a;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c10 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
 .c2 {
   background: #ffffff;
   border-radius: 4px;
@@ -40702,20 +43596,6 @@ exports[`Storyshots Design System/Components/ToggleCheckbox not activated 1`] = 
   background: #ffffff;
   padding-right: 32px;
   padding-left: 32px;
-}
-
-.c7 {
-  font-weight: 600;
-  color: #b72b1a;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c10 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
 }
 
 .c5 {
@@ -40840,6 +43720,20 @@ exports[`Storyshots Design System/Components/ToggleCheckbox size S 1`] = `
   width: 1px;
 }
 
+.c7 {
+  font-weight: 600;
+  color: #b72b1a;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c10 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
 .c2 {
   background: #ffffff;
   border-radius: 4px;
@@ -40855,20 +43749,6 @@ exports[`Storyshots Design System/Components/ToggleCheckbox size S 1`] = `
   background: #ffffff;
   padding-right: 32px;
   padding-left: 32px;
-}
-
-.c7 {
-  font-weight: 600;
-  color: #b72b1a;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c10 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
 }
 
 .c5 {
@@ -40993,6 +43873,26 @@ exports[`Storyshots Design System/Components/ToggleInput base 1`] = `
   width: 1px;
 }
 
+.c4 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c14 {
+  font-weight: 600;
+  color: #271fe0;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c16 {
+  color: #666687;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
 .c5 {
   padding-left: 4px;
 }
@@ -41012,26 +43912,6 @@ exports[`Storyshots Design System/Components/ToggleInput base 1`] = `
   background: #f0f0ff;
   padding-right: 32px;
   padding-left: 32px;
-}
-
-.c4 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c14 {
-  font-weight: 600;
-  color: #271fe0;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c16 {
-  color: #666687;
-  font-size: 0.75rem;
-  line-height: 1.33;
 }
 
 .c3 {
@@ -41142,7 +44022,7 @@ exports[`Storyshots Design System/Components/ToggleInput base 1`] = `
       >
         <label
           class="c4"
-          for="toggleinput-214"
+          for="toggleinput-226"
         >
           Enabled
         </label>
@@ -41151,7 +44031,7 @@ exports[`Storyshots Design System/Components/ToggleInput base 1`] = `
         >
           <span>
             <button
-              aria-describedby="tooltip-215"
+              aria-describedby="tooltip-227"
               aria-label="Information about the email"
               style="padding: 0px; background: transparent;"
               tabindex="0"
@@ -41208,7 +44088,7 @@ exports[`Storyshots Design System/Components/ToggleInput base 1`] = `
             aria-disabled="false"
             checked=""
             class="c15"
-            id="toggleinput-214"
+            id="toggleinput-226"
             name="enable-provider"
             type="checkbox"
           />
@@ -41216,7 +44096,7 @@ exports[`Storyshots Design System/Components/ToggleInput base 1`] = `
       </label>
       <p
         class="c16"
-        id="toggleinput-214-hint"
+        id="toggleinput-226-hint"
       >
         Enable provider
       </p>
@@ -41238,23 +44118,6 @@ exports[`Storyshots Design System/Components/ToggleInput error 1`] = `
   width: 1px;
 }
 
-.c6 {
-  background: #ffffff;
-  border-radius: 4px;
-}
-
-.c8 {
-  background: #fcecea;
-  padding-right: 32px;
-  padding-left: 32px;
-}
-
-.c11 {
-  background: #ffffff;
-  padding-right: 32px;
-  padding-left: 32px;
-}
-
 .c4 {
   font-weight: 600;
   color: #32324d;
@@ -41273,6 +44136,23 @@ exports[`Storyshots Design System/Components/ToggleInput error 1`] = `
   color: #d02b20;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c6 {
+  background: #ffffff;
+  border-radius: 4px;
+}
+
+.c8 {
+  background: #fcecea;
+  padding-right: 32px;
+  padding-left: 32px;
+}
+
+.c11 {
+  background: #ffffff;
+  padding-right: 32px;
+  padding-left: 32px;
 }
 
 .c3 {
@@ -41379,7 +44259,7 @@ exports[`Storyshots Design System/Components/ToggleInput error 1`] = `
       >
         <label
           class="c4"
-          for="toggleinput-217"
+          for="toggleinput-229"
         >
           Label
         </label>
@@ -41418,7 +44298,7 @@ exports[`Storyshots Design System/Components/ToggleInput error 1`] = `
           <input
             aria-disabled="false"
             class="c13"
-            id="toggleinput-217"
+            id="toggleinput-229"
             name="enable-provider"
             type="checkbox"
           />
@@ -41427,7 +44307,7 @@ exports[`Storyshots Design System/Components/ToggleInput error 1`] = `
       <p
         class="c14"
         data-strapi-field-error="true"
-        id="toggleinput-217-error"
+        id="toggleinput-229-error"
       >
         this field is required
       </p>
@@ -41449,17 +44329,6 @@ exports[`Storyshots Design System/Components/ToggleInput null-value 1`] = `
   width: 1px;
 }
 
-.c6 {
-  background: #ffffff;
-  border-radius: 4px;
-}
-
-.c8 {
-  background: #ffffff;
-  padding-right: 32px;
-  padding-left: 32px;
-}
-
 .c4 {
   font-weight: 600;
   color: #32324d;
@@ -41478,6 +44347,17 @@ exports[`Storyshots Design System/Components/ToggleInput null-value 1`] = `
   color: #666687;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c6 {
+  background: #ffffff;
+  border-radius: 4px;
+}
+
+.c8 {
+  background: #ffffff;
+  padding-right: 32px;
+  padding-left: 32px;
 }
 
 .c3 {
@@ -41584,7 +44464,7 @@ exports[`Storyshots Design System/Components/ToggleInput null-value 1`] = `
       >
         <label
           class="c4"
-          for="toggleinput-218"
+          for="toggleinput-230"
         >
           Label
         </label>
@@ -41623,7 +44503,7 @@ exports[`Storyshots Design System/Components/ToggleInput null-value 1`] = `
           <input
             aria-disabled="false"
             class="c12"
-            id="toggleinput-218"
+            id="toggleinput-230"
             name="enable-provider"
             type="checkbox"
           />
@@ -41631,7 +44511,7 @@ exports[`Storyshots Design System/Components/ToggleInput null-value 1`] = `
       </label>
       <p
         class="c13"
-        id="toggleinput-218-hint"
+        id="toggleinput-230-hint"
       >
         Enable provider
       </p>
@@ -41653,23 +44533,6 @@ exports[`Storyshots Design System/Components/ToggleInput size S 1`] = `
   width: 1px;
 }
 
-.c6 {
-  background: #ffffff;
-  border-radius: 4px;
-}
-
-.c8 {
-  background: #fcecea;
-  padding-right: 32px;
-  padding-left: 32px;
-}
-
-.c11 {
-  background: #ffffff;
-  padding-right: 32px;
-  padding-left: 32px;
-}
-
 .c4 {
   font-weight: 600;
   color: #32324d;
@@ -41688,6 +44551,23 @@ exports[`Storyshots Design System/Components/ToggleInput size S 1`] = `
   color: #d02b20;
   font-size: 0.75rem;
   line-height: 1.33;
+}
+
+.c6 {
+  background: #ffffff;
+  border-radius: 4px;
+}
+
+.c8 {
+  background: #fcecea;
+  padding-right: 32px;
+  padding-left: 32px;
+}
+
+.c11 {
+  background: #ffffff;
+  padding-right: 32px;
+  padding-left: 32px;
 }
 
 .c3 {
@@ -41794,7 +44674,7 @@ exports[`Storyshots Design System/Components/ToggleInput size S 1`] = `
       >
         <label
           class="c4"
-          for="toggleinput-219"
+          for="toggleinput-231"
         >
           Label
         </label>
@@ -41833,7 +44713,7 @@ exports[`Storyshots Design System/Components/ToggleInput size S 1`] = `
           <input
             aria-disabled="false"
             class="c13"
-            id="toggleinput-219"
+            id="toggleinput-231"
             name="enable-provider"
             type="checkbox"
           />
@@ -41842,7 +44722,7 @@ exports[`Storyshots Design System/Components/ToggleInput size S 1`] = `
       <p
         class="c14"
         data-strapi-field-error="true"
-        id="toggleinput-219-error"
+        id="toggleinput-231-error"
       >
         this field is required
       </p>
@@ -41878,7 +44758,7 @@ exports[`Storyshots Design System/Components/Tooltip base 1`] = `
     </p>
     <span>
       <span
-        aria-describedby="tooltip-220"
+        aria-describedby="tooltip-232"
         tabindex="0"
       >
         Show tooltip
@@ -41950,7 +44830,7 @@ exports[`Storyshots Design System/Components/Tooltip grid 1`] = `
       >
         <span>
           <button
-            aria-describedby="tooltip-222"
+            aria-describedby="tooltip-234"
             tabindex="0"
           >
             Default tooltip
@@ -41966,7 +44846,7 @@ exports[`Storyshots Design System/Components/Tooltip grid 1`] = `
       >
         <span>
           <button
-            aria-describedby="tooltip-224"
+            aria-describedby="tooltip-236"
             tabindex="0"
           >
             Bottom
@@ -41982,7 +44862,7 @@ exports[`Storyshots Design System/Components/Tooltip grid 1`] = `
       >
         <span>
           <button
-            aria-describedby="tooltip-226"
+            aria-describedby="tooltip-238"
             tabindex="0"
           >
             Right
@@ -41998,7 +44878,7 @@ exports[`Storyshots Design System/Components/Tooltip grid 1`] = `
       >
         <span>
           <button
-            aria-describedby="tooltip-228"
+            aria-describedby="tooltip-240"
             tabindex="0"
           >
             Left
@@ -42034,7 +44914,7 @@ exports[`Storyshots Design System/Components/Tooltip with text inside 1`] = `
   <div>
     <span>
       <span
-        aria-describedby="tooltip-230"
+        aria-describedby="tooltip-242"
         tabindex="0"
       >
         Show tooltip
@@ -42044,7 +44924,7 @@ exports[`Storyshots Design System/Components/Tooltip with text inside 1`] = `
   <div>
     <span>
       <button
-        aria-describedby="tooltip-232"
+        aria-describedby="tooltip-244"
         tabindex="0"
       >
         A longer CTA with longer content
@@ -42614,6 +45494,42 @@ exports[`Storyshots Design System/Technical Components/BaseCheckbox indeterminat
 </main>
 `;
 
+exports[`Storyshots Design System/Technical Components/BaseLink base 1`] = `
+.c0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c1 {
+  cursor: pointer;
+}
+
+<main>
+  <div
+    class="c0"
+  >
+    <h1>
+      Storybook story
+    </h1>
+  </div>
+  <a
+    class="c1"
+    href="https://strapi.io"
+    rel="noreferrer noopener"
+    target="_blank"
+  >
+    Base link
+  </a>
+</main>
+`;
+
 exports[`Storyshots Design System/Technical Components/BaseRadio base 1`] = `
 .c0 {
   border: 0;
@@ -42987,6 +45903,20 @@ exports[`Storyshots Design System/Technical Components/FocusTrap base 1`] = `
   width: 1px;
 }
 
+.c6 {
+  color: #32324d;
+  font-weight: 600;
+  font-size: 1.125rem;
+  line-height: 1.22;
+}
+
+.c10 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
 .c2 {
   background: #eaeaef;
   padding: 56px;
@@ -43000,20 +45930,6 @@ exports[`Storyshots Design System/Technical Components/FocusTrap base 1`] = `
 
 .c7 {
   padding-top: 8px;
-}
-
-.c6 {
-  color: #32324d;
-  font-weight: 600;
-  font-size: 1.125rem;
-  line-height: 1.22;
-}
-
-.c10 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.75rem;
-  line-height: 1.33;
 }
 
 .c3 {
@@ -46190,21 +49106,6 @@ exports[`Storyshots Design System/Technical Components/Typography variants 1`] =
   width: 1px;
 }
 
-.c2 {
-  background: #eaeaef;
-}
-
-.c4 {
-  padding-top: 8px;
-  padding-left: 16px;
-}
-
-.c14 {
-  padding-top: 8px;
-  padding-left: 16px;
-  width: 200px;
-}
-
 .c1 {
   color: #32324d;
   font-weight: 600;
@@ -46281,6 +49182,21 @@ exports[`Storyshots Design System/Technical Components/Typography variants 1`] =
   text-overflow: ellipsis;
   font-size: 0.875rem;
   line-height: 1.43;
+}
+
+.c2 {
+  background: #eaeaef;
+}
+
+.c4 {
+  padding-top: 8px;
+  padding-left: 16px;
+}
+
+.c14 {
+  padding-top: 8px;
+  padding-left: 16px;
+  width: 200px;
 }
 
 .c3 {

--- a/packages/strapi-design-system/webpack.config.js
+++ b/packages/strapi-design-system/webpack.config.js
@@ -66,7 +66,6 @@ module.exports = {
     {
       react: 'react',
       'react-dom': 'react-dom',
-      'react-router-dom': 'react-router-dom',
       'styled-components': 'styled-components',
     },
     /^@strapi\/icons/,

--- a/plop-templates/stories.hbs
+++ b/plop-templates/stories.hbs
@@ -1,6 +1,6 @@
 <!--- {{name}}.stories.mdx --->
 
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { {{name}} } from './{{name}}';
 
 <Meta

--- a/website/package.json
+++ b/website/package.json
@@ -28,6 +28,7 @@
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.26.1",
-    "prettier": "^2.4.1"
+    "prettier": "^2.4.1",
+    "react-router-dom": "^6.0.2"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -28,7 +28,6 @@
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.26.1",
-    "prettier": "^2.4.1",
-    "react-router-dom": "^6.0.2"
+    "prettier": "^2.4.1"
   }
 }

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -226,10 +226,17 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.16.3", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.6":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.16.3", "@babel/runtime@^7.6.2":
   version "7.16.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.3.tgz#b86f0db02a04187a3c17caa77de69840165d42d5"
   integrity sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.7.6":
+  version "7.17.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
+  integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -2033,10 +2040,10 @@ he@1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-history@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/history/-/history-5.1.0.tgz#2e93c09c064194d38d52ed62afd0afc9d9b01ece"
-  integrity sha512-zPuQgPacm2vH2xdORvGGz1wQMuHSIB56yNAy5FnLuwOwgSYyPKptJtcMm6Ev+hRGeS+GzhbmRacHzvlESbFwDg==
+history@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.2.0.tgz#7cdd31cf9bac3c5d31f09c231c9928fad0007b7c"
+  integrity sha512-uPSF6lAJb3nSePJ43hN3eKj1dTWpN9gMod0ZssbFTIsen+WehTmEadgL+kg78xLJFdRfrrC//SavDzmRVdE+Ig==
   dependencies:
     "@babel/runtime" "^7.7.6"
 
@@ -3210,19 +3217,19 @@ react-refresh@0.8.3:
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
 
 react-router-dom@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.0.2.tgz#860cefa697b9d4965eced3f91e82cdbc5995f3ad"
-  integrity sha512-cOpJ4B6raFutr0EG8O/M2fEoyQmwvZWomf1c6W2YXBZuFBx8oTk/zqjXghwScyhfrtnt0lANXV2182NQblRxFA==
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.2.1.tgz#32ec81829152fbb8a7b045bf593a22eadf019bec"
+  integrity sha512-I6Zax+/TH/cZMDpj3/4Fl2eaNdcvoxxHoH1tYOREsQ22OKDYofGebrNm6CTPUcvLvZm63NL/vzCYdjf9CUhqmA==
   dependencies:
-    history "^5.1.0"
-    react-router "6.0.2"
+    history "^5.2.0"
+    react-router "6.2.1"
 
-react-router@6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.0.2.tgz#bd2b0fa84fd1d152671e9f654d9c0b1f5a7c86da"
-  integrity sha512-8/Wm3Ed8t7TuedXjAvV39+c8j0vwrI5qVsYqjFr5WkJjsJpEvNSoLRUbtqSEYzqaTUj1IV+sbPJxvO+accvU0Q==
+react-router@6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.2.1.tgz#be2a97a6006ce1d9123c28934e604faef51448a3"
+  integrity sha512-2fG0udBtxou9lXtK97eJeET2ki5//UWfQSl1rlJ7quwe6jrktK9FCCc8dQb5QY6jAv3jua8bBQRhhDOM/kVRsg==
   dependencies:
-    history "^5.1.0"
+    history "^5.2.0"
 
 react@17.0.2:
   version "17.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,38 +3,38 @@
 
 
 "@babel/code-frame@^7.0.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.0.tgz#0dfc80309beec8411e65e706461c408b0bb9b431"
-  integrity sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
+  integrity sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
   dependencies:
-    "@babel/highlight" "^7.16.0"
+    "@babel/highlight" "^7.16.7"
 
-"@babel/helper-validator-identifier@^7.15.7":
-  version "7.15.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz#220df993bfe904a4a6b02ab4f3385a5ebf6e2389"
-  integrity sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==
+"@babel/helper-validator-identifier@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
+  integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
 
-"@babel/highlight@^7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.16.0.tgz#6ceb32b2ca4b8f5f361fb7fd821e3fddf4a1725a"
-  integrity sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==
+"@babel/highlight@^7.16.7":
+  version "7.16.10"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.16.10.tgz#744f2eb81579d6eea753c227b0f570ad785aba88"
+  integrity sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.15.7"
+    "@babel/helper-validator-identifier" "^7.16.7"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
 "@babel/runtime-corejs3@^7.9.2":
-  version "7.16.3"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.16.3.tgz#1e25de4fa994c57c18e5fdda6cc810dac70f5590"
-  integrity sha512-IAdDC7T0+wEB4y2gbIL0uOXEYpiZEeuFUTVbdGq+UwCcF35T/tS8KrmMomEwEc5wBbyfH3PJVpTSUqrhPDXFcQ==
+  version "7.17.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.17.2.tgz#fdca2cd05fba63388babe85d349b6801b008fd13"
+  integrity sha512-NcKtr2epxfIrNM4VOmPKO46TvDMCBhgi2CrSHaEarrz+Plk2K5r9QemmOFTGpZaoKnWoGH5MO+CzeRsih/Fcgg==
   dependencies:
-    core-js-pure "^3.19.0"
+    core-js-pure "^3.20.2"
     regenerator-runtime "^0.13.4"
 
 "@babel/runtime@^7.15.4":
-  version "7.16.3"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.3.tgz#b86f0db02a04187a3c17caa77de69840165d42d5"
-  integrity sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==
+  version "7.17.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
+  integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -758,9 +758,9 @@
   integrity sha512-3BGrt6FLjqM6br5AhWRKTr3u5GIVkjRYeAFrMp3HjnfICrg4xOrVRwFavKT6tsp++bq5dluL5t8ME/Nha/6c1Q==
 
 "@npmcli/fs@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@npmcli/fs/-/fs-1.0.0.tgz#589612cfad3a6ea0feafcb901d29c63fd52db09f"
-  integrity sha512-8ltnOpRR/oJbOp8vaGUnipOi3bqkcW+sLHFlyXIr08OGHmVJLB1Hn7QtGXbYcpVtH1gAYZTlmDXtE4YV0+AMMQ==
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@npmcli/fs/-/fs-1.1.1.tgz#72f719fe935e687c56a4faecf3c03d06ba593257"
+  integrity sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==
   dependencies:
     "@gar/promisify" "^1.0.1"
     semver "^7.3.5"
@@ -895,15 +895,15 @@
     once "^1.4.0"
 
 "@octokit/request@^5.6.0":
-  version "5.6.2"
-  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.6.2.tgz#1aa74d5da7b9e04ac60ef232edd9a7438dcf32d8"
-  integrity sha512-je66CvSEVf0jCpRISxkUcCa0UkxmFs6eGDRSbfJtAVwbLH5ceqF+YEyC8lj8ystKyZTy8adWr0qmkY52EfOeLA==
+  version "5.6.3"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.6.3.tgz#19a022515a5bba965ac06c9d1334514eb50c48b0"
+  integrity sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==
   dependencies:
     "@octokit/endpoint" "^6.0.1"
     "@octokit/request-error" "^2.1.0"
     "@octokit/types" "^6.16.1"
     is-plain-object "^5.0.0"
-    node-fetch "^2.6.1"
+    node-fetch "^2.6.7"
     universal-user-agent "^6.0.0"
 
 "@octokit/rest@^18.1.0":
@@ -931,10 +931,10 @@
     component-type "^1.2.1"
     join-component "^1.1.0"
 
-"@sideway/address@^4.1.0":
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.2.tgz#811b84333a335739d3969cfc434736268170cad1"
-  integrity sha512-idTz8ibqWFrPU8kMirL0CoPH/A29XOzzAzpyN3zQ4kAWnzmNfFmRaoMNN6VI8ske5M73HZyhIaW4OuSFIdM4oA==
+"@sideway/address@^4.1.3":
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.3.tgz#d93cce5d45c5daec92ad76db492cc2ee3c64ab27"
+  integrity sha512-8ncEUtmnTsMmL7z1YPB47kPUq7LpKWJNFPsRzHiIajGC5uXlWGn+AmkYPcHNl8S4tcEGx+cnORnNYaw2wvL+LQ==
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
@@ -1038,9 +1038,9 @@
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
 "@types/node@*":
-  version "16.11.11"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.11.tgz#6ea7342dfb379ea1210835bada87b3c512120234"
-  integrity sha512-KB0sixD67CeecHC33MYn+eYARkqTheIRNuu97y2XMjR7Wu3XibO1vaY6VBV6O/a89SPI81cEUIYT87UqUWlZNw==
+  version "17.0.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.18.tgz#3b4fed5cfb58010e3a2be4b6e74615e4847f1074"
+  integrity sha512-eKj4f/BsN/qcculZiRSujogjvp5O/k4lOW5m35NopjZM/QwLOR075a8pJW5hD+Rtdm2DaCVPENS6KtSQnUD6BA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -1085,9 +1085,9 @@ agent-base@6, agent-base@^6.0.2:
     debug "4"
 
 agentkeepalive@^4.1.3:
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.1.4.tgz#d928028a4862cb11718e55227872e842a44c945b"
-  integrity sha512-+V/rGa3EuU74H6wR04plBb7Ks10FbtUQgRj/FQOG7uUIEuaINI+AiqJR1k6t3SVNs7o7ZjIdus6706qqzVq8jQ==
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.2.0.tgz#616ce94ccb41d1a39a45d203d8076fe98713062d"
+  integrity sha512-0PhAp58jZNw13UJv7NVdTGb0ZcghHUb3DrZ046JiiJY/BOaTTpbwdHq2VObPCBV8M2GPh7sgrJ3AQ8Ey468LJw==
   dependencies:
     debug "^4.1.0"
     depd "^1.1.2"
@@ -1136,11 +1136,6 @@ ansi-align@^3.0.0:
   integrity sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==
   dependencies:
     string-width "^4.1.0"
-
-ansi-colors@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
-  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
 
 ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
   version "4.3.2"
@@ -1543,9 +1538,9 @@ camelcase@^5.3.1:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 camelcase@^6.2.0:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.1.tgz#250fd350cfd555d0d2160b1d51510eaf8326e86e"
-  integrity sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
+  integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1669,11 +1664,10 @@ cli-cursor@^3.1.0:
     restore-cursor "^3.1.0"
 
 cli-progress@^3.9.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/cli-progress/-/cli-progress-3.9.1.tgz#a22eba6a20f53289fdd05d5ee8cb2cc8c28f866e"
-  integrity sha512-AXxiCe2a0Lm0VN+9L0jzmfQSkcZm5EYspfqXKaSIQKqIk+0hnkZ3/v1E9B39mkD6vYhKih3c/RPsJBSwq9O99Q==
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/cli-progress/-/cli-progress-3.10.0.tgz#63fd9d6343c598c93542fdfa3563a8b59887d78a"
+  integrity sha512-kLORQrhYCAtUPLZxqsAt2YJGOvRdt34+O6jl5cQGb7iF3dM55FQZlTR+rQyIK9JUcO9bBMwZsTlND+3dmFU2Cw==
   dependencies:
-    colors "^1.1.2"
     string-width "^4.2.0"
 
 cli-spinners@^2.0.0, cli-spinners@^2.5.0:
@@ -1682,14 +1676,13 @@ cli-spinners@^2.0.0, cli-spinners@^2.5.0:
   integrity sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==
 
 cli-table3@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.0.tgz#b7b1bc65ca8e7b5cef9124e13dc2b21e2ce4faee"
-  integrity sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.1.tgz#36ce9b7af4847f288d3cdd081fbd09bf7bd237b8"
+  integrity sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==
   dependencies:
-    object-assign "^4.1.0"
     string-width "^4.2.0"
   optionalDependencies:
-    colors "^1.1.2"
+    colors "1.4.0"
 
 cli-truncate@^2.1.0:
   version "2.1.0"
@@ -1791,17 +1784,17 @@ colorette@^2.0.16:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.16.tgz#713b9af84fdb000139f04546bd4a93f62a5085da"
   integrity sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==
 
-colors@^1.1.2:
+colors@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
 columnify@^1.5.4:
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/columnify/-/columnify-1.5.4.tgz#4737ddf1c7b69a8a7c340570782e947eec8e78bb"
-  integrity sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/columnify/-/columnify-1.6.0.tgz#6989531713c9008bb29735e61e37acf5bd553cf3"
+  integrity sha512-lomjuFZKfM6MSAnV9aCZC9sc0qGbmZdfygNv+nCpqVkSKdCxCklLtd16O0EILGkImHw9ZpHkAnHaB+8Zxq5W6Q==
   dependencies:
-    strip-ansi "^3.0.0"
+    strip-ansi "^6.0.1"
     wcwidth "^1.0.0"
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
@@ -1926,13 +1919,13 @@ conventional-changelog-preset-loader@^2.3.4:
   integrity sha512-GEKRWkrSAZeTq5+YjUZOYxdHq+ci4dNwHvpaBC3+ENalzFWuCWa9EZXSuZBpkr72sMdKB+1fyDV4takK1Lf58g==
 
 conventional-changelog-writer@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-writer/-/conventional-changelog-writer-5.0.0.tgz#c4042f3f1542f2f41d7d2e0d6cad23aba8df8eec"
-  integrity sha512-HnDh9QHLNWfL6E1uHz6krZEQOgm8hN7z/m7tT16xwd802fwgMN0Wqd7AQYVkhpsjDUx/99oo+nGgvKF657XP5g==
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-writer/-/conventional-changelog-writer-5.0.1.tgz#e0757072f045fe03d91da6343c843029e702f359"
+  integrity sha512-5WsuKUfxW7suLblAbFnxAcrvf6r+0b7GvNaWUwUIk0bXMnENP/PEieGKVUQrjPqwPT4o3EPAASBXiY6iHooLOQ==
   dependencies:
     conventional-commits-filter "^2.0.7"
     dateformat "^3.0.0"
-    handlebars "^4.7.6"
+    handlebars "^4.7.7"
     json-stringify-safe "^5.0.1"
     lodash "^4.17.15"
     meow "^8.0.0"
@@ -1949,9 +1942,9 @@ conventional-commits-filter@^2.0.7:
     modify-values "^1.0.0"
 
 conventional-commits-parser@^3.2.0:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/conventional-commits-parser/-/conventional-commits-parser-3.2.3.tgz#fc43704698239451e3ef35fd1d8ed644f46bd86e"
-  integrity sha512-YyRDR7On9H07ICFpRm/igcdjIqebXbvf4Cff+Pf0BrBys1i1EOzx9iFXNlAbdrLAR8jf7bkUYkDAr8pEy0q4Pw==
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/conventional-commits-parser/-/conventional-commits-parser-3.2.4.tgz#a7d3b77758a202a9b2293d2112a8d8052c740972"
+  integrity sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==
   dependencies:
     JSONStream "^1.0.4"
     is-text-path "^1.0.1"
@@ -1979,10 +1972,10 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-core-js-pure@^3.19.0:
-  version "3.19.2"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.19.2.tgz#26b5bfb503178cff6e3e115bc2ba6c6419383680"
-  integrity sha512-5LkcgQEy8pFeVnd/zomkUBSwnmIxuF1C8E9KrMAbOc8f34IBT9RGvTYeNDdp1PnvMJrrVhvk1hg/yVV5h/znlg==
+core-js-pure@^3.20.2:
+  version "3.21.0"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.21.0.tgz#819adc8dfb808205ce25b51d50591becd615db7e"
+  integrity sha512-VaJUunCZLnxuDbo1rNOzwbet9E1K9joiXS5+DQMPtgxd24wfsZbJZMMfQLGYMlCUvSxLfsRUUhoOR2x28mFfeg==
 
 core-util-is@1.0.2:
   version "1.0.2"
@@ -2050,7 +2043,7 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-debug@4, debug@^4.1.0, debug@^4.3.1, debug@^4.3.2:
+debug@4, debug@^4.1.0, debug@^4.3.1, debug@^4.3.3:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
   integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
@@ -2245,6 +2238,11 @@ duplexer@^0.1.1:
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
   integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
 
+eastasianwidth@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
+  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -2281,13 +2279,6 @@ end-of-stream@^1.1.0:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
-
-enquirer@^2.3.6:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
-  integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
-  dependencies:
-    ansi-colors "^4.1.1"
 
 env-paths@^2.2.0:
   version "2.2.1"
@@ -2459,10 +2450,10 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.0.3, fast-glob@^3.1.1:
-  version "3.2.7"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
-  integrity sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==
+fast-glob@^3.0.3, fast-glob@^3.2.9:
+  version "3.2.11"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
+  integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -2731,9 +2722,9 @@ getpass@^0.1.1:
     assert-plus "^1.0.0"
 
 git-raw-commits@^2.0.8:
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/git-raw-commits/-/git-raw-commits-2.0.10.tgz#e2255ed9563b1c9c3ea6bd05806410290297bbc1"
-  integrity sha512-sHhX5lsbG9SOO6yXdlwgEMQ/ljIn7qMpAbJZCGfXX2fq5T8M5SrDnpYk9/4HswTildcIqatsWa91vty6VhWSaQ==
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/git-raw-commits/-/git-raw-commits-2.0.11.tgz#bc3576638071d18655e1cc60d7f524920008d723"
+  integrity sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==
   dependencies:
     dargs "^7.0.0"
     lodash "^4.17.15"
@@ -2840,15 +2831,15 @@ globby@^10.0.1:
     slash "^3.0.0"
 
 globby@^11.0.2:
-  version "11.0.4"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
-  integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
+  integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
   dependencies:
     array-union "^2.1.0"
     dir-glob "^3.0.1"
-    fast-glob "^3.1.1"
-    ignore "^5.1.4"
-    merge2 "^1.3.0"
+    fast-glob "^3.2.9"
+    ignore "^5.2.0"
+    merge2 "^1.4.1"
     slash "^3.0.0"
 
 got@^9.6.0:
@@ -2869,11 +2860,11 @@ got@^9.6.0:
     url-parse-lax "^3.0.0"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.3:
-  version "4.2.8"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
-  integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
+  version "4.2.9"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96"
+  integrity sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
 
-handlebars@^4.4.3, handlebars@^4.7.6:
+handlebars@^4.4.3, handlebars@^4.7.7:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
@@ -3006,9 +2997,9 @@ hosted-git-info@^2.1.4:
   integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
 hosted-git-info@^4.0.0, hosted-git-info@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-4.0.2.tgz#5e425507eede4fea846b7262f0838456c4209961"
-  integrity sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-4.1.0.tgz#827b82867e9ff1c8d0c4d9d53880397d2c86d224"
+  integrity sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -3097,10 +3088,10 @@ ignore-walk@^3.0.3:
   dependencies:
     minimatch "^3.0.4"
 
-ignore@^5.1.1, ignore@^5.1.4:
-  version "5.1.9"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.9.tgz#9ec1a5cbe8e1446ec60d4420060d43aa6e7382fb"
-  integrity sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==
+ignore@^5.1.1, ignore@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
+  integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
 import-fresh@^3.2.1:
   version "3.3.0"
@@ -3116,9 +3107,9 @@ import-lazy@^2.1.0:
   integrity sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=
 
 import-local@^3.0.2:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/import-local/-/import-local-3.0.3.tgz#4d51c2c495ca9393da259ec66b62e022920211e0"
-  integrity sha512-bE9iaUY3CXH8Cwfan/abDKAxe1KGT9kyGsBPqf6DMK/z0a2OzAsrukeYNgIH6cH5Xr452jb1TUL8rSfCLjZ9uA==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/import-local/-/import-local-3.1.0.tgz#b4479df8a5fd44f6cdce24070675676063c95cb4"
+  integrity sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==
   dependencies:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
@@ -3271,10 +3262,10 @@ is-ci@^2.0.0:
   dependencies:
     ci-info "^2.0.0"
 
-is-core-module@^2.2.0, is-core-module@^2.5.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.0.tgz#0321336c3d0925e497fd97f5d95cb114a5ccd548"
-  integrity sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==
+is-core-module@^2.5.0, is-core-module@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.1.tgz#f59fdfca701d5879d0a6b100a40aa1560ce27211"
+  integrity sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==
   dependencies:
     has "^1.0.3"
 
@@ -3391,9 +3382,9 @@ is-lower-case@^1.1.0:
     lower-case "^1.1.0"
 
 is-negative-zero@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.1.tgz#3de746c18dda2319241a53675908d8f766f11c24"
-  integrity sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.2.tgz#7bf6f03a28003b8b3965de3ac26f664d765f3150"
+  integrity sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==
 
 is-npm@^5.0.0:
   version "5.0.0"
@@ -3539,11 +3530,11 @@ is-upper-case@^1.1.0:
     upper-case "^1.1.0"
 
 is-weakref@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.1.tgz#842dba4ec17fa9ac9850df2d6efbc1737274f2a2"
-  integrity sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.2.tgz#9529f383a9338205e89765e0392efc2f100f06f2"
+  integrity sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==
   dependencies:
-    call-bind "^1.0.0"
+    call-bind "^1.0.2"
 
 is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
@@ -3595,13 +3586,13 @@ jest-styled-components@^7.0.4:
     css "^3.0.0"
 
 joi@^17.4.0:
-  version "17.4.2"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-17.4.2.tgz#02f4eb5cf88e515e614830239379dcbbe28ce7f7"
-  integrity sha512-Lm56PP+n0+Z2A2rfRvsfWVDXGEWjXxatPopkQ8qQ5mxCEhwHG+Ettgg5o98FFaxilOxozoa14cFhrE/hOzh/Nw==
+  version "17.6.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.6.0.tgz#0bb54f2f006c09a96e75ce687957bd04290054b2"
+  integrity sha512-OX5dG6DTbcr/kbMFj0KGYxuew69HPcAE3K/sZpEV2nP6e/j/C0HV+HNiBPCASxdx5T7DMoa0s8UeHWMnb6n2zw==
   dependencies:
     "@hapi/hoek" "^9.0.0"
     "@hapi/topo" "^5.0.0"
-    "@sideway/address" "^4.1.0"
+    "@sideway/address" "^4.1.3"
     "@sideway/formula" "^3.0.0"
     "@sideway/pinpoint" "^2.0.0"
 
@@ -3789,36 +3780,35 @@ lines-and-columns@^1.1.6:
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
 lint-staged@>=10:
-  version "12.1.2"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-12.1.2.tgz#90c571927e1371fc133e720671dd7989eab53f74"
-  integrity sha512-bSMcQVqMW98HLLLR2c2tZ+vnDCnx4fd+0QJBQgN/4XkdspGRPc8DGp7UuOEBe1ApCfJ+wXXumYnJmU+wDo7j9A==
+  version "12.3.4"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-12.3.4.tgz#4b1ff8c394c3e6da436aaec5afd4db18b5dac360"
+  integrity sha512-yv/iK4WwZ7/v0GtVkNb3R82pdL9M+ScpIbJLJNyCXkJ1FGaXvRCOg/SeL59SZtPpqZhE7BD6kPKFLIDUhDx2/w==
   dependencies:
     cli-truncate "^3.1.0"
     colorette "^2.0.16"
     commander "^8.3.0"
-    debug "^4.3.2"
-    enquirer "^2.3.6"
+    debug "^4.3.3"
     execa "^5.1.1"
     lilconfig "2.0.4"
-    listr2 "^3.13.3"
+    listr2 "^4.0.1"
     micromatch "^4.0.4"
     normalize-path "^3.0.0"
-    object-inspect "^1.11.0"
+    object-inspect "^1.12.0"
     string-argv "^0.3.1"
-    supports-color "^9.0.2"
+    supports-color "^9.2.1"
     yaml "^1.10.2"
 
-listr2@^3.13.3:
-  version "3.13.5"
-  resolved "https://registry.yarnpkg.com/listr2/-/listr2-3.13.5.tgz#105a813f2eb2329c4aae27373a281d610ee4985f"
-  integrity sha512-3n8heFQDSk+NcwBn3CgxEibZGaRzx+pC64n3YjpMD1qguV4nWus3Al+Oo3KooqFKTQEJ1v7MmnbnyyNspgx3NA==
+listr2@^4.0.1:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-4.0.4.tgz#d098a1c419284fb26e184b5d5889b235e8912245"
+  integrity sha512-vJOm5KD6uZXjSsrwajr+mNacIjf87gWvlBEltPWLbTkslUscWAzquyK4xfe9Zd4RDgO5nnwFyV06FC+uVR+5mg==
   dependencies:
     cli-truncate "^2.1.0"
     colorette "^2.0.16"
     log-update "^4.0.0"
     p-map "^4.0.0"
     rfdc "^1.3.0"
-    rxjs "^7.4.0"
+    rxjs "^7.5.4"
     through "^2.3.8"
     wrap-ansi "^7.0.0"
 
@@ -4085,7 +4075,7 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-merge2@^1.2.3, merge2@^1.3.0:
+merge2@^1.2.3, merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
@@ -4150,9 +4140,9 @@ min-indent@^1.0.0:
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
 minimatch@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
-  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
 
@@ -4226,9 +4216,9 @@ minipass@^2.6.0, minipass@^2.9.0:
     yallist "^3.0.0"
 
 minipass@^3.0.0, minipass@^3.1.0, minipass@^3.1.1, minipass@^3.1.3:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.5.tgz#71f6251b0a33a49c01b3cf97ff77eda030dff732"
-  integrity sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.6.tgz#3b8150aa688a711a1521af5e8779c1d3bb4f45ee"
+  integrity sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==
   dependencies:
     yallist "^4.0.0"
 
@@ -4330,9 +4320,9 @@ nanomatch@^1.2.9:
     to-regex "^3.0.1"
 
 negotiator@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
-  integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
+  integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
 neo-async@^2.6.0:
   version "2.6.2"
@@ -4353,7 +4343,7 @@ node-emoji@^1.10.0:
   dependencies:
     lodash "^4.17.21"
 
-node-fetch@^2.6.1:
+node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
@@ -4589,10 +4579,10 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-inspect@^1.11.0, object-inspect@^1.9.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.11.0.tgz#9dceb146cedd4148a0d9e51ab88d34cf509922b1"
-  integrity sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==
+object-inspect@^1.11.0, object-inspect@^1.12.0, object-inspect@^1.9.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.0.tgz#6e2c120e868fd1fd18cb4f18c31741d0d6e776f0"
+  integrity sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==
 
 object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
@@ -4975,7 +4965,7 @@ path-key@^3.0.0, path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-parse@^1.0.6:
+path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
@@ -5010,9 +5000,9 @@ performance-now@^2.1.0:
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
 picomatch@^2.2.3:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
-  integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
+  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
 pify@^2.3.0:
   version "2.3.0"
@@ -5145,16 +5135,16 @@ q@^1.5.1:
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
 qs@^6.9.4:
-  version "6.10.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
-  integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
+  version "6.10.3"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.3.tgz#d6cde1b2ffca87b5aa57889816c5f81535e22e8e"
+  integrity sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==
   dependencies:
     side-channel "^1.0.4"
 
 qs@~6.5.2:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
-  integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
+  integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
 
 query-string@^6.13.8:
   version "6.14.1"
@@ -5432,12 +5422,13 @@ resolve-url@^0.2.1:
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
 resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.12.0:
-  version "1.20.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
-  integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.0.tgz#5e0b8c67c15df57a89bdbabe603a002f21731198"
+  integrity sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==
   dependencies:
-    is-core-module "^2.2.0"
-    path-parse "^1.0.6"
+    is-core-module "^2.8.1"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
 
 responselike@^1.0.2:
   version "1.0.2"
@@ -5515,12 +5506,12 @@ rxjs@^6.4.0, rxjs@^6.6.0:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^7.4.0:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.4.0.tgz#a12a44d7eebf016f5ff2441b87f28c9a51cebc68"
-  integrity sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==
+rxjs@^7.5.4:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.4.tgz#3d6bd407e6b7ce9a123e76b1e770dc5761aa368d"
+  integrity sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==
   dependencies:
-    tslib "~2.1.0"
+    tslib "^2.1.0"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@^5.2.1, safe-buffer@~5.2.0:
   version "5.2.1"
@@ -5639,9 +5630,9 @@ side-channel@^1.0.4:
     object-inspect "^1.9.0"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.6.tgz#24e630c4b0f03fea446a2bd299e62b4a6ca8d0af"
-  integrity sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
+  integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
 slash@^3.0.0:
   version "3.0.0"
@@ -5679,7 +5670,7 @@ slide@^1.1.6:
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
   integrity sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=
 
-smart-buffer@^4.1.0:
+smart-buffer@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
@@ -5740,12 +5731,12 @@ socks-proxy-agent@^6.0.0:
     socks "^2.6.1"
 
 socks@^2.3.3, socks@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/socks/-/socks-2.6.1.tgz#989e6534a07cf337deb1b1c94aaa44296520d30e"
-  integrity sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.6.2.tgz#ec042d7960073d40d94268ff3bb727dc685f111a"
+  integrity sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==
   dependencies:
     ip "^1.1.5"
-    smart-buffer "^4.1.0"
+    smart-buffer "^4.2.0"
 
 sort-keys@^2.0.0:
   version "2.0.0"
@@ -5848,9 +5839,9 @@ split@^1.0.0:
     through "2"
 
 sshpk@^1.7.0:
-  version "1.16.1"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.1.tgz#fb661c0bef29b39db40769ee39fa70093d6f6877"
-  integrity sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.17.0.tgz#578082d92d4fe612b13007496e543fa0fbcbe4c5"
+  integrity sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==
   dependencies:
     asn1 "~0.2.3"
     assert-plus "^1.0.0"
@@ -5906,12 +5897,12 @@ string-width@^1.0.1:
     strip-ansi "^6.0.1"
 
 string-width@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.0.1.tgz#0d8158335a6cfd8eb95da9b6b262ce314a036ffd"
-  integrity sha512-5ohWO/M4//8lErlUUtrFy3b11GtNOuMOU0ysKCDXFcfXuuvUXu95akgj/i8ofmaGdN0hCqyl6uu9i8dS/mQp5g==
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.0.tgz#5ab00980cfb29f43e736b113a120a73a0fb569d3"
+  integrity sha512-7x54QnN21P+XL/v8SuNKvfgsUre6PXpN7mc77N3HlZv+f1SBRGmjxtOud2Z6FZ8DmdkD/IdjCaf9XXbnqmTZGQ==
   dependencies:
+    eastasianwidth "^0.2.0"
     emoji-regex "^9.2.2"
-    is-fullwidth-code-point "^4.0.0"
     strip-ansi "^7.0.1"
 
 string.prototype.trimend@^1.0.4:
@@ -6027,10 +6018,15 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-supports-color@^9.0.2:
+supports-color@^9.2.1:
   version "9.2.1"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-9.2.1.tgz#599dc9d45acf74c6176e0d880bab1d7d718fe891"
   integrity sha512-Obv7ycoCTG51N7y175StI9BlAXrmgZrFhZOb0/PyjHBher/NmsdBgbbQ1Inhq+gIhz6+7Gb+jWF2Vqi7Mf1xnQ==
+
+supports-preserve-symlinks-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
 swap-case@^1.1.0:
   version "1.1.2"
@@ -6188,10 +6184,10 @@ tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
-  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+tslib@^2.1.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -6248,9 +6244,9 @@ typedarray@^0.0.6:
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 uglify-js@^3.1.4:
-  version "3.14.3"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.14.3.tgz#c0f25dfea1e8e5323eccf59610be08b6043c15cf"
-  integrity sha512-mic3aOdiq01DuSVx0TseaEzMIVqebMZ0Z3vaeDhFEh9bsc24hV1TFvN74reA2vs08D0ZWfNjAcJ3UbVLaBss+g==
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.15.1.tgz#9403dc6fa5695a6172a91bc983ea39f0f7c9086d"
+  integrity sha512-FAGKF12fWdkpvNJZENacOH0e/83eG6JyVQyanIJaBXCN1J11TUQv1T1/z8S+Z0CG0ZPk1nPcreF/c7lrTd0TEQ==
 
 uid-number@0.0.6:
   version "0.0.6"


### PR DESCRIPTION
# Remove react-router-dom peer dependency

## Links components update

Links usage:
Simple external links
```jsx
import { Link } from '@strapi/design-system/Link';

<Link href="https://strapi.io">Strapi</Link>
```

Usage with routing libraries (e.g. react-router-dom)
```jsx
import { Link } from '@strapi/design-system/Link';
import { NavLink } from 'react-router-dom';

<Link as={NavLink} to="/somewhere">Somewhere</Link>
```

Usage with NextJS
```jsx
import { Link } from '@strapi/design-system/Link';
import NextLink from 'next/link';

<NextLink href="/home" passHref>
  <Link>Home</Link>
</NextLink>
```

⚠️ ⚠️ ⚠️   **The same applies to the following components**
- LinkButton
- MainNav
    - NavLink
    - NavBrand
- SubNav
    - SubNavLink
- Pagination
    - PageLink
    - PreviousLink
    - NextLink
- SimpleMenu
    - MenuItem