### PR TITLE
ToggleCheckbox: Improve styles to clarify the components state

### DIFF
--- a/packages/strapi-design-system/src/ToggleCheckbox/ToggleCheckbox.js
+++ b/packages/strapi-design-system/src/ToggleCheckbox/ToggleCheckbox.js
@@ -15,55 +15,45 @@ const Label = styled.label`
 
 const ToggleCheckboxWrapper = styled(Box)`
   height: ${getThemeSize('input')};
+  background-color: ${({ theme }) => theme.colors.neutral100};
   border: 1px solid ${({ theme, disabled }) => (disabled ? theme.colors.neutral300 : theme.colors.neutral200)};
   display: inline-flex;
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : undefined)};
   // Masks the background of each value
   overflow: hidden;
+  padding: ${({ theme }) => theme.spaces[1]};
 
   ${inputFocusStyle()}
 `;
 
-const OnBox = styled(Flex)`
-  text-transform: uppercase;
+const ValueBox = styled(Flex).attrs({
+  hasRadius: true,
+})`
+  background-color: ${({ theme, disabled, checked }) => (checked && !disabled ? theme.colors.neutral0 : 'transparent')};
+  border: ${({ theme, disabled, checked }) =>
+    checked && checked !== null && !disabled ? `1px solid ${theme.colors.neutral200}` : '0'};
   position: relative;
-  z-index: 2;
-`;
-
-const OffBox = styled(Flex)`
-  text-transform: uppercase;
-  border-right: 1px solid ${({ theme, disabled }) => (disabled ? theme.colors.neutral300 : theme.colors.neutral200)};
-  position: relative;
+  user-select: none;
   z-index: 2;
 `;
 
 /**
- * visually Hiding the input under the wrapper without SR-only
- * helps Android SR to provide information with touch and haptic
+ * visually hiding the input without SR-only helps Android SR to provide information with touch and haptic
  */
 const Input = styled.input`
+  left: 0;
+  opacity: 0;
   position: absolute;
+  top: 0;
   z-index: 1;
-  // These are pixel in order to escape the focus offset set in pixel. It's just a hack to hide
-  // the Input behind the toggle checkbox
-  left: 4px;
-  top: 4px;
 `;
 
 export const ToggleCheckbox = React.forwardRef(
   ({ size, onLabel, offLabel, children, checked, disabled, onChange, ...props }, ref) => {
-    const labelColor = 'neutral800';
-    let offCheckboxLabelColor = checked ? labelColor : 'danger700';
-    let onCheckboxLabelColor = checked ? 'primary700' : labelColor;
-    let offCheckboxBackgroundColor = checked ? 'neutral0' : 'danger100';
-    let onCheckboxBackgroundColor = checked ? 'primary100' : 'neutral0';
+    const labelColor = 'neutral600';
 
-    if (checked === null) {
-      offCheckboxBackgroundColor = 'neutral0';
-      onCheckboxBackgroundColor = 'neutral0';
-      offCheckboxLabelColor = 'neutral600';
-      onCheckboxLabelColor = 'neutral600';
-    }
+    let offCheckboxLabelColor = !checked && checked !== null ? 'danger700' : labelColor;
+    let onCheckboxLabelColor = checked ? 'primary600' : labelColor;
 
     const handleChange = (e) => {
       if (disabled) return;
@@ -76,28 +66,39 @@ export const ToggleCheckbox = React.forwardRef(
         <VisuallyHidden>{children}</VisuallyHidden>
 
         <ToggleCheckboxWrapper background="neutral0" hasRadius size={size} disabled={disabled}>
-          <OffBox
-            background={disabled ? 'neutral150' : offCheckboxBackgroundColor}
+          <ValueBox
             paddingLeft={7}
             paddingRight={7}
             aria-hidden={true}
+            checked={checked === null ? false : !checked}
             disabled={disabled}
           >
-            <Typography variant="pi" fontWeight="bold" textColor={disabled ? 'neutral600' : offCheckboxLabelColor}>
+            <Typography
+              variant="pi"
+              fontWeight="bold"
+              textTransform="uppercase"
+              textColor={disabled ? 'neutral600' : offCheckboxLabelColor}
+            >
               {offLabel}
             </Typography>
-          </OffBox>
+          </ValueBox>
 
-          <OnBox
-            background={disabled ? 'neutral200' : onCheckboxBackgroundColor}
+          <ValueBox
             paddingLeft={7}
             paddingRight={7}
             aria-hidden={true}
+            checked={checked === null ? false : checked}
+            disabled={disabled}
           >
-            <Typography variant="pi" fontWeight="bold" textColor={disabled ? 'neutral700' : onCheckboxLabelColor}>
+            <Typography
+              variant="pi"
+              fontWeight="bold"
+              textTransform="uppercase"
+              textColor={disabled ? 'neutral600' : onCheckboxLabelColor}
+            >
               {onLabel}
             </Typography>
-          </OnBox>
+          </ValueBox>
 
           <Input
             type="checkbox"

--- a/packages/strapi-design-system/src/ToggleCheckbox/ToggleCheckbox.js
+++ b/packages/strapi-design-system/src/ToggleCheckbox/ToggleCheckbox.js
@@ -15,13 +15,9 @@ const Label = styled.label`
 
 const ToggleCheckboxWrapper = styled(Box)`
   height: ${getThemeSize('input')};
-  background-color: ${({ theme }) => theme.colors.neutral100};
-  border: 1px solid ${({ theme, disabled }) => (disabled ? theme.colors.neutral300 : theme.colors.neutral200)};
-  display: inline-flex;
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : undefined)};
   // Masks the background of each value
   overflow: hidden;
-  padding: ${({ theme }) => theme.spaces[1]};
 
   ${inputFocusStyle()}
 `;
@@ -30,8 +26,9 @@ const ValueBox = styled(Flex).attrs({
   hasRadius: true,
 })`
   background-color: ${({ theme, disabled, checked }) => (checked && !disabled ? theme.colors.neutral0 : 'transparent')};
-  border: ${({ theme, disabled, checked }) =>
-    checked && checked !== null && !disabled ? `1px solid ${theme.colors.neutral200}` : '0'};
+  border: 1px solid
+    ${({ theme, disabled, checked }) =>
+      checked && checked !== null && !disabled ? theme.colors.neutral200 : theme.colors.neutral100};
   position: relative;
   user-select: none;
   z-index: 2;
@@ -67,7 +64,18 @@ export const ToggleCheckbox = React.forwardRef(
       <Label>
         <VisuallyHidden>{children}</VisuallyHidden>
 
-        <ToggleCheckboxWrapper background="neutral0" hasRadius size={size} disabled={disabled}>
+        <ToggleCheckboxWrapper
+          background="neutral100"
+          hasRadius
+          size={size}
+          disabled={disabled}
+          padding={1}
+          display="inline-flex"
+          backgroundColor="neutral100"
+          borderStyle="solid"
+          borderWidth="1px"
+          borderColor="neutral200"
+        >
           <ValueBox
             paddingLeft={7}
             paddingRight={7}

--- a/packages/strapi-design-system/src/ToggleCheckbox/ToggleCheckbox.js
+++ b/packages/strapi-design-system/src/ToggleCheckbox/ToggleCheckbox.js
@@ -41,11 +41,13 @@ const ValueBox = styled(Flex).attrs({
  * visually hiding the input without SR-only helps Android SR to provide information with touch and haptic
  */
 const Input = styled.input`
+  height: 100%;
   left: 0;
   opacity: 0;
   position: absolute;
   top: 0;
   z-index: 1;
+  width: 100%;
 `;
 
 export const ToggleCheckbox = React.forwardRef(
@@ -103,7 +105,7 @@ export const ToggleCheckbox = React.forwardRef(
           <Input
             type="checkbox"
             aria-disabled={disabled}
-            onChange={handleChange}
+            onChange={(e) => handleChange(e)}
             ref={ref}
             {...props}
             checked={checked}
@@ -120,6 +122,7 @@ ToggleCheckbox.defaultProps = {
   disabled: false,
   checked: false,
   onChange: undefined,
+  onClear: undefined,
   size: 'M',
 };
 
@@ -129,6 +132,7 @@ ToggleCheckbox.propTypes = {
   disabled: PropTypes.bool,
   offLabel: PropTypes.string.isRequired,
   onChange: PropTypes.func,
+  onClear: PropTypes.func,
   onLabel: PropTypes.string.isRequired,
   size: PropTypes.oneOf(Object.keys(sizes.input)),
 };

--- a/packages/strapi-design-system/src/ToggleCheckbox/ToggleCheckbox.stories.mdx
+++ b/packages/strapi-design-system/src/ToggleCheckbox/ToggleCheckbox.stories.mdx
@@ -29,27 +29,16 @@ import { ToggleCheckbox } from '@strapi/design-system/ToggleCheckbox';
 
 Use a toggle whenever the users need to turn something on or off in a form. A toggle can be disabled.
 
-### Activated Toggle
-
-The activated state is one of the two available states for a Toggle.
-
 <Canvas>
-  <Story name="activated">
-    <ToggleCheckbox onLabel="True" offLabel="False" checked={true} onChange={() => {}}>
-      The field is required?
-    </ToggleCheckbox>
-  </Story>
-</Canvas>
-
-### ToggleCheckbox not activated
-
-The deactivated state is one of the two available states for a Toggle.
-
-<Canvas>
-  <Story name="not activated">
-    <ToggleCheckbox onLabel="True" offLabel="False" checked={false} onChange={() => {}}>
-      The field is required?
-    </ToggleCheckbox>
+  <Story name="base">
+    {() => {
+      const [checked, setChecked] = useState(false);
+      return (
+        <ToggleCheckbox onLabel="True" offLabel="False" checked={checked} onChange={(e) => setChecked(prev => !prev)}>
+          The field is required?
+        </ToggleCheckbox>
+      )
+    }}
   </Story>
 </Canvas>
 
@@ -62,6 +51,24 @@ The deactivated state is one of the two available states for a Toggle.
     <ToggleCheckbox size="S" onLabel="True" offLabel="False" checked={false} onChange={() => {}}>
       The field is required?
     </ToggleCheckbox>
+  </Story>
+</Canvas>
+
+### Null value
+
+<Canvas>
+  <Story name="null-value">
+    {() => {
+      const [checked, setChecked] = useState(null);
+      return (
+        <ToggleCheckbox
+          onLabel="True"
+          offLabel="False"
+          checked={checked}
+          onChange={(e) => setChecked(prev => !prev)}
+        />
+      )
+    }}
   </Story>
 </Canvas>
 

--- a/packages/strapi-design-system/src/ToggleCheckbox/ToggleCheckbox.stories.mdx
+++ b/packages/strapi-design-system/src/ToggleCheckbox/ToggleCheckbox.stories.mdx
@@ -35,7 +35,7 @@ The activated state is one of the two available states for a Toggle.
 
 <Canvas>
   <Story name="activated">
-    <ToggleCheckbox onLabel={'On'} offLabel={'Off'} checked={true} onChange={() => {}}>
+    <ToggleCheckbox onLabel="True" offLabel="False" checked={true} onChange={() => {}}>
       The field is required?
     </ToggleCheckbox>
   </Story>
@@ -47,7 +47,7 @@ The deactivated state is one of the two available states for a Toggle.
 
 <Canvas>
   <Story name="not activated">
-    <ToggleCheckbox onLabel={'On'} offLabel={'Off'} checked={false} onChange={() => {}}>
+    <ToggleCheckbox onLabel="True" offLabel="False" checked={false} onChange={() => {}}>
       The field is required?
     </ToggleCheckbox>
   </Story>
@@ -59,7 +59,7 @@ The deactivated state is one of the two available states for a Toggle.
 
 <Canvas>
   <Story name="size S">
-    <ToggleCheckbox size="S" onLabel={'On'} offLabel={'Off'} checked={false} onChange={() => {}}>
+    <ToggleCheckbox size="S" onLabel="True" offLabel="False" checked={false} onChange={() => {}}>
       The field is required?
     </ToggleCheckbox>
   </Story>
@@ -69,7 +69,7 @@ The deactivated state is one of the two available states for a Toggle.
 
 <Canvas>
   <Story name="disabled">
-    <ToggleCheckbox disabled onLabel={'On'} offLabel={'Off'} checked={true} onChange={() => {}}>
+    <ToggleCheckbox disabled onLabel="True" offLabel="False" checked={true} onChange={() => {}}>
       The field is required?
     </ToggleCheckbox>
   </Story>

--- a/packages/strapi-design-system/src/ToggleCheckbox/__tests__/ToggleCheckbox.e2e.js
+++ b/packages/strapi-design-system/src/ToggleCheckbox/__tests__/ToggleCheckbox.e2e.js
@@ -3,19 +3,9 @@ const { injectAxe, checkA11y } = require('axe-playwright');
 const { test } = require('@playwright/test');
 
 test.describe.parallel('ToggleCheckbox', () => {
-  test.describe('activated', () => {
-    test('triggers axe on the document', async ({ page }) => {
-      await page.goto('/iframe.html?id=design-system-components-togglecheckbox--activated&viewMode=storyy');
-      await injectAxe(page);
-      await checkA11y(page);
-    });
-  });
-
-  test.describe('not activated', () => {
-    test('triggers axe on the document', async ({ page }) => {
-      await page.goto('/iframe.html?id=design-system-components-togglecheckbox--not-activated&viewMode=story');
-      await injectAxe(page);
-      await checkA11y(page);
-    });
+  test('triggers axe on the document', async ({ page }) => {
+    await page.goto('/iframe.html?id=design-system-components-togglecheckbox--base&viewMode=story');
+    await injectAxe(page);
+    await checkA11y(page);
   });
 });

--- a/packages/strapi-design-system/src/ToggleInput/ToggleInput.js
+++ b/packages/strapi-design-system/src/ToggleInput/ToggleInput.js
@@ -6,24 +6,49 @@ import { useId } from '../helpers/useId';
 import { Field, FieldHint, FieldError, FieldLabel } from '../Field';
 import { Stack } from '../Stack';
 import { Flex } from '../Flex';
+import { TextButton } from '../TextButton';
 import { ToggleCheckbox } from '../ToggleCheckbox';
 
 const FieldWrapper = styled(Field)`
   width: fit-content;
 `;
 
-export const ToggleInput = ({ size, error, hint, label, name, labelAction, required, id, ...props }) => {
+const LabelAction = styled(Box)`
+  svg path {
+    fill: ${({ theme }) => theme.colors.neutral500};
+  }
+`;
+
+const ClearButton = styled(TextButton)`
+  align-self: flex-end;
+  margin-left: auto;
+`;
+
+export const ToggleInput = ({
+  size,
+  error,
+  hint,
+  label,
+  name,
+  labelAction,
+  required,
+  id,
+  onClear,
+  clearLabel,
+  checked,
+  ...props
+}) => {
   const generatedId = useId('toggleinput', id);
 
   return (
     <FieldWrapper name={name} hint={hint} error={error} id={generatedId}>
       <Stack size={1}>
         <Flex>
-          <FieldLabel required={required} action={labelAction}>
-            {label}
-          </FieldLabel>
+          <FieldLabel required={required}>{label}</FieldLabel>
+          {labelAction && <LabelAction paddingLeft={1}>{labelAction}</LabelAction>}
+          {clearLabel && onClear && checked !== null && <ClearButton onClick={onClear}>{clearLabel}</ClearButton>}
         </Flex>
-        <ToggleCheckbox id={generatedId} size={size} name={name} {...props}>
+        <ToggleCheckbox id={generatedId} size={size} name={name} onClear={onClear} checked={checked} {...props}>
           {label}
         </ToggleCheckbox>
         <FieldHint />
@@ -36,23 +61,29 @@ export const ToggleInput = ({ size, error, hint, label, name, labelAction, requi
 ToggleInput.displayName = 'ToggleInput';
 
 ToggleInput.defaultProps = {
+  checked: false,
+  clearLabel: undefined,
   error: undefined,
   hint: undefined,
   id: undefined,
   label: '',
   labelAction: undefined,
   name: '',
+  onClear: undefined,
   required: false,
   size: 'M',
 };
 
 ToggleInput.propTypes = {
+  checked: PropTypes.bool,
+  clearLabel: PropTypes.string,
   error: PropTypes.string,
   hint: PropTypes.string,
   id: PropTypes.string,
   label: PropTypes.string,
   labelAction: PropTypes.node,
   name: PropTypes.string,
+  onClear: PropTypes.func,
   required: PropTypes.bool,
   size: PropTypes.oneOf(Object.keys(sizes.input)),
 };

--- a/packages/strapi-design-system/src/ToggleInput/ToggleInput.js
+++ b/packages/strapi-design-system/src/ToggleInput/ToggleInput.js
@@ -13,12 +13,6 @@ const FieldWrapper = styled(Field)`
   width: fit-content;
 `;
 
-const LabelAction = styled(Box)`
-  svg path {
-    fill: ${({ theme }) => theme.colors.neutral500};
-  }
-`;
-
 const ClearButton = styled(TextButton)`
   align-self: flex-end;
   margin-left: auto;
@@ -44,8 +38,9 @@ export const ToggleInput = ({
     <FieldWrapper name={name} hint={hint} error={error} id={generatedId}>
       <Stack size={1}>
         <Flex>
-          <FieldLabel required={required}>{label}</FieldLabel>
-          {labelAction && <LabelAction paddingLeft={1}>{labelAction}</LabelAction>}
+          <FieldLabel required={required} action={labelAction}>
+            {label}
+          </FieldLabel>
           {clearLabel && onClear && checked !== null && <ClearButton onClick={onClear}>{clearLabel}</ClearButton>}
         </Flex>
         <ToggleCheckbox id={generatedId} size={size} name={name} onClear={onClear} checked={checked} {...props}>

--- a/packages/strapi-design-system/src/ToggleInput/ToggleInput.stories.mdx
+++ b/packages/strapi-design-system/src/ToggleInput/ToggleInput.stories.mdx
@@ -38,8 +38,8 @@ import { ToggleInput } from '@strapi/design-system/ToggleInput';
           </button>
         </Tooltip>
       }
-      onLabel="on"
-      offLabel="off"
+      onLabel="True"
+      offLabel="False"
       checked={true}
       onChange={() => {}}
     />
@@ -55,8 +55,8 @@ import { ToggleInput } from '@strapi/design-system/ToggleInput';
       error="this field is required"
       label="Label"
       name="enable-provider"
-      onLabel="on"
-      offLabel="off"
+      onLabel="True"
+      offLabel="False"
       checked={false}
       onChange={() => {}}
     />
@@ -73,8 +73,8 @@ import { ToggleInput } from '@strapi/design-system/ToggleInput';
       error="this field is required"
       label="Label"
       name="enable-provider"
-      onLabel="on"
-      offLabel="off"
+      onLabel="True"
+      offLabel="False"
       checked={false}
       onChange={() => {}}
     />
@@ -89,8 +89,8 @@ import { ToggleInput } from '@strapi/design-system/ToggleInput';
       hint="Enable provider"
       label="Label"
       name="enable-provider"
-      onLabel="on"
-      offLabel="off"
+      onLabel="True"
+      offLabel="False"
       checked={null}
       onChange={() => {}}
     />

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -11741,7 +11741,7 @@ exports[`Storyshots Design System/Components/DatePicker base 1`] = `
                 class="c8"
                 id="datepicker-45"
                 name="datepicker"
-                placeholder="2/28/2022"
+                placeholder="3/1/2022"
                 value=""
               />
             </div>
@@ -11974,7 +11974,7 @@ exports[`Storyshots Design System/Components/DatePicker disabled 1`] = `
                 class="c8"
                 id="datepicker-46"
                 name="datepicker"
-                placeholder="2/28/2022"
+                placeholder="3/1/2022"
                 value=""
               />
             </div>
@@ -12201,7 +12201,7 @@ exports[`Storyshots Design System/Components/DatePicker min/ max date 1`] = `
               class="c8"
               id="datepicker-47"
               name="datepicker"
-              placeholder="2/28/2022"
+              placeholder="3/1/2022"
               value=""
             />
           </div>
@@ -12421,7 +12421,7 @@ exports[`Storyshots Design System/Components/DatePicker size S 1`] = `
                 class="c8"
                 id="datepicker-48"
                 name="datepicker"
-                placeholder="2/28/2022"
+                placeholder="3/1/2022"
                 value=""
               />
             </div>
@@ -44104,7 +44104,7 @@ exports[`Storyshots Design System/Components/TimePicker size S 1`] = `
 </main>
 `;
 
-exports[`Storyshots Design System/Components/ToggleCheckbox activated 1`] = `
+exports[`Storyshots Design System/Components/ToggleCheckbox base 1`] = `
 .c0 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
@@ -44119,33 +44119,37 @@ exports[`Storyshots Design System/Components/ToggleCheckbox activated 1`] = `
 
 .c7 {
   font-weight: 600;
-  color: #32324d;
+  color: #b72b1a;
+  text-transform: uppercase;
   font-size: 0.75rem;
   line-height: 1.33;
 }
 
-.c10 {
+.c9 {
   font-weight: 600;
-  color: #271fe0;
+  color: #666687;
+  text-transform: uppercase;
   font-size: 0.75rem;
   line-height: 1.33;
 }
 
 .c2 {
-  background: #ffffff;
+  background: #f6f6f9;
+  padding: 4px;
   border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  border-color: #dcdce4;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
 }
 
 .c4 {
-  background: #ffffff;
   padding-right: 32px;
   padding-left: 32px;
-}
-
-.c8 {
-  background: #f0f0ff;
-  padding-right: 32px;
-  padding-left: 32px;
+  border-radius: 4px;
 }
 
 .c5 {
@@ -44169,11 +44173,6 @@ exports[`Storyshots Design System/Components/ToggleCheckbox activated 1`] = `
 
 .c3 {
   height: 2.5rem;
-  border: 1px solid #dcdce4;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
   overflow: hidden;
   outline: none;
   box-shadow: 0;
@@ -44188,24 +44187,36 @@ exports[`Storyshots Design System/Components/ToggleCheckbox activated 1`] = `
   box-shadow: #4945ff 0px 0px 0px 2px;
 }
 
-.c9 {
-  text-transform: uppercase;
-  position: relative;
-  z-index: 2;
-}
-
 .c6 {
-  text-transform: uppercase;
-  border-right: 1px solid #dcdce4;
+  background-color: #ffffff;
+  border: 1px solid #dcdce4;
   position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   z-index: 2;
 }
 
-.c11 {
+.c8 {
+  background-color: transparent;
+  border: 1px solid #f6f6f9;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  z-index: 2;
+}
+
+.c10 {
+  height: 100%;
+  left: 0;
+  opacity: 0;
   position: absolute;
+  top: 0;
   z-index: 1;
-  left: 4px;
-  top: 4px;
+  width: 100%;
 }
 
 <main>
@@ -44226,6 +44237,7 @@ exports[`Storyshots Design System/Components/ToggleCheckbox activated 1`] = `
     </div>
     <div
       class="c2 c3"
+      display="inline-flex"
     >
       <div
         aria-hidden="true"
@@ -44234,23 +44246,22 @@ exports[`Storyshots Design System/Components/ToggleCheckbox activated 1`] = `
         <span
           class="c7"
         >
-          Off
+          False
         </span>
       </div>
       <div
         aria-hidden="true"
-        class="c8 c5 c9"
+        class="c4 c5 c8"
       >
         <span
-          class="c10"
+          class="c9"
         >
-          On
+          True
         </span>
       </div>
       <input
         aria-disabled="false"
-        checked=""
-        class="c11"
+        class="c10"
         type="checkbox"
       />
     </div>
@@ -44274,32 +44285,28 @@ exports[`Storyshots Design System/Components/ToggleCheckbox disabled 1`] = `
 .c7 {
   font-weight: 600;
   color: #666687;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c10 {
-  font-weight: 600;
-  color: #4a4a6a;
+  text-transform: uppercase;
   font-size: 0.75rem;
   line-height: 1.33;
 }
 
 .c2 {
-  background: #ffffff;
+  background: #f6f6f9;
+  padding: 4px;
   border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  border-color: #dcdce4;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
 }
 
 .c4 {
-  background: #eaeaef;
   padding-right: 32px;
   padding-left: 32px;
-}
-
-.c8 {
-  background: #dcdce4;
-  padding-right: 32px;
-  padding-left: 32px;
+  border-radius: 4px;
 }
 
 .c5 {
@@ -44323,11 +44330,6 @@ exports[`Storyshots Design System/Components/ToggleCheckbox disabled 1`] = `
 
 .c3 {
   height: 2.5rem;
-  border: 1px solid #c0c0cf;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
   cursor: not-allowed;
   overflow: hidden;
   outline: none;
@@ -44343,24 +44345,25 @@ exports[`Storyshots Design System/Components/ToggleCheckbox disabled 1`] = `
   box-shadow: #4945ff 0px 0px 0px 2px;
 }
 
-.c9 {
-  text-transform: uppercase;
-  position: relative;
-  z-index: 2;
-}
-
 .c6 {
-  text-transform: uppercase;
-  border-right: 1px solid #c0c0cf;
+  background-color: transparent;
+  border: 1px solid #f6f6f9;
   position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   z-index: 2;
 }
 
-.c11 {
+.c8 {
+  height: 100%;
+  left: 0;
+  opacity: 0;
   position: absolute;
+  top: 0;
   z-index: 1;
-  left: 4px;
-  top: 4px;
+  width: 100%;
 }
 
 <main>
@@ -44382,6 +44385,7 @@ exports[`Storyshots Design System/Components/ToggleCheckbox disabled 1`] = `
     <div
       class="c2 c3"
       disabled=""
+      display="inline-flex"
     >
       <div
         aria-hidden="true"
@@ -44391,23 +44395,24 @@ exports[`Storyshots Design System/Components/ToggleCheckbox disabled 1`] = `
         <span
           class="c7"
         >
-          Off
+          False
         </span>
       </div>
       <div
         aria-hidden="true"
-        class="c8 c5 c9"
+        class="c4 c5 c6"
+        disabled=""
       >
         <span
-          class="c10"
+          class="c7"
         >
-          On
+          True
         </span>
       </div>
       <input
         aria-disabled="true"
         checked=""
-        class="c11"
+        class="c8"
         type="checkbox"
       />
     </div>
@@ -44415,7 +44420,7 @@ exports[`Storyshots Design System/Components/ToggleCheckbox disabled 1`] = `
 </main>
 `;
 
-exports[`Storyshots Design System/Components/ToggleCheckbox not activated 1`] = `
+exports[`Storyshots Design System/Components/ToggleCheckbox null-value 1`] = `
 .c0 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
@@ -44430,33 +44435,29 @@ exports[`Storyshots Design System/Components/ToggleCheckbox not activated 1`] = 
 
 .c7 {
   font-weight: 600;
-  color: #b72b1a;
-  font-size: 0.75rem;
-  line-height: 1.33;
-}
-
-.c10 {
-  font-weight: 600;
-  color: #32324d;
+  color: #666687;
+  text-transform: uppercase;
   font-size: 0.75rem;
   line-height: 1.33;
 }
 
 .c2 {
-  background: #ffffff;
+  background: #f6f6f9;
+  padding: 4px;
   border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  border-color: #dcdce4;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
 }
 
 .c4 {
-  background: #fcecea;
   padding-right: 32px;
   padding-left: 32px;
-}
-
-.c8 {
-  background: #ffffff;
-  padding-right: 32px;
-  padding-left: 32px;
+  border-radius: 4px;
 }
 
 .c5 {
@@ -44480,11 +44481,6 @@ exports[`Storyshots Design System/Components/ToggleCheckbox not activated 1`] = 
 
 .c3 {
   height: 2.5rem;
-  border: 1px solid #dcdce4;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
   overflow: hidden;
   outline: none;
   box-shadow: 0;
@@ -44499,24 +44495,25 @@ exports[`Storyshots Design System/Components/ToggleCheckbox not activated 1`] = 
   box-shadow: #4945ff 0px 0px 0px 2px;
 }
 
-.c9 {
-  text-transform: uppercase;
-  position: relative;
-  z-index: 2;
-}
-
 .c6 {
-  text-transform: uppercase;
-  border-right: 1px solid #dcdce4;
+  background-color: transparent;
+  border: 1px solid #f6f6f9;
   position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   z-index: 2;
 }
 
-.c11 {
+.c8 {
+  height: 100%;
+  left: 0;
+  opacity: 0;
   position: absolute;
+  top: 0;
   z-index: 1;
-  left: 4px;
-  top: 4px;
+  width: 100%;
 }
 
 <main>
@@ -44532,11 +44529,10 @@ exports[`Storyshots Design System/Components/ToggleCheckbox not activated 1`] = 
   >
     <div
       class="c0"
-    >
-      The field is required?
-    </div>
+    />
     <div
       class="c2 c3"
+      display="inline-flex"
     >
       <div
         aria-hidden="true"
@@ -44545,22 +44541,22 @@ exports[`Storyshots Design System/Components/ToggleCheckbox not activated 1`] = 
         <span
           class="c7"
         >
-          Off
+          False
         </span>
       </div>
       <div
         aria-hidden="true"
-        class="c8 c5 c9"
+        class="c4 c5 c6"
       >
         <span
-          class="c10"
+          class="c7"
         >
-          On
+          True
         </span>
       </div>
       <input
         aria-disabled="false"
-        class="c11"
+        class="c8"
         type="checkbox"
       />
     </div>
@@ -44584,32 +44580,36 @@ exports[`Storyshots Design System/Components/ToggleCheckbox size S 1`] = `
 .c7 {
   font-weight: 600;
   color: #b72b1a;
+  text-transform: uppercase;
   font-size: 0.75rem;
   line-height: 1.33;
 }
 
-.c10 {
+.c9 {
   font-weight: 600;
-  color: #32324d;
+  color: #666687;
+  text-transform: uppercase;
   font-size: 0.75rem;
   line-height: 1.33;
 }
 
 .c2 {
-  background: #ffffff;
+  background: #f6f6f9;
+  padding: 4px;
   border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  border-color: #dcdce4;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
 }
 
 .c4 {
-  background: #fcecea;
   padding-right: 32px;
   padding-left: 32px;
-}
-
-.c8 {
-  background: #ffffff;
-  padding-right: 32px;
-  padding-left: 32px;
+  border-radius: 4px;
 }
 
 .c5 {
@@ -44633,11 +44633,6 @@ exports[`Storyshots Design System/Components/ToggleCheckbox size S 1`] = `
 
 .c3 {
   height: 2rem;
-  border: 1px solid #dcdce4;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
   overflow: hidden;
   outline: none;
   box-shadow: 0;
@@ -44652,24 +44647,36 @@ exports[`Storyshots Design System/Components/ToggleCheckbox size S 1`] = `
   box-shadow: #4945ff 0px 0px 0px 2px;
 }
 
-.c9 {
-  text-transform: uppercase;
-  position: relative;
-  z-index: 2;
-}
-
 .c6 {
-  text-transform: uppercase;
-  border-right: 1px solid #dcdce4;
+  background-color: #ffffff;
+  border: 1px solid #dcdce4;
   position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   z-index: 2;
 }
 
-.c11 {
+.c8 {
+  background-color: transparent;
+  border: 1px solid #f6f6f9;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  z-index: 2;
+}
+
+.c10 {
+  height: 100%;
+  left: 0;
+  opacity: 0;
   position: absolute;
+  top: 0;
   z-index: 1;
-  left: 4px;
-  top: 4px;
+  width: 100%;
 }
 
 <main>
@@ -44690,6 +44697,7 @@ exports[`Storyshots Design System/Components/ToggleCheckbox size S 1`] = `
     </div>
     <div
       class="c2 c3"
+      display="inline-flex"
     >
       <div
         aria-hidden="true"
@@ -44698,22 +44706,22 @@ exports[`Storyshots Design System/Components/ToggleCheckbox size S 1`] = `
         <span
           class="c7"
         >
-          Off
+          False
         </span>
       </div>
       <div
         aria-hidden="true"
-        class="c8 c5 c9"
+        class="c4 c5 c8"
       >
         <span
-          class="c10"
+          class="c9"
         >
-          On
+          True
         </span>
       </div>
       <input
         aria-disabled="false"
-        class="c11"
+        class="c10"
         type="checkbox"
       />
     </div>
@@ -44741,9 +44749,18 @@ exports[`Storyshots Design System/Components/ToggleInput base 1`] = `
   line-height: 1.33;
 }
 
+.c12 {
+  font-weight: 600;
+  color: #666687;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
 .c14 {
   font-weight: 600;
-  color: #271fe0;
+  color: #4945ff;
+  text-transform: uppercase;
   font-size: 0.75rem;
   line-height: 1.33;
 }
@@ -44759,20 +44776,22 @@ exports[`Storyshots Design System/Components/ToggleInput base 1`] = `
 }
 
 .c8 {
-  background: #ffffff;
+  background: #f6f6f9;
+  padding: 4px;
   border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  border-color: #dcdce4;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
 }
 
 .c10 {
-  background: #ffffff;
   padding-right: 32px;
   padding-left: 32px;
-}
-
-.c12 {
-  background: #f0f0ff;
-  padding-right: 32px;
-  padding-left: 32px;
+  border-radius: 4px;
 }
 
 .c3 {
@@ -44823,11 +44842,6 @@ exports[`Storyshots Design System/Components/ToggleInput base 1`] = `
 
 .c9 {
   height: 2.5rem;
-  border: 1px solid #dcdce4;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
   overflow: hidden;
   outline: none;
   box-shadow: 0;
@@ -44842,24 +44856,36 @@ exports[`Storyshots Design System/Components/ToggleInput base 1`] = `
   box-shadow: #4945ff 0px 0px 0px 2px;
 }
 
-.c13 {
-  text-transform: uppercase;
+.c11 {
+  background-color: transparent;
+  border: 1px solid #f6f6f9;
   position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   z-index: 2;
 }
 
-.c11 {
-  text-transform: uppercase;
-  border-right: 1px solid #dcdce4;
+.c13 {
+  background-color: #ffffff;
+  border: 1px solid #dcdce4;
   position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   z-index: 2;
 }
 
 .c15 {
+  height: 100%;
+  left: 0;
+  opacity: 0;
   position: absolute;
+  top: 0;
   z-index: 1;
-  left: 4px;
-  top: 4px;
+  width: 100%;
 }
 
 .c1 {
@@ -44932,25 +44958,26 @@ exports[`Storyshots Design System/Components/ToggleInput base 1`] = `
         </div>
         <div
           class="c8 c9"
+          display="inline-flex"
         >
           <div
             aria-hidden="true"
             class="c10 c3 c11"
           >
             <span
-              class="c4"
+              class="c12"
             >
-              off
+              False
             </span>
           </div>
           <div
             aria-hidden="true"
-            class="c12 c3 c13"
+            class="c10 c3 c13"
           >
             <span
               class="c14"
             >
-              on
+              True
             </span>
           </div>
           <input
@@ -44997,6 +45024,15 @@ exports[`Storyshots Design System/Components/ToggleInput error 1`] = `
 .c10 {
   font-weight: 600;
   color: #b72b1a;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c12 {
+  font-weight: 600;
+  color: #666687;
+  text-transform: uppercase;
   font-size: 0.75rem;
   line-height: 1.33;
 }
@@ -45008,20 +45044,22 @@ exports[`Storyshots Design System/Components/ToggleInput error 1`] = `
 }
 
 .c6 {
-  background: #ffffff;
+  background: #f6f6f9;
+  padding: 4px;
   border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  border-color: #dcdce4;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
 }
 
 .c8 {
-  background: #fcecea;
   padding-right: 32px;
   padding-left: 32px;
-}
-
-.c11 {
-  background: #ffffff;
-  padding-right: 32px;
-  padding-left: 32px;
+  border-radius: 4px;
 }
 
 .c3 {
@@ -45064,11 +45102,6 @@ exports[`Storyshots Design System/Components/ToggleInput error 1`] = `
 
 .c7 {
   height: 2.5rem;
-  border: 1px solid #dcdce4;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
   overflow: hidden;
   outline: none;
   box-shadow: 0;
@@ -45083,24 +45116,36 @@ exports[`Storyshots Design System/Components/ToggleInput error 1`] = `
   box-shadow: #4945ff 0px 0px 0px 2px;
 }
 
-.c12 {
-  text-transform: uppercase;
+.c9 {
+  background-color: #ffffff;
+  border: 1px solid #dcdce4;
   position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   z-index: 2;
 }
 
-.c9 {
-  text-transform: uppercase;
-  border-right: 1px solid #dcdce4;
+.c11 {
+  background-color: transparent;
+  border: 1px solid #f6f6f9;
   position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   z-index: 2;
 }
 
 .c13 {
+  height: 100%;
+  left: 0;
+  opacity: 0;
   position: absolute;
+  top: 0;
   z-index: 1;
-  left: 4px;
-  top: 4px;
+  width: 100%;
 }
 
 .c1 {
@@ -45147,6 +45192,7 @@ exports[`Storyshots Design System/Components/ToggleInput error 1`] = `
         </div>
         <div
           class="c6 c7"
+          display="inline-flex"
         >
           <div
             aria-hidden="true"
@@ -45155,17 +45201,17 @@ exports[`Storyshots Design System/Components/ToggleInput error 1`] = `
             <span
               class="c10"
             >
-              off
+              False
             </span>
           </div>
           <div
             aria-hidden="true"
-            class="c11 c3 c12"
+            class="c8 c3 c11"
           >
             <span
-              class="c4"
+              class="c12"
             >
-              on
+              True
             </span>
           </div>
           <input
@@ -45212,25 +45258,34 @@ exports[`Storyshots Design System/Components/ToggleInput null-value 1`] = `
 .c10 {
   font-weight: 600;
   color: #666687;
+  text-transform: uppercase;
   font-size: 0.75rem;
   line-height: 1.33;
 }
 
-.c13 {
+.c12 {
   color: #666687;
   font-size: 0.75rem;
   line-height: 1.33;
 }
 
 .c6 {
-  background: #ffffff;
+  background: #f6f6f9;
+  padding: 4px;
   border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  border-color: #dcdce4;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
 }
 
 .c8 {
-  background: #ffffff;
   padding-right: 32px;
   padding-left: 32px;
+  border-radius: 4px;
 }
 
 .c3 {
@@ -45273,11 +45328,6 @@ exports[`Storyshots Design System/Components/ToggleInput null-value 1`] = `
 
 .c7 {
   height: 2.5rem;
-  border: 1px solid #dcdce4;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
   overflow: hidden;
   outline: none;
   box-shadow: 0;
@@ -45292,24 +45342,25 @@ exports[`Storyshots Design System/Components/ToggleInput null-value 1`] = `
   box-shadow: #4945ff 0px 0px 0px 2px;
 }
 
-.c11 {
-  text-transform: uppercase;
-  position: relative;
-  z-index: 2;
-}
-
 .c9 {
-  text-transform: uppercase;
-  border-right: 1px solid #dcdce4;
+  background-color: transparent;
+  border: 1px solid #f6f6f9;
   position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   z-index: 2;
 }
 
-.c12 {
+.c11 {
+  height: 100%;
+  left: 0;
+  opacity: 0;
   position: absolute;
+  top: 0;
   z-index: 1;
-  left: 4px;
-  top: 4px;
+  width: 100%;
 }
 
 .c1 {
@@ -45356,6 +45407,7 @@ exports[`Storyshots Design System/Components/ToggleInput null-value 1`] = `
         </div>
         <div
           class="c6 c7"
+          display="inline-flex"
         >
           <div
             aria-hidden="true"
@@ -45364,22 +45416,22 @@ exports[`Storyshots Design System/Components/ToggleInput null-value 1`] = `
             <span
               class="c10"
             >
-              off
+              False
             </span>
           </div>
           <div
             aria-hidden="true"
-            class="c8 c3 c11"
+            class="c8 c3 c9"
           >
             <span
               class="c10"
             >
-              on
+              True
             </span>
           </div>
           <input
             aria-disabled="false"
-            class="c12"
+            class="c11"
             id="toggleinput-232"
             name="enable-provider"
             type="checkbox"
@@ -45387,7 +45439,7 @@ exports[`Storyshots Design System/Components/ToggleInput null-value 1`] = `
         </div>
       </label>
       <p
-        class="c13"
+        class="c12"
         id="toggleinput-232-hint"
       >
         Enable provider
@@ -45420,6 +45472,15 @@ exports[`Storyshots Design System/Components/ToggleInput size S 1`] = `
 .c10 {
   font-weight: 600;
   color: #b72b1a;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c12 {
+  font-weight: 600;
+  color: #666687;
+  text-transform: uppercase;
   font-size: 0.75rem;
   line-height: 1.33;
 }
@@ -45431,20 +45492,22 @@ exports[`Storyshots Design System/Components/ToggleInput size S 1`] = `
 }
 
 .c6 {
-  background: #ffffff;
+  background: #f6f6f9;
+  padding: 4px;
   border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  border-color: #dcdce4;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
 }
 
 .c8 {
-  background: #fcecea;
   padding-right: 32px;
   padding-left: 32px;
-}
-
-.c11 {
-  background: #ffffff;
-  padding-right: 32px;
-  padding-left: 32px;
+  border-radius: 4px;
 }
 
 .c3 {
@@ -45487,11 +45550,6 @@ exports[`Storyshots Design System/Components/ToggleInput size S 1`] = `
 
 .c7 {
   height: 2rem;
-  border: 1px solid #dcdce4;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
   overflow: hidden;
   outline: none;
   box-shadow: 0;
@@ -45506,24 +45564,36 @@ exports[`Storyshots Design System/Components/ToggleInput size S 1`] = `
   box-shadow: #4945ff 0px 0px 0px 2px;
 }
 
-.c12 {
-  text-transform: uppercase;
+.c9 {
+  background-color: #ffffff;
+  border: 1px solid #dcdce4;
   position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   z-index: 2;
 }
 
-.c9 {
-  text-transform: uppercase;
-  border-right: 1px solid #dcdce4;
+.c11 {
+  background-color: transparent;
+  border: 1px solid #f6f6f9;
   position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   z-index: 2;
 }
 
 .c13 {
+  height: 100%;
+  left: 0;
+  opacity: 0;
   position: absolute;
+  top: 0;
   z-index: 1;
-  left: 4px;
-  top: 4px;
+  width: 100%;
 }
 
 .c1 {
@@ -45570,6 +45640,7 @@ exports[`Storyshots Design System/Components/ToggleInput size S 1`] = `
         </div>
         <div
           class="c6 c7"
+          display="inline-flex"
         >
           <div
             aria-hidden="true"
@@ -45578,17 +45649,17 @@ exports[`Storyshots Design System/Components/ToggleInput size S 1`] = `
             <span
               class="c10"
             >
-              off
+              False
             </span>
           </div>
           <div
             aria-hidden="true"
-            class="c11 c3 c12"
+            class="c8 c3 c11"
           >
             <span
-              class="c4"
+              class="c12"
             >
-              on
+              True
             </span>
           </div>
           <input


### PR DESCRIPTION
This PR implements the first batch of the `ToggleCheckbox` refresh:

<img width="262" alt="Screenshot 2022-02-17 at 14 21 45" src="https://user-images.githubusercontent.com/2244375/154490264-882d4a89-9dcf-48dc-a0d1-14ed73478a0f.png">

The content squad hopes to clarify the state the checkbox is in.

## Demo

- https://design-system-git-content-73-toggle-checkbox-refresh-strapijs.vercel.app/?path=/story/design-system-components-toggleinput--base

## References

Refs: https://www.figma.com/file/PICiE8O4NLrHO1lhJftLdE/Strapi---UI-Kit-%F0%9F%A7%A9?node-id=10500%3A120443
Refs: https://strapi-inc.atlassian.net/browse/CONTENT-73
Refs: https://github.com/strapi/strapi/issues/12372