### PR TITLE
Add docs to the first set of components

### DIFF
--- a/packages/strapi-design-system/src/Accordion/Accordion.js
+++ b/packages/strapi-design-system/src/Accordion/Accordion.js
@@ -53,22 +53,11 @@ const AccordionWrapper = styled(Box)`
   }
 `;
 
-export const Accordion = ({
-  children,
-  toggle,
-  expanded,
-  id,
-  size,
-  variant,
-  disabled,
-  error,
-  hasErrorMessage,
-  onToggle,
-}) => {
+export const Accordion = ({ children, expanded, id, size, variant, disabled, error, hasErrorMessage, onToggle }) => {
   const generatedId = useId('accordion', id);
 
   return (
-    <AccordionContext.Provider value={{ expanded, toggle, onToggle, id: generatedId, size, variant, disabled }}>
+    <AccordionContext.Provider value={{ expanded, onToggle, id: generatedId, size, variant, disabled }}>
       <AccordionWrapper
         data-strapi-expanded={expanded}
         disabled={disabled}
@@ -136,11 +125,8 @@ Accordion.propTypes = {
    */
   size: PropTypes.oneOf(['S', 'M']),
   /**
-   * DEPRECATED: The callback invoked when click on the `Accordion` row.
-   */
-  toggle: PropTypes.func.isRequired,
-  /**
-   * Color variant for Accordion
+   * Color variant for `Accordion`. The "secondary" variant reverses the background colors.
+   * This is useful when you want to display a list and alternate the colors of the accordions.
    */
   variant: PropTypes.oneOf(['primary', 'secondary']),
 };

--- a/packages/strapi-design-system/src/Accordion/Accordion.js
+++ b/packages/strapi-design-system/src/Accordion/Accordion.js
@@ -53,11 +53,22 @@ const AccordionWrapper = styled(Box)`
   }
 `;
 
-export const Accordion = ({ children, toggle, expanded, id, size, variant, disabled, error, hasErrorMessage }) => {
+export const Accordion = ({
+  children,
+  toggle,
+  expanded,
+  id,
+  size,
+  variant,
+  disabled,
+  error,
+  hasErrorMessage,
+  onToggle,
+}) => {
   const generatedId = useId('accordion', id);
 
   return (
-    <AccordionContext.Provider value={{ expanded, toggle, id: generatedId, size, variant, disabled }}>
+    <AccordionContext.Provider value={{ expanded, toggle, onToggle, id: generatedId, size, variant, disabled }}>
       <AccordionWrapper
         data-strapi-expanded={expanded}
         disabled={disabled}
@@ -89,16 +100,47 @@ Accordion.defaultProps = {
   toggle: false,
   size: 'M',
   variant: 'primary',
+  onToggle: undefined,
 };
 
 Accordion.propTypes = {
   children: PropTypes.node.isRequired,
+  /**
+   * If `true`, the accordion will be disabled.
+   */
   disabled: PropTypes.bool,
+  /**
+   * If defined, will add a border (borderColor: `danger600`) and display the error message under the component.
+   */
   error: PropTypes.string,
+  /**
+   * If `true`, an expanded accordion will be rendered.
+   */
   expanded: PropTypes.bool,
+  /**
+   * If `false`, the error message won't show.
+   * If the `Accordion` is used under an `AccordionGroup`, this prop will be set to `false` automatically.
+   * The error message of the `AccordionGroup` will be shown under the group instead.
+   */
   hasErrorMessage: PropTypes.bool,
+  /**
+   * The id of the component.
+   */
   id: PropTypes.string,
+  /**
+   * The callback invoked when click on the `Accordion` row.
+   */
+  onToggle: PropTypes.func,
+  /**
+   * Size of the Accordion.
+   */
   size: PropTypes.oneOf(['S', 'M']),
+  /**
+   * DEPRECATED: The callback invoked when click on the `Accordion` row.
+   */
   toggle: PropTypes.func.isRequired,
+  /**
+   * Color variant for Accordion
+   */
   variant: PropTypes.oneOf(['primary', 'secondary']),
 };

--- a/packages/strapi-design-system/src/Accordion/Accordion.js
+++ b/packages/strapi-design-system/src/Accordion/Accordion.js
@@ -110,17 +110,17 @@ Accordion.propTypes = {
    */
   disabled: PropTypes.bool,
   /**
-   * If defined, will add a border (borderColor: `danger600`) and display the error message under the component.
+   * If defined, will add a border (borderColor: `danger600`) and display the error message below the component.
    */
   error: PropTypes.string,
   /**
-   * If `true`, an expanded accordion will be rendered.
+   * If `true`, an expanded Accordion will be rendered.
    */
   expanded: PropTypes.bool,
   /**
    * If `false`, the error message won't show.
-   * If the `Accordion` is used under an `AccordionGroup`, this prop will be set to `false` automatically.
-   * The error message of the `AccordionGroup` will be shown under the group instead.
+   * If the `Accordion` is as child of an `AccordionGroup`, this prop will be set to `false` automatically.
+   * The error message of the `AccordionGroup` will be shown below the group instead of the Accordion itself.
    */
   hasErrorMessage: PropTypes.bool,
   /**
@@ -128,7 +128,7 @@ Accordion.propTypes = {
    */
   id: PropTypes.string,
   /**
-   * The callback invoked when click on the `Accordion` row.
+   * The callback invoked after a click event on the `AccordionToggle`.
    */
   onToggle: PropTypes.func,
   /**

--- a/packages/strapi-design-system/src/Accordion/Accordion.stories.mdx
+++ b/packages/strapi-design-system/src/Accordion/Accordion.stories.mdx
@@ -57,7 +57,7 @@ import { Accordion, AccordionToggle, AccordionContent, AccordionGroup } from '@s
             <Accordion
               error="The component contain error(s)"
               expanded={expanded}
-              toggle={() => setExpanded((s) => !s)}
+              onToggle={() => setExpanded((s) => !s)}
               id="acc-1"
               size="S"
             >
@@ -68,7 +68,7 @@ import { Accordion, AccordionToggle, AccordionContent, AccordionGroup } from '@s
             </Accordion>
           </Box>
           <Box padding={8} background="neutral0">
-            <Accordion expanded={expanded} toggle={() => setExpanded((s) => !s)} id="acc-2" variant="secondary">
+            <Accordion expanded={expanded} onToggle={() => setExpanded((s) => !s)} id="acc-2" variant="secondary">
               <AccordionToggle
                 title="User informations 2"
                 description="The following contains information about the current user 2"
@@ -80,7 +80,7 @@ import { Accordion, AccordionToggle, AccordionContent, AccordionGroup } from '@s
             </Accordion>
           </Box>
           <Box padding={8} background="neutral100">
-            <Accordion expanded={expanded} toggle={() => setExpanded((s) => !s)} id="acc-3">
+            <Accordion expanded={expanded} onToggle={() => setExpanded((s) => !s)} id="acc-3">
               <AccordionToggle
                 togglePosition="left"
                 title="User informations 3"
@@ -92,7 +92,7 @@ import { Accordion, AccordionToggle, AccordionContent, AccordionGroup } from '@s
             </Accordion>
           </Box>
           <Box padding={8} background="neutral0">
-            <Accordion expanded={expanded} toggle={() => setExpanded((s) => !s)} id="acc-4" variant="secondary">
+            <Accordion expanded={expanded} onToggle={() => setExpanded((s) => !s)} id="acc-4" variant="secondary">
               <AccordionToggle
                 togglePosition="left"
                 title="User informations 4"
@@ -146,7 +146,7 @@ import { Accordion, AccordionToggle, AccordionContent, AccordionGroup } from '@s
               <Accordion
                 error="The components contain error(s)"
                 expanded={expanded}
-                toggle={() => setExpanded((s) => !s)}
+                onToggle={() => setExpanded((s) => !s)}
                 id="acc-1"
                 size="S"
               >
@@ -168,7 +168,7 @@ import { Accordion, AccordionToggle, AccordionContent, AccordionGroup } from '@s
               <Accordion
                 error="The component contain error(s)"
                 expanded={false}
-                toggle={() => setExpanded((s) => !s)}
+                onToggle={() => setExpanded((s) => !s)}
                 id="acc-2"
                 size="S"
               >
@@ -177,13 +177,13 @@ import { Accordion, AccordionToggle, AccordionContent, AccordionGroup } from '@s
                   <Box padding={3}>My name is John Duff</Box>
                 </AccordionContent>
               </Accordion>
-              <Accordion expanded={expanded} toggle={() => setExpanded((s) => !s)} id="acc-3" size="S">
+              <Accordion expanded={expanded} onToggle={() => setExpanded((s) => !s)} id="acc-3" size="S">
                 <AccordionToggle title="User informations" togglePosition="left" />
                 <AccordionContent>
                   <Box padding={3}>My name is Michka</Box>
                 </AccordionContent>
               </Accordion>
-              <Accordion expanded={false} toggle={() => setExpanded((s) => !s)} id="acc-2" size="S">
+              <Accordion expanded={false} onToggle={() => setExpanded((s) => !s)} id="acc-2" size="S">
                 <AccordionToggle
                   startIcon={<User aria-hidden={true} />}
                   title="User informations"
@@ -211,7 +211,7 @@ The accordion component has two main states: collapsed and expanded. By default 
       return (
         <KeyboardNavigable attributeName="data-strapi-accordion-toggle">
           <Box padding={8} background="neutral100">
-            <Accordion expanded={false} toggle={() => {}} id="acc-1">
+            <Accordion expanded={false} onToggle={() => {}} id="acc-1">
               <AccordionToggle
                 title="User informations"
                 description="The following contains information about the current user"
@@ -222,7 +222,7 @@ The accordion component has two main states: collapsed and expanded. By default 
             </Accordion>
           </Box>
           <Box padding={8} background="neutral0">
-            <Accordion expanded={false} toggle={() => {}} id="acc-2">
+            <Accordion expanded={false} onToggle={() => {}} id="acc-2">
               <AccordionToggle
                 variant="secondary"
                 title="User informations 2"
@@ -234,7 +234,7 @@ The accordion component has two main states: collapsed and expanded. By default 
             </Accordion>
           </Box>
           <Box padding={8} background="neutral100">
-            <Accordion expanded={false} toggle={() => {}} id="acc-3">
+            <Accordion expanded={false} onToggle={() => {}} id="acc-3">
               <AccordionToggle
                 togglePosition="left"
                 title="User informations 3"
@@ -246,7 +246,7 @@ The accordion component has two main states: collapsed and expanded. By default 
             </Accordion>
           </Box>
           <Box padding={8} background="neutral0">
-            <Accordion expanded={false} toggle={() => {}} id="acc-4">
+            <Accordion expanded={false} onToggle={() => {}} id="acc-4">
               <AccordionToggle
                 variant="secondary"
                 togglePosition="left"
@@ -270,7 +270,7 @@ The Accordion component can also be open by default using the parameter `expande
 
 <Canvas>
   <Story name="expanded">
-    <Accordion expanded={true} toggle={() => {}} id="acc-1">
+    <Accordion expanded={true} onToggle={() => {}} id="acc-1">
       <AccordionToggle
         title="User informations"
         description="The following contains information about the current user"

--- a/packages/strapi-design-system/src/Accordion/Accordion.stories.mdx
+++ b/packages/strapi-design-system/src/Accordion/Accordion.stories.mdx
@@ -54,7 +54,13 @@ import { Accordion, AccordionToggle, AccordionContent, AccordionGroup } from '@s
       return (
         <div>
           <Box padding={8} background="neutral100">
-            <Accordion error='The component contain error(s)' expanded={expanded} toggle={() => setExpanded((s) => !s)} id="acc-1" size="S">
+            <Accordion
+              error="The component contain error(s)"
+              expanded={expanded}
+              toggle={() => setExpanded((s) => !s)}
+              id="acc-1"
+              size="S"
+            >
               <AccordionToggle title="User informations" />
               <AccordionContent>
                 <Box padding={3}>My name is John Duff</Box>
@@ -113,7 +119,7 @@ import { Accordion, AccordionToggle, AccordionContent, AccordionGroup } from '@s
         <div>
           <Box padding={8} background="neutral0">
             <AccordionGroup
-              error='The components contain error(s)'
+              error="The components contain error(s)"
               footer={
                 <Flex justifyContent="center" height="48px" background="neutral150">
                   <TextButton disabled={true} startIcon={<Plus />}>
@@ -137,7 +143,13 @@ import { Accordion, AccordionToggle, AccordionContent, AccordionGroup } from '@s
                 </Tooltip>
               }
             >
-              <Accordion error='The components contain error(s)' expanded={expanded} toggle={() => setExpanded((s) => !s)} id="acc-1" size="S">
+              <Accordion
+                error="The components contain error(s)"
+                expanded={expanded}
+                toggle={() => setExpanded((s) => !s)}
+                id="acc-1"
+                size="S"
+              >
                 <AccordionToggle
                   startIcon={<User aria-hidden={true} />}
                   action={
@@ -153,7 +165,13 @@ import { Accordion, AccordionToggle, AccordionContent, AccordionGroup } from '@s
                   <Box padding={3}>My name is John Duff</Box>
                 </AccordionContent>
               </Accordion>
-              <Accordion error='The component contain error(s)' expanded={false} toggle={() => setExpanded((s) => !s)} id="acc-2" size="S">
+              <Accordion
+                error="The component contain error(s)"
+                expanded={false}
+                toggle={() => setExpanded((s) => !s)}
+                id="acc-2"
+                size="S"
+              >
                 <AccordionToggle title="User informations" togglePosition="left" />
                 <AccordionContent>
                   <Box padding={3}>My name is John Duff</Box>
@@ -165,13 +183,12 @@ import { Accordion, AccordionToggle, AccordionContent, AccordionGroup } from '@s
                   <Box padding={3}>My name is Michka</Box>
                 </AccordionContent>
               </Accordion>
-              <Accordion
-                expanded={false}
-                toggle={() => setExpanded((s) => !s)}
-                id="acc-2"
-                size="S"
-              >
-                <AccordionToggle startIcon={<User aria-hidden={true} />} title="User informations" togglePosition="left" />
+              <Accordion expanded={false} toggle={() => setExpanded((s) => !s)} id="acc-2" size="S">
+                <AccordionToggle
+                  startIcon={<User aria-hidden={true} />}
+                  title="User informations"
+                  togglePosition="left"
+                />
                 <AccordionContent>
                   <Box padding={3}>My name is John Duff</Box>
                 </AccordionContent>
@@ -265,6 +282,14 @@ The Accordion component can also be open by default using the parameter `expande
   </Story>
 </Canvas>
 
-## Props
+## Accordion props
 
 <ArgsTable of={Accordion} />
+
+## AccordionGroup props
+
+<ArgsTable of={AccordionGroup} />
+
+## AccordionToggle props
+
+<ArgsTable of={AccordionToggle} />

--- a/packages/strapi-design-system/src/Accordion/AccordionGroup.js
+++ b/packages/strapi-design-system/src/Accordion/AccordionGroup.js
@@ -96,11 +96,11 @@ AccordionGroup.defaultProps = {
 AccordionGroup.propTypes = {
   children: PropTypes.node.isRequired,
   /**
-   * If defined, will show the error message at the bottom of the AccordionGroup and will hide children Accordion error messages (in order to display only one error).
+   * If defined, the component will show the error message at the bottom of the `AccordionGroup` and will hide all Accordion error messages children (in order to display only one error).
    */
   error: PropTypes.string,
   /**
-   * Render a node under the last child. Mainly used for an "Add new accordion" button
+   * Render a node a last child. Mainly used for an "Add new accordion" button
    */
   footer: PropTypes.node,
   /**

--- a/packages/strapi-design-system/src/Accordion/AccordionGroup.js
+++ b/packages/strapi-design-system/src/Accordion/AccordionGroup.js
@@ -95,8 +95,20 @@ AccordionGroup.defaultProps = {
 
 AccordionGroup.propTypes = {
   children: PropTypes.node.isRequired,
+  /**
+   * If defined, will show the error message at the bottom of the AccordionGroup and will hide children Accordion error messages (in order to display only one error).
+   */
   error: PropTypes.string,
+  /**
+   * Render a node under the last child. Mainly used for an "Add new accordion" button
+   */
   footer: PropTypes.node,
+  /**
+   * The label of the AccordionGroup
+   */
   label: PropTypes.string,
+  /**
+   * Will render a node to the right of the label
+   */
   labelAction: PropTypes.node,
 };

--- a/packages/strapi-design-system/src/Accordion/AccordionToggle.js
+++ b/packages/strapi-design-system/src/Accordion/AccordionToggle.js
@@ -40,7 +40,7 @@ const FlexWithSize = styled(Flex)`
 
 export const AccordionToggle = ({ title, description, as, togglePosition, action, ...props }) => {
   const toggleButtonRef = useRef(null);
-  const { toggle, expanded, id, size, variant, disabled } = useAccordion();
+  const { toggle, onToggle, expanded, id, size, variant, disabled } = useAccordion();
 
   // Accessibility identifiers
   const ariaControls = `accordion-content-${id}`;
@@ -57,7 +57,14 @@ export const AccordionToggle = ({ title, description, as, togglePosition, action
 
   const handleToggle = () => {
     if (!disabled) {
-      toggle();
+      if (toggle && !onToggle) {
+        console.warn(
+          'Deprecation warning: Usage of "toggle" prop in Accordion component. This is discouraged and will be removed in upcoming major. Please use "onToggle" instead',
+        );
+        toggle();
+      } else {
+        onToggle();
+      }
     }
   };
 
@@ -195,10 +202,25 @@ AccordionToggle.defaultProps = {
 };
 
 AccordionToggle.propTypes = {
+  /**
+   * Will render a node to the right of the Accordion component
+   */
   action: PropTypes.node,
   as: PropTypes.string,
+  /**
+   * Show the secondary text of the Accordion component
+   */
   description: PropTypes.string,
+  /**
+   * Show the main title of the Accordion component
+   */
   title: PropTypes.string.isRequired,
+  /**
+   * Set the position of the toggle icon button
+   */
   togglePosition: PropTypes.oneOf(['right', 'left']),
+  /**
+   * Color variant
+   */
   variant: PropTypes.oneOf(['primary', 'secondary']),
 };

--- a/packages/strapi-design-system/src/Accordion/AccordionToggle.js
+++ b/packages/strapi-design-system/src/Accordion/AccordionToggle.js
@@ -40,7 +40,7 @@ const FlexWithSize = styled(Flex)`
 
 export const AccordionToggle = ({ title, description, as, togglePosition, action, ...props }) => {
   const toggleButtonRef = useRef(null);
-  const { toggle, onToggle, expanded, id, size, variant, disabled } = useAccordion();
+  const { onToggle, expanded, id, size, variant, disabled } = useAccordion();
 
   // Accessibility identifiers
   const ariaControls = `accordion-content-${id}`;
@@ -57,14 +57,7 @@ export const AccordionToggle = ({ title, description, as, togglePosition, action
 
   const handleToggle = () => {
     if (!disabled) {
-      if (toggle && !onToggle) {
-        console.warn(
-          'Deprecation warning: Usage of "toggle" prop in Accordion component. This is discouraged and will be removed in upcoming major. Please use "onToggle" instead',
-        );
-        toggle();
-      } else {
-        onToggle();
-      }
+      onToggle();
     }
   };
 

--- a/packages/strapi-design-system/src/Alert/Alert.js
+++ b/packages/strapi-design-system/src/Alert/Alert.js
@@ -109,12 +109,33 @@ Alert.defaultProps = {
 };
 
 Alert.propTypes = {
+  /**
+   * Render a React element under the `Alert` body (Mainly used to render a Link).
+   */
   action: PropTypes.element,
+  /**
+   * The body of the `Alert` (Will be rendered under the `Alert` title).
+   */
   children: PropTypes.string.isRequired,
+  /**
+   * Accessible label for the close icon button.
+   */
   closeLabel: PropTypes.string.isRequired,
+  /**
+   * The callback invoked when click on the close icon button.
+   */
   onClose: PropTypes.func.isRequired,
+  /**
+   * The title of the `Alert`.
+   */
   title: PropTypes.string.isRequired,
+  /**
+   * An `as` prop to change the element render, like styled-components.
+   */
   titleAs: PropTypes.string,
+  /**
+   * `Alert` color variant.
+   */
   variant: PropTypes.oneOf(['danger', 'success', 'default']),
 };
 

--- a/packages/strapi-design-system/src/Alert/Alert.js
+++ b/packages/strapi-design-system/src/Alert/Alert.js
@@ -110,7 +110,7 @@ Alert.defaultProps = {
 
 Alert.propTypes = {
   /**
-   * Render a React element under the `Alert` body (Mainly used to render a Link).
+   * Render a React element below the body of an `Alert` (Mainly used to render a Link).
    */
   action: PropTypes.element,
   /**
@@ -130,7 +130,7 @@ Alert.propTypes = {
    */
   title: PropTypes.string.isRequired,
   /**
-   * An `as` prop to change the element render, like styled-components.
+   * Changes the element, as which a component will render (similar to styled-components).
    */
   titleAs: PropTypes.string,
   /**

--- a/packages/strapi-design-system/src/Alert/Alert.stories.mdx
+++ b/packages/strapi-design-system/src/Alert/Alert.stories.mdx
@@ -127,7 +127,7 @@ Alerts can contain an action. Via a Link component, they mostly encourage the us
 ## Accessibility
 
 - Alerts use a combination of icons and colors to show their purpose and level of importance.
-- This is just a visual component. It does not implement toasted notification nor live region.
+- This is a visual component which does not implement toasted notification nor a live region.
 
 ## Props
 

--- a/packages/strapi-design-system/src/Alert/Alert.stories.mdx
+++ b/packages/strapi-design-system/src/Alert/Alert.stories.mdx
@@ -127,6 +127,7 @@ Alerts can contain an action. Via a Link component, they mostly encourage the us
 ## Accessibility
 
 - Alerts use a combination of icons and colors to show their purpose and level of importance.
+- This is just a visual component. It does not implement toasted notification nor live region.
 
 ## Props
 

--- a/packages/strapi-design-system/src/Avatar/Avatar.js
+++ b/packages/strapi-design-system/src/Avatar/Avatar.js
@@ -104,7 +104,16 @@ Avatar.defaultProps = {
 };
 
 Avatar.propTypes = {
+  /**
+   * Alternative text
+   */
   alt: PropTypes.string.isRequired,
+  /**
+   * Image src of the image preview (displayed on `Avatar` hover).
+   */
   preview: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  /**
+   * Image src of the `Avatar`
+   */
   src: PropTypes.string.isRequired,
 };

--- a/packages/strapi-design-system/src/Badge/Badge.js
+++ b/packages/strapi-design-system/src/Badge/Badge.js
@@ -31,7 +31,7 @@ Badge.defaultProps = {
 
 Badge.propTypes = {
   /**
-   * If `true`, change the `backgroundColor` to `primary100` and the `textColor` to `primary600`
+   * If `true`, it changes the `backgroundColor` to `primary100` and the `textColor` to `primary600`
    */
   active: PropTypes.bool,
   backgroundColor: PropTypes.string,

--- a/packages/strapi-design-system/src/Badge/Badge.js
+++ b/packages/strapi-design-system/src/Badge/Badge.js
@@ -30,6 +30,9 @@ Badge.defaultProps = {
 };
 
 Badge.propTypes = {
+  /**
+   * If `true`, change the `backgroundColor` to `primary100` and the `textColor` to `primary600`
+   */
   active: PropTypes.bool,
   backgroundColor: PropTypes.string,
   children: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,

--- a/packages/strapi-design-system/src/BaseButton/BaseButton.stories.mdx
+++ b/packages/strapi-design-system/src/BaseButton/BaseButton.stories.mdx
@@ -4,10 +4,7 @@ import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { BaseButton } from './BaseButton';
 
-<Meta
-  title="Design System/Technical Components/BaseButton"
-  component={ BaseButton }
-/>
+<Meta title="Design System/Technical Components/BaseButton" component={BaseButton} />
 
 ## Imports
 

--- a/packages/strapi-design-system/src/BaseCheckbox/BaseCheckbox.js
+++ b/packages/strapi-design-system/src/BaseCheckbox/BaseCheckbox.js
@@ -107,9 +107,22 @@ BaseCheckbox.defaultProps = {
 };
 
 BaseCheckbox.propTypes = {
+  /**
+   * If `true`, display the indeterminate state.
+   */
   indeterminate: PropTypes.bool,
+  /**
+   * `Checkbox` input name
+   */
   name: PropTypes.string,
+  /**
+   * The callback invoked when click on the `Checkbox`
+   * `(value: Bool) => {}`
+   */
   onValueChange: PropTypes.func,
+  /**
+   * Set the size of the checkbox
+   */
   size: PropTypes.oneOf(['M', 'L']),
   value: PropTypes.bool,
 };

--- a/packages/strapi-design-system/src/Box/BoxProps.js
+++ b/packages/strapi-design-system/src/Box/BoxProps.js
@@ -26,7 +26,7 @@ BoxProps.defaultProps = {
 
 BoxProps.propTypes = {
   /**
-   * Javascript hover handler
+   * JavaScript hover handler
    */
   _hover: PropTypes.func,
   /**

--- a/packages/strapi-design-system/src/Box/BoxProps.js
+++ b/packages/strapi-design-system/src/Box/BoxProps.js
@@ -25,22 +25,73 @@ BoxProps.defaultProps = {
 };
 
 BoxProps.propTypes = {
+  /**
+   * Javascript hover handler
+   */
   _hover: PropTypes.func,
+  /**
+   * Background color
+   */
   background: PropTypes.string,
+  /**
+   * Flex basis
+   */
   basis: PropTypes.oneOfType([PropTypes.string, PropTypes.string]),
+  /**
+   * Border color
+   */
   borderColor: PropTypes.string,
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
+  /**
+   * Text color
+   */
   color: PropTypes.string,
+  /**
+   * Flex
+   */
   flex: PropTypes.oneOfType([PropTypes.string, PropTypes.string]),
+  /**
+   * Flex grow
+   */
   grow: PropTypes.oneOfType([PropTypes.string, PropTypes.string]),
+  /**
+   * If `true`, will add a border radius to the `Box`
+   */
   hasRadius: PropTypes.bool,
+  /**
+   * Responsive hiding. If `true`, will the `Box` for tablet size screens.
+   */
   hiddenS: PropTypes.bool,
+  /**
+   * Responsive hiding. If `true`, will the `Box` for mobile size screens.
+   */
   hiddenXS: PropTypes.bool,
+  /**
+   * Padding. Supports responsive values
+   */
   padding: PropTypes.oneOfType([PropTypes.number, PropTypes.arrayOf(PropTypes.number)]),
+  /**
+   * Padding bottom. Supports responsive values
+   */
   paddingBottom: PropTypes.oneOfType([PropTypes.number, PropTypes.arrayOf(PropTypes.number)]),
+  /**
+   * Padding left. Supports responsive values
+   */
   paddingLeft: PropTypes.oneOfType([PropTypes.number, PropTypes.arrayOf(PropTypes.number)]),
+  /**
+   * Padding right. Supports responsive values
+   */
   paddingRight: PropTypes.oneOfType([PropTypes.number, PropTypes.arrayOf(PropTypes.number)]),
+  /**
+   * Padding top. Supports responsive values
+   */
   paddingTop: PropTypes.oneOfType([PropTypes.number, PropTypes.arrayOf(PropTypes.number)]),
+  /**
+   * Shadow name (see `theme.shadows`)
+   */
   shadow: PropTypes.string,
+  /**
+   * Flex shrink
+   */
   shrink: PropTypes.oneOfType([PropTypes.string, PropTypes.string]),
 };


### PR DESCRIPTION
Add props details to component documentation

- Accordion
- Alert
- Avatar
- Badge
- BaseButton
- BaseCheckbox
- Box

The proptypes comments adds a description column to the `ArgTable` storybook component.

![Screenshot 2022-02-16 at 19 03 31](https://user-images.githubusercontent.com/7756284/154327569-af28dd5f-14d8-480d-8b06-169ae2236363.png)
