### PR TITLE
Move labelAction into the FieldLabel component

### DIFF
--- a/packages/strapi-design-system/src/CarouselInput/CarouselInput.js
+++ b/packages/strapi-design-system/src/CarouselInput/CarouselInput.js
@@ -11,6 +11,7 @@ export const CarouselInput = ({
   error,
   hint,
   label,
+  labelAction,
   nextLabel,
   onNext,
   onPrevious,
@@ -26,7 +27,11 @@ export const CarouselInput = ({
   return (
     <Field hint={hint} error={error} id={generatedId}>
       <Stack size={1}>
-        <FieldLabel required={required}>{label}</FieldLabel>
+        {label && (
+          <FieldLabel required={required} action={labelAction}>
+            {label}
+          </FieldLabel>
+        )}
         <Carousel
           actions={actions}
           label={label}
@@ -64,6 +69,7 @@ CarouselInput.propTypes = {
   hint: PropTypes.string,
   id: PropTypes.string,
   label: PropTypes.string.isRequired,
+  labelAction: PropTypes.element,
   nextLabel: PropTypes.string.isRequired,
   onNext: PropTypes.func.isRequired,
   onPrevious: PropTypes.func.isRequired,

--- a/packages/strapi-design-system/src/Field/Field.stories.mdx
+++ b/packages/strapi-design-system/src/Field/Field.stories.mdx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
+import Earth from '@strapi/icons/Earth';
 import Password from '@strapi/icons/Password';
 import Information from '@strapi/icons/Information';
 import { FieldLabel } from './FieldLabel';
@@ -70,6 +71,23 @@ An example of the Field components with an error.
     <Field name="password" error={'Password is too short'}>
       <Stack size={1}>
         <FieldLabel>Password</FieldLabel>
+        <FieldInput type="password" placeholder="Placeholder" value={''} onChange={() => {}} />
+        <FieldHint />
+        <FieldError />
+      </Stack>
+    </Field>
+  </Story>
+</Canvas>
+
+## With label action
+
+An example of the Field components with a label action.
+
+<Canvas>
+  <Story name="with label-action">
+    <Field name="password">
+      <Stack size={1}>
+        <FieldLabel required action={<Earth />}>Password</FieldLabel>
         <FieldInput type="password" placeholder="Placeholder" value={''} onChange={() => {}} />
         <FieldHint />
         <FieldError />

--- a/packages/strapi-design-system/src/Field/FieldLabel.js
+++ b/packages/strapi-design-system/src/Field/FieldLabel.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
+import { Flex } from '../Flex';
 import { useField } from './FieldContext';
 import { Typography } from '../Typography';
 
@@ -8,7 +9,15 @@ const TypographyAsterisk = styled(Typography)`
   line-height: 0;
 `;
 
-export const FieldLabel = ({ children, required, ...props }) => {
+const Action = styled(Flex)`
+  line-height: 0;
+
+  svg path {
+    fill: ${({ theme }) => theme.colors.neutral500};
+  }
+`;
+
+export const FieldLabel = ({ children, required, action, ...props }) => {
   const { id } = useField();
 
   return (
@@ -21,16 +30,21 @@ export const FieldLabel = ({ children, required, ...props }) => {
       required={required}
       {...props}
     >
-      {children}
-      {required && <TypographyAsterisk textColor="danger600">*</TypographyAsterisk>}
+      <Flex alignItems="center">
+        {children}
+        {required && <TypographyAsterisk textColor="danger600">*</TypographyAsterisk>}
+        {action && <Action marginLeft={1}>{action}</Action>}
+      </Flex>
     </Typography>
   );
 };
 
 FieldLabel.defaultProps = {
   required: false,
+  action: undefined,
 };
 FieldLabel.propTypes = {
+  action: PropTypes.element,
   children: PropTypes.node.isRequired,
   required: PropTypes.bool,
 };

--- a/packages/strapi-design-system/src/NumberInput/NumberInput.js
+++ b/packages/strapi-design-system/src/NumberInput/NumberInput.js
@@ -6,8 +6,6 @@ import { sizes } from '../themes/sizes';
 import { NumberFormatter, NumberParser } from '@internationalized/number';
 import { Field, FieldLabel, FieldHint, FieldError, FieldInput } from '../Field';
 import { Stack } from '../Stack';
-import { Flex } from '../Flex';
-import { Box } from '../Box';
 import { Icon } from '../Icon';
 import { useId } from '../helpers/useId';
 import { KeyboardKeys } from '../helpers/keyboardKeys';
@@ -168,10 +166,9 @@ export const NumberInput = React.forwardRef(
       <Field name={name} hint={hint} error={error} id={generatedId}>
         <Stack size={1}>
           {label && (
-            <Flex cols="auto auto 1fr" gap={1}>
-              <FieldLabel required={required}>{label}</FieldLabel>
-              {labelAction && <Box paddingLeft={1}>{labelAction}</Box>}
-            </Flex>
+            <FieldLabel required={required} action={labelAction}>
+              {label}
+            </FieldLabel>
           )}
           <FieldInput
             ref={ref}

--- a/packages/strapi-design-system/src/Select/Select.js
+++ b/packages/strapi-design-system/src/Select/Select.js
@@ -26,6 +26,7 @@ const MainRow = styled(Flex)`
 
 export const Select = ({
   label,
+  labelAction,
   id,
   children,
   customizeContent,
@@ -149,7 +150,7 @@ export const Select = ({
     <Field hint={hint} error={error} id={generatedId}>
       <Stack size={label || hint || error ? 1 : 0}>
         {label && (
-          <FieldLabel required={required} as="span" id={labelId}>
+          <FieldLabel required={required} as="span" id={labelId} action={labelAction}>
             {label}
           </FieldLabel>
         )}
@@ -264,6 +265,7 @@ Select.defaultProps = {
   disabled: false,
   id: undefined,
   label: undefined,
+  labelAction: undefined,
   multi: false,
   onChange: () => {},
   onClear: undefined,
@@ -288,6 +290,7 @@ Select.propTypes = {
   hint: PropTypes.string,
   id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   label: PropTypes.string,
+  labelAction: PropTypes.element,
   multi: PropTypes.bool,
   onChange: PropTypes.func,
   onClear: PropTypes.func,

--- a/packages/strapi-design-system/src/Select/Select.stories.mdx
+++ b/packages/strapi-design-system/src/Select/Select.stories.mdx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
+import Earth from '@strapi/icons/Earth';
 import Plus from '@strapi/icons/Plus';
 import { Select } from './Select';
 import { Option } from './Option';
@@ -58,6 +59,7 @@ The default Select.
           <Select
             id="select1"
             label="Choose your meal"
+            labelAction={<Earth />}
             required
             placeholder="Your example"
             hint="Description line"

--- a/packages/strapi-design-system/src/Select/__tests__/Select.spec.js
+++ b/packages/strapi-design-system/src/Select/__tests__/Select.spec.js
@@ -51,42 +51,6 @@ describe('Select', () => {
         cursor: not-allowed;
       }
 
-      .c1 {
-        font-weight: 600;
-        color: #32324d;
-        font-size: 0.75rem;
-        line-height: 1.33;
-      }
-
-      .c9 {
-        color: #32324d;
-        display: block;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        font-size: 0.875rem;
-        line-height: 1.43;
-      }
-
-      .c12 {
-        color: #666687;
-        font-size: 0.75rem;
-        line-height: 1.33;
-      }
-
-      .c19 {
-        font-weight: 600;
-        color: #4945ff;
-        font-size: 0.875rem;
-        line-height: 1.43;
-      }
-
-      .c20 {
-        color: #32324d;
-        font-size: 0.875rem;
-        line-height: 1.43;
-      }
-
       .c7 {
         padding-left: 12px;
       }
@@ -141,6 +105,42 @@ describe('Select', () => {
         -webkit-box-align: center;
         -ms-flex-align: center;
         align-items: center;
+      }
+
+      .c1 {
+        font-weight: 600;
+        color: #32324d;
+        font-size: 0.75rem;
+        line-height: 1.33;
+      }
+
+      .c9 {
+        color: #32324d;
+        display: block;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        font-size: 0.875rem;
+        line-height: 1.43;
+      }
+
+      .c12 {
+        color: #666687;
+        font-size: 0.75rem;
+        line-height: 1.33;
+      }
+
+      .c19 {
+        font-weight: 600;
+        color: #4945ff;
+        font-size: 0.875rem;
+        line-height: 1.43;
+      }
+
+      .c20 {
+        color: #32324d;
+        font-size: 0.875rem;
+        line-height: 1.43;
       }
 
       .c15 {
@@ -282,7 +282,11 @@ describe('Select', () => {
               for="select-1"
               id="select-1-label"
             >
-              Choose your meal
+              <div
+                class="c2"
+              >
+                Choose your meal
+              </div>
             </span>
             <div
               class="c2 c3"
@@ -500,42 +504,6 @@ describe('Select', () => {
         cursor: not-allowed;
       }
 
-      .c1 {
-        font-weight: 600;
-        color: #32324d;
-        font-size: 0.75rem;
-        line-height: 1.33;
-      }
-
-      .c8 {
-        color: #32324d;
-        display: block;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        font-size: 0.875rem;
-        line-height: 1.43;
-      }
-
-      .c13 {
-        color: #666687;
-        font-size: 0.75rem;
-        line-height: 1.33;
-      }
-
-      .c21 {
-        font-weight: 600;
-        color: #4945ff;
-        font-size: 0.875rem;
-        line-height: 1.43;
-      }
-
-      .c23 {
-        color: #32324d;
-        font-size: 0.875rem;
-        line-height: 1.43;
-      }
-
       .c7 {
         padding-right: 16px;
         padding-left: 16px;
@@ -594,6 +562,42 @@ describe('Select', () => {
         -webkit-box-align: center;
         -ms-flex-align: center;
         align-items: center;
+      }
+
+      .c1 {
+        font-weight: 600;
+        color: #32324d;
+        font-size: 0.75rem;
+        line-height: 1.33;
+      }
+
+      .c8 {
+        color: #32324d;
+        display: block;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        font-size: 0.875rem;
+        line-height: 1.43;
+      }
+
+      .c13 {
+        color: #666687;
+        font-size: 0.75rem;
+        line-height: 1.33;
+      }
+
+      .c21 {
+        font-weight: 600;
+        color: #4945ff;
+        font-size: 0.875rem;
+        line-height: 1.43;
+      }
+
+      .c23 {
+        color: #32324d;
+        font-size: 0.875rem;
+        line-height: 1.43;
       }
 
       .c15 {
@@ -765,7 +769,11 @@ describe('Select', () => {
               for="select-3"
               id="select-3-label"
             >
-              Choose your meal
+              <div
+                class="c2"
+              >
+                Choose your meal
+              </div>
             </span>
             <div
               class="c2 c3"

--- a/packages/strapi-design-system/src/TextInput/TextInput.js
+++ b/packages/strapi-design-system/src/TextInput/TextInput.js
@@ -2,17 +2,8 @@ import React, { useImperativeHandle, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { Field, FieldLabel, FieldHint, FieldError, FieldInput } from '../Field';
 import { Stack } from '../Stack';
-import { Flex } from '../Flex';
-import { Box } from '../Box';
 import { sizes } from '../themes/sizes';
-import styled from 'styled-components';
 import { useId } from '../helpers/useId';
-
-const LabelAction = styled(Box)`
-  svg path {
-    fill: ${({ theme }) => theme.colors.neutral500};
-  }
-`;
 
 export const TextInput = React.forwardRef(
   ({ size, startAction, endAction, name, hint, error, label, labelAction, id, required, ...props }, ref) => {
@@ -32,10 +23,9 @@ export const TextInput = React.forwardRef(
         <Field name={name} hint={hint} error={error} id={generatedId}>
           <Stack size={1}>
             {label && (
-              <Flex>
-                <FieldLabel required={required}>{label}</FieldLabel>
-                {labelAction && <LabelAction paddingLeft={1}>{labelAction}</LabelAction>}
-              </Flex>
+              <FieldLabel required={required} action={labelAction}>
+                {label}
+              </FieldLabel>
             )}
             <FieldInput size={size} ref={ref} startAction={startAction} endAction={endAction} {...props} />
             <FieldHint />

--- a/packages/strapi-design-system/src/Textarea/Textarea.js
+++ b/packages/strapi-design-system/src/Textarea/Textarea.js
@@ -4,7 +4,6 @@ import { Field, FieldLabel, FieldHint, FieldError } from '../Field';
 import { TextareaInput } from './TextareaInput';
 import { Stack } from '../Stack';
 import { Flex } from '../Flex';
-import { Box } from '../Box';
 import styled from 'styled-components';
 import { useId } from '../helpers/useId';
 
@@ -34,8 +33,9 @@ export const Textarea = React.forwardRef(
           <Stack size={1}>
             {label && (
               <Flex>
-                <FieldLabel required={required}>{label}</FieldLabel>
-                {labelAction && <Box paddingLeft={1}>{labelAction}</Box>}
+                <FieldLabel required={required} action={labelAction}>
+                  {label}
+                </FieldLabel>
               </Flex>
             )}
             <TextareaInput ref={ref} as="textarea" value={children} {...props} />

--- a/packages/strapi-design-system/src/TimePicker/__tests__/TimePicker.spec.js
+++ b/packages/strapi-design-system/src/TimePicker/__tests__/TimePicker.spec.js
@@ -46,42 +46,6 @@ describe('TimePicker', () => {
         cursor: not-allowed;
       }
 
-      .c1 {
-        font-weight: 600;
-        color: #32324d;
-        font-size: 0.75rem;
-        line-height: 1.33;
-      }
-
-      .c10 {
-        color: #32324d;
-        display: block;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        font-size: 0.875rem;
-        line-height: 1.43;
-      }
-
-      .c13 {
-        color: #666687;
-        font-size: 0.75rem;
-        line-height: 1.33;
-      }
-
-      .c20 {
-        color: #32324d;
-        font-size: 0.875rem;
-        line-height: 1.43;
-      }
-
-      .c21 {
-        font-weight: 600;
-        color: #4945ff;
-        font-size: 0.875rem;
-        line-height: 1.43;
-      }
-
       .c7 {
         padding-left: 12px;
       }
@@ -136,6 +100,42 @@ describe('TimePicker', () => {
         -webkit-box-align: center;
         -ms-flex-align: center;
         align-items: center;
+      }
+
+      .c1 {
+        font-weight: 600;
+        color: #32324d;
+        font-size: 0.75rem;
+        line-height: 1.33;
+      }
+
+      .c10 {
+        color: #32324d;
+        display: block;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        font-size: 0.875rem;
+        line-height: 1.43;
+      }
+
+      .c13 {
+        color: #666687;
+        font-size: 0.75rem;
+        line-height: 1.33;
+      }
+
+      .c20 {
+        color: #32324d;
+        font-size: 0.875rem;
+        line-height: 1.43;
+      }
+
+      .c21 {
+        font-weight: 600;
+        color: #4945ff;
+        font-size: 0.875rem;
+        line-height: 1.43;
       }
 
       .c16 {
@@ -297,7 +297,11 @@ describe('TimePicker', () => {
               for="timepicker-1"
               id="timepicker-1-label"
             >
-              Choose a time
+              <div
+                class="c2"
+              >
+                Choose a time
+              </div>
             </span>
             <div
               class="c2 c3"

--- a/packages/strapi-design-system/src/ToggleInput/ToggleInput.js
+++ b/packages/strapi-design-system/src/ToggleInput/ToggleInput.js
@@ -5,18 +5,11 @@ import { sizes } from '../themes/sizes';
 import { useId } from '../helpers/useId';
 import { Field, FieldHint, FieldError, FieldLabel } from '../Field';
 import { Stack } from '../Stack';
-import { Box } from '../Box';
 import { Flex } from '../Flex';
 import { ToggleCheckbox } from '../ToggleCheckbox';
 
 const FieldWrapper = styled(Field)`
   width: fit-content;
-`;
-
-const LabelAction = styled(Box)`
-  svg path {
-    fill: ${({ theme }) => theme.colors.neutral500};
-  }
 `;
 
 export const ToggleInput = ({ size, error, hint, label, name, labelAction, required, id, ...props }) => {
@@ -26,8 +19,9 @@ export const ToggleInput = ({ size, error, hint, label, name, labelAction, requi
     <FieldWrapper name={name} hint={hint} error={error} id={generatedId}>
       <Stack size={1}>
         <Flex>
-          <FieldLabel required={required}>{label}</FieldLabel>
-          {labelAction && <LabelAction paddingLeft={1}>{labelAction}</LabelAction>}
+          <FieldLabel required={required} action={labelAction}>
+            {label}
+          </FieldLabel>
         </Flex>
         <ToggleCheckbox id={generatedId} size={size} name={name} {...props}>
           {label}


### PR DESCRIPTION
Before this PR each Field component used it's own way to render the action for a label. This PR moves it into the `FieldLabel` component, so that: 1) no component is forgotten 2) it is rendered visually consistent and 3) we are not duplicating the code in multiple places.

![Screen Shot 2022-02-17 at 12 08 14](https://user-images.githubusercontent.com/2244375/154469212-356c59c9-d6a0-426d-8f5e-b2702fdfa226.png)

~The positioning of the icon is not great at the moment. It's not perfectly centered, because if interferes with the line-height of the label. It would help to push it down a little. What do you think about it?~

Refs: https://strapi-inc.atlassian.net/browse/CONTENT-131