### PR TITLE
Datepicker: make min/ max date configurable and extend default range

### DIFF
--- a/packages/strapi-design-system/src/DatePicker/DatePicker.js
+++ b/packages/strapi-design-system/src/DatePicker/DatePicker.js
@@ -20,6 +20,8 @@ export const DatePicker = ({
   onClear,
   clearLabel,
   disabled,
+  minDate,
+  maxDate,
   id,
   ...props
 }) => {
@@ -28,7 +30,7 @@ export const DatePicker = ({
   const inputRef = useRef(null);
   const datePickerButtonRef = useRef(null);
   const formattedDate = selectedDate ? formatDate(selectedDate) : '';
-  const placeholder = formatDate(new Date(1970, 0, 1));
+  const placeholder = formatDate(new Date());
 
   const toggleVisibility = () => {
     if (disabled) return;
@@ -90,6 +92,8 @@ export const DatePicker = ({
           onChange={handleChange}
           popoverSource={inputRef.current.inputWrapperRef}
           label={label || ariaLabel}
+          minDate={minDate}
+          maxDate={maxDate}
         />
       )}
     </DatePickerWrapper>
@@ -115,6 +119,8 @@ DatePicker.propTypes = {
   id: PropTypes.string,
   initialDate: PropTypes.instanceOf(Date),
   label: PropTypes.string,
+  maxDate: PropTypes.instanceOf(Date),
+  minDate: PropTypes.instanceOf(Date),
   onChange: PropTypes.func.isRequired,
   onClear: PropTypes.func,
   selectedDate: PropTypes.instanceOf(Date),

--- a/packages/strapi-design-system/src/DatePicker/DatePicker.stories.mdx
+++ b/packages/strapi-design-system/src/DatePicker/DatePicker.stories.mdx
@@ -109,6 +109,31 @@ TODO
   </Story>
 </Canvas>
 
+## Min and Max Dates
+
+By passing in `minDate` or `maxDate` it is possible to define the range of years, the datepicker displays.
+
+<Canvas>
+  <Story name="min/ max date">
+    {() => {
+      const [date, setDate] = useState();
+      return (
+        <DatePicker
+          onChange={setDate}
+          selectedDate={date}
+          label="Date picker"
+          name="datepicker"
+          clearLabel={'Clear the datepicker'}
+          onClear={() => setDate(undefined)}
+          selectedDateLabel={(formattedDate) => `Date picker, current is ${formattedDate}`}
+          minDate={new Date(2000, 1, 1)}
+          maxDate={new Date(2040, 1, 1)}
+        />
+      );
+    }}
+  </Story>
+</Canvas>
+
 ## Props
 
 <ArgsTable of={DatePicker} />

--- a/packages/strapi-design-system/src/DatePicker/DatePickerCalendar.js
+++ b/packages/strapi-design-system/src/DatePicker/DatePickerCalendar.js
@@ -11,12 +11,12 @@ import { DatePickerTd } from './DatePickerTd';
 import { FocusTrap } from '../FocusTrap';
 import { getMonths, getDayOfWeek, generateWeeks, getYears, formatDate } from './utils';
 
-export const DatePickerCalendar = ({ selectedDate, initialDate, popoverSource, onChange, label }) => {
+export const DatePickerCalendar = ({ selectedDate, initialDate, popoverSource, onChange, label, minDate, maxDate }) => {
   const [date, setDate] = useState(initialDate);
   const [weeks, activeRow, activeCol] = generateWeeks(date, selectedDate);
   const { sun, mon, tue, wed, thu, fri, sat } = getDayOfWeek();
   const months = getMonths();
-  const years = getYears();
+  const years = getYears(minDate, maxDate);
 
   useEffect(() => {
     if (selectedDate) {
@@ -104,6 +104,18 @@ DatePickerCalendar.defaultProps = { selectedDate: undefined, initialDate: new Da
 DatePickerCalendar.propTypes = {
   initialDate: PropTypes.instanceOf(Date),
   label: PropTypes.string.isRequired,
+
+  /*
+   * Maximum year, that can be selected through the year select
+   */
+
+  maxDate: PropTypes.instanceOf(Date),
+
+  /*
+   * Minimum year, that can be selected through the year select
+   */
+
+  minDate: PropTypes.instanceOf(Date),
   onChange: PropTypes.func.isRequired,
   popoverSource: PropTypes.shape({ current: PropTypes.instanceOf(Element) }).isRequired,
   selectedDate: PropTypes.instanceOf(Date),

--- a/packages/strapi-design-system/src/DatePicker/utils/getYears.js
+++ b/packages/strapi-design-system/src/DatePicker/utils/getYears.js
@@ -1,10 +1,19 @@
 /**
  * Hack method to retrieve the array of years
  */
-export const getYears = () => {
-  const currentYear = new Date().getFullYear();
 
-  return Array(101)
-    .fill(null)
-    .map((_, index) => currentYear - 50 + index);
+const DEFAULT_PAST_RANGE = 200;
+const DEFAULT_FUTURE_RANGE = 15;
+
+export const getYears = (minDate, maxDate) => {
+  const currentYear = new Date().getFullYear();
+  const startYear = minDate?.getFullYear() ?? parseInt(currentYear, 10) - DEFAULT_PAST_RANGE;
+  const endYear = maxDate?.getFullYear() ?? parseInt(currentYear, 10) + DEFAULT_FUTURE_RANGE;
+  const years = [];
+
+  for (let i = startYear; i <= endYear; i++) {
+    years.push(i);
+  }
+
+  return years;
 };

--- a/packages/strapi-design-system/src/DatePicker/utils/tests/getYears.spec.js
+++ b/packages/strapi-design-system/src/DatePicker/utils/tests/getYears.spec.js
@@ -1,11 +1,21 @@
 import { getYears } from '../getYears';
 
 describe('getYears', () => {
-  it('should retrieve an array of years from 1970 to 2070', () => {
-    jest.useFakeTimers('modern');
-    jest.setSystemTime(new Date(2020, 3, 1));
+  jest.useFakeTimers('modern');
+  jest.setSystemTime(new Date(2020, 3, 1));
+
+  it('should retrieve an array of years from 1820 to 2035', () => {
     const years = getYears();
-    expect(years[0]).toEqual(1970);
-    expect(years[years.length - 1]).toEqual(2070);
+    expect(years[0]).toEqual(1820);
+    expect(years[years.length - 1]).toEqual(2035);
+  });
+
+  it('should retrieve an array of years between min and max date', () => {
+    const minDate = new Date(2018, 1, 1);
+    const maxDate = new Date(2024, 1, 1);
+    const years = getYears(minDate, maxDate);
+
+    expect(years[0]).toEqual(2018);
+    expect(years[years.length - 1]).toEqual(2024);
   });
 });

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -11741,7 +11741,7 @@ exports[`Storyshots Design System/Components/DatePicker base 1`] = `
                 class="c8"
                 id="datepicker-45"
                 name="datepicker"
-                placeholder="1/1/1970"
+                placeholder="2/28/2022"
                 value=""
               />
             </div>
@@ -11974,7 +11974,7 @@ exports[`Storyshots Design System/Components/DatePicker disabled 1`] = `
                 class="c8"
                 id="datepicker-46"
                 name="datepicker"
-                placeholder="1/1/1970"
+                placeholder="2/28/2022"
                 value=""
               />
             </div>
@@ -11988,6 +11988,225 @@ exports[`Storyshots Design System/Components/DatePicker disabled 1`] = `
       <button>
         Button outside picker
       </button>
+    </div>
+  </div>
+</main>
+`;
+
+exports[`Storyshots Design System/Components/DatePicker min/ max date 1`] = `
+.c0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c2 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c6 {
+  padding-right: 8px;
+  padding-left: 12px;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c1 > * {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.c1 > * + * {
+  margin-top: 4px;
+}
+
+.c8 {
+  border: none;
+  border-radius: 4px;
+  padding-left: 0;
+  padding-right: 16px;
+  color: #32324d;
+  font-weight: 400;
+  font-size: 0.875rem;
+  display: block;
+  width: 100%;
+}
+
+.c8::-webkit-input-placeholder {
+  color: #8e8ea9;
+  opacity: 1;
+}
+
+.c8::-moz-placeholder {
+  color: #8e8ea9;
+  opacity: 1;
+}
+
+.c8:-ms-input-placeholder {
+  color: #8e8ea9;
+  opacity: 1;
+}
+
+.c8::placeholder {
+  color: #8e8ea9;
+  opacity: 1;
+}
+
+.c8[aria-disabled='true'] {
+  background: inherit;
+  color: inherit;
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: none;
+}
+
+.c5 {
+  border: 1px solid #dcdce4;
+  border-radius: 4px;
+  background: #ffffff;
+  height: 2.5rem;
+  outline: none;
+  box-shadow: 0;
+  -webkit-transition-property: border-color,box-shadow,fill;
+  transition-property: border-color,box-shadow,fill;
+  -webkit-transition-duration: 0.2s;
+  transition-duration: 0.2s;
+}
+
+.c5:focus-within {
+  border: 1px solid #4945ff;
+  box-shadow: #4945ff 0px 0px 0px 2px;
+}
+
+.c7 {
+  border: none;
+  background: transparent;
+  border-radius: 4px;
+}
+
+.c7 svg path {
+  fill: #8e8ea9;
+}
+
+<main>
+  <div
+    class="c0"
+  >
+    <h1>
+      Storybook story
+    </h1>
+  </div>
+  <div
+    class=""
+  >
+    <div>
+      <div>
+        <div
+          class="c1"
+        >
+          <label
+            class="c2"
+            for="datepicker-47"
+          >
+            <div
+              class="c3"
+            >
+              Date picker
+            </div>
+          </label>
+          <div
+            class="c4 c5"
+          >
+            <div
+              class="c6"
+            >
+              <button
+                aria-disabled="false"
+                aria-label="Date picker"
+                class="c7"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="none"
+                  height="1em"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M3.869 2.99V0h2.9v2.99h10.463V0h2.9v2.99h.629c2.768 0 3.203.498 3.239 2.926V21c0 2.124-.191 3-2.802 3H2.818C.208 24 0 23.363 0 20.785V6.21c.035-2.049.233-3.22 3.001-3.22h.868zM2.32 20.369c0 .811.245.865.776.865h17.905c.53 0 .68-.012.68-.825V8.233c-.015-.627-.219-.737-.631-.737H2.907c-.413 0-.592.09-.587.573v12.3z"
+                    fill="#212134"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </button>
+            </div>
+            <input
+              aria-autocomplete="none"
+              aria-disabled="false"
+              aria-invalid="false"
+              class="c8"
+              id="datepicker-47"
+              name="datepicker"
+              placeholder="2/28/2022"
+              value=""
+            />
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </main>
@@ -12158,7 +12377,7 @@ exports[`Storyshots Design System/Components/DatePicker size S 1`] = `
           >
             <label
               class="c2"
-              for="datepicker-47"
+              for="datepicker-48"
             >
               <div
                 class="c3"
@@ -12200,9 +12419,9 @@ exports[`Storyshots Design System/Components/DatePicker size S 1`] = `
                 aria-disabled="false"
                 aria-invalid="false"
                 class="c8"
-                id="datepicker-47"
+                id="datepicker-48"
                 name="datepicker"
-                placeholder="1/1/1970"
+                placeholder="2/28/2022"
                 value=""
               />
             </div>
@@ -13410,7 +13629,7 @@ exports[`Storyshots Design System/Components/Field base 1`] = `
     >
       <label
         class="c2"
-        for="field-49"
+        for="field-50"
       >
         <div
           class="c3"
@@ -13425,7 +13644,7 @@ exports[`Storyshots Design System/Components/Field base 1`] = `
           aria-disabled="false"
           aria-invalid="false"
           class="c6"
-          id="field-49"
+          id="field-50"
           name="email"
           placeholder="Placeholder"
           type="text"
@@ -13591,7 +13810,7 @@ exports[`Storyshots Design System/Components/Field disabled 1`] = `
     >
       <label
         class="c2"
-        for="field-50"
+        for="field-51"
       >
         <div
           class="c3"
@@ -13604,11 +13823,11 @@ exports[`Storyshots Design System/Components/Field disabled 1`] = `
         disabled=""
       >
         <input
-          aria-describedby="field-50-hint"
+          aria-describedby="field-51-hint"
           aria-disabled="true"
           aria-invalid="false"
           class="c6"
-          id="field-50"
+          id="field-51"
           name="password"
           placeholder="Placeholder"
           value="Hello world"
@@ -13616,7 +13835,7 @@ exports[`Storyshots Design System/Components/Field disabled 1`] = `
       </div>
       <p
         class="c7"
-        id="field-50-hint"
+        id="field-51-hint"
       >
         Description line
       </p>
@@ -13816,7 +14035,7 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
         >
           <label
             class="c4"
-            for="field-51"
+            for="field-52"
           >
             <div
               class="c3"
@@ -13829,7 +14048,7 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
           >
             <span>
               <button
-                aria-describedby="tooltip-52"
+                aria-describedby="tooltip-53"
                 aria-label="Information about the email"
                 style="padding: 0px; background: transparent;"
                 tabindex="0"
@@ -13888,11 +14107,11 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
             </button>
           </div>
           <input
-            aria-describedby="field-51-hint"
+            aria-describedby="field-52-hint"
             aria-disabled="false"
             aria-invalid="false"
             class="c10"
-            id="field-51"
+            id="field-52"
             name="password"
             placeholder="example@domain.com"
             value=""
@@ -13927,7 +14146,7 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
         </div>
         <p
           class="c12"
-          id="field-51-hint"
+          id="field-52-hint"
         >
           Description line
         </p>
@@ -14128,7 +14347,7 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
         >
           <label
             class="c4"
-            for="field-54"
+            for="field-55"
           >
             <div
               class="c3"
@@ -14141,7 +14360,7 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
           >
             <span>
               <button
-                aria-describedby="tooltip-55"
+                aria-describedby="tooltip-56"
                 aria-label="Information about the email"
                 style="padding: 0px; background: transparent;"
                 tabindex="0"
@@ -14200,11 +14419,11 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
             </button>
           </div>
           <input
-            aria-describedby="field-54-hint"
+            aria-describedby="field-55-hint"
             aria-disabled="false"
             aria-invalid="false"
             class="c10"
-            id="field-54"
+            id="field-55"
             name="password"
             placeholder="example@domain.com"
             value=""
@@ -14239,7 +14458,7 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
         </div>
         <p
           class="c12"
-          id="field-54-hint"
+          id="field-55-hint"
         >
           Description line
         </p>
@@ -14410,7 +14629,7 @@ exports[`Storyshots Design System/Components/Field with description 1`] = `
     >
       <label
         class="c2"
-        for="field-57"
+        for="field-58"
         required=""
       >
         <div
@@ -14428,11 +14647,11 @@ exports[`Storyshots Design System/Components/Field with description 1`] = `
         class="c6 c7"
       >
         <input
-          aria-describedby="field-57-hint"
+          aria-describedby="field-58-hint"
           aria-disabled="false"
           aria-invalid="false"
           class="c8"
-          id="field-57"
+          id="field-58"
           name="email"
           placeholder="Placeholder"
           type="text"
@@ -14441,7 +14660,7 @@ exports[`Storyshots Design System/Components/Field with description 1`] = `
       </div>
       <p
         class="c9"
-        id="field-57-hint"
+        id="field-58-hint"
       >
         Description line
       </p>
@@ -14601,7 +14820,7 @@ exports[`Storyshots Design System/Components/Field with error 1`] = `
     >
       <label
         class="c2"
-        for="field-58"
+        for="field-59"
       >
         <div
           class="c3"
@@ -14613,11 +14832,11 @@ exports[`Storyshots Design System/Components/Field with error 1`] = `
         class="c4 c5"
       >
         <input
-          aria-describedby="field-58-error"
+          aria-describedby="field-59-error"
           aria-disabled="false"
           aria-invalid="true"
           class="c6"
-          id="field-58"
+          id="field-59"
           name="password"
           placeholder="Placeholder"
           type="password"
@@ -14627,7 +14846,7 @@ exports[`Storyshots Design System/Components/Field with error 1`] = `
       <p
         class="c7"
         data-strapi-field-error="true"
-        id="field-58-error"
+        id="field-59-error"
       >
         Password is too short
       </p>
@@ -14803,7 +15022,7 @@ exports[`Storyshots Design System/Components/Field with label-action 1`] = `
     >
       <label
         class="c2"
-        for="field-59"
+        for="field-60"
         required=""
       >
         <div
@@ -14848,7 +15067,7 @@ exports[`Storyshots Design System/Components/Field with label-action 1`] = `
           aria-disabled="false"
           aria-invalid="false"
           class="c10"
-          id="field-59"
+          id="field-60"
           name="password"
           placeholder="Placeholder"
           type="password"
@@ -17004,7 +17223,7 @@ exports[`Storyshots Design System/Components/IconButton base 1`] = `
       <span>
         <button
           aria-disabled="false"
-          aria-labelledby="tooltip-60"
+          aria-labelledby="tooltip-61"
           class="c3 c4"
           tabindex="0"
           type="button"
@@ -17028,7 +17247,7 @@ exports[`Storyshots Design System/Components/IconButton base 1`] = `
       <span>
         <button
           aria-disabled="false"
-          aria-labelledby="tooltip-62"
+          aria-labelledby="tooltip-63"
           class="c3 c4"
           tabindex="0"
           type="button"
@@ -17050,7 +17269,7 @@ exports[`Storyshots Design System/Components/IconButton base 1`] = `
       <span>
         <button
           aria-disabled="false"
-          aria-labelledby="tooltip-64"
+          aria-labelledby="tooltip-65"
           class="c3 c4"
           tabindex="0"
           type="button"
@@ -17072,7 +17291,7 @@ exports[`Storyshots Design System/Components/IconButton base 1`] = `
       <span>
         <button
           aria-disabled="false"
-          aria-labelledby="tooltip-66"
+          aria-labelledby="tooltip-67"
           class="c3 c4"
           tabindex="0"
           type="button"
@@ -17242,7 +17461,7 @@ exports[`Storyshots Design System/Components/IconButton disabled 1`] = `
       <span>
         <button
           aria-disabled="true"
-          aria-labelledby="tooltip-68"
+          aria-labelledby="tooltip-69"
           class="c3 c4"
           tabindex="0"
           type="button"
@@ -17266,7 +17485,7 @@ exports[`Storyshots Design System/Components/IconButton disabled 1`] = `
       <span>
         <button
           aria-disabled="true"
-          aria-labelledby="tooltip-70"
+          aria-labelledby="tooltip-71"
           class="c3 c4"
           tabindex="0"
           type="button"
@@ -17288,7 +17507,7 @@ exports[`Storyshots Design System/Components/IconButton disabled 1`] = `
       <span>
         <button
           aria-disabled="true"
-          aria-labelledby="tooltip-72"
+          aria-labelledby="tooltip-73"
           class="c3 c4"
           tabindex="0"
           type="button"
@@ -17310,7 +17529,7 @@ exports[`Storyshots Design System/Components/IconButton disabled 1`] = `
       <span>
         <button
           aria-disabled="true"
-          aria-labelledby="tooltip-74"
+          aria-labelledby="tooltip-75"
           class="c3 c4"
           tabindex="0"
           type="button"
@@ -17518,7 +17737,7 @@ exports[`Storyshots Design System/Components/IconButton group 1`] = `
       <span>
         <button
           aria-disabled="false"
-          aria-labelledby="tooltip-76"
+          aria-labelledby="tooltip-77"
           class="c4 c5 c6"
           tabindex="0"
           type="button"
@@ -17542,7 +17761,7 @@ exports[`Storyshots Design System/Components/IconButton group 1`] = `
       <span>
         <button
           aria-disabled="false"
-          aria-labelledby="tooltip-78"
+          aria-labelledby="tooltip-79"
           class="c4 c5 c6"
           tabindex="0"
           type="button"
@@ -17564,7 +17783,7 @@ exports[`Storyshots Design System/Components/IconButton group 1`] = `
       <span>
         <button
           aria-disabled="false"
-          aria-labelledby="tooltip-80"
+          aria-labelledby="tooltip-81"
           class="c4 c5 c6"
           tabindex="0"
           type="button"
@@ -17586,7 +17805,7 @@ exports[`Storyshots Design System/Components/IconButton group 1`] = `
       <span>
         <button
           aria-disabled="false"
-          aria-labelledby="tooltip-82"
+          aria-labelledby="tooltip-83"
           class="c4 c5 c6"
           tabindex="0"
           type="button"
@@ -18821,7 +19040,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
             <span>
               <button
                 aria-disabled="false"
-                aria-labelledby="tooltip-85"
+                aria-labelledby="tooltip-86"
                 class="c9 c10"
                 tabindex="0"
                 type="button"
@@ -18868,7 +19087,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                     class="c1 c19"
                   >
                     <button
-                      aria-controls="subnav-list-87"
+                      aria-controls="subnav-list-88"
                       aria-expanded="true"
                       class="c1 c20 c21"
                     >
@@ -18913,7 +19132,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                   </div>
                 </div>
                 <ul
-                  id="subnav-list-87"
+                  id="subnav-list-88"
                 >
                   <li>
                     <a
@@ -19073,7 +19292,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                     class="c1 c19"
                   >
                     <button
-                      aria-controls="subnav-list-88"
+                      aria-controls="subnav-list-89"
                       aria-expanded="true"
                       class="c1 c20 c21"
                     >
@@ -19118,7 +19337,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                   </div>
                 </div>
                 <ul
-                  id="subnav-list-88"
+                  id="subnav-list-89"
                 >
                   <li>
                     <div
@@ -19131,7 +19350,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           class="c1 c19"
                         >
                           <button
-                            aria-controls="subnav-list-89"
+                            aria-controls="subnav-list-90"
                             aria-expanded="true"
                             class="c36"
                           >
@@ -19167,7 +19386,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                         </div>
                       </div>
                       <ul
-                        id="subnav-list-89"
+                        id="subnav-list-90"
                       >
                         <li>
                           <a
@@ -20595,7 +20814,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-90"
+                              aria-labelledby="tooltip-91"
                               class="c9 c10"
                               tabindex="-1"
                               type="button"
@@ -20622,7 +20841,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                             <span>
                               <button
                                 aria-disabled="false"
-                                aria-labelledby="tooltip-92"
+                                aria-labelledby="tooltip-93"
                                 class="c9 c10"
                                 tabindex="-1"
                                 type="button"
@@ -20766,7 +20985,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-94"
+                              aria-labelledby="tooltip-95"
                               class="c9 c10"
                               tabindex="-1"
                               type="button"
@@ -20793,7 +21012,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                             <span>
                               <button
                                 aria-disabled="false"
-                                aria-labelledby="tooltip-96"
+                                aria-labelledby="tooltip-97"
                                 class="c9 c10"
                                 tabindex="-1"
                                 type="button"
@@ -20937,7 +21156,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-98"
+                              aria-labelledby="tooltip-99"
                               class="c9 c10"
                               tabindex="-1"
                               type="button"
@@ -20964,7 +21183,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                             <span>
                               <button
                                 aria-disabled="false"
-                                aria-labelledby="tooltip-100"
+                                aria-labelledby="tooltip-101"
                                 class="c9 c10"
                                 tabindex="-1"
                                 type="button"
@@ -21108,7 +21327,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-102"
+                              aria-labelledby="tooltip-103"
                               class="c9 c10"
                               tabindex="-1"
                               type="button"
@@ -21135,7 +21354,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                             <span>
                               <button
                                 aria-disabled="false"
-                                aria-labelledby="tooltip-104"
+                                aria-labelledby="tooltip-105"
                                 class="c9 c10"
                                 tabindex="-1"
                                 type="button"
@@ -21279,7 +21498,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-106"
+                              aria-labelledby="tooltip-107"
                               class="c9 c10"
                               tabindex="-1"
                               type="button"
@@ -21306,7 +21525,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                             <span>
                               <button
                                 aria-disabled="false"
-                                aria-labelledby="tooltip-108"
+                                aria-labelledby="tooltip-109"
                                 class="c9 c10"
                                 tabindex="-1"
                                 type="button"
@@ -27345,7 +27564,7 @@ exports[`Storyshots Design System/Components/NumberInput base 1`] = `
       >
         <label
           class="c3"
-          for="numberinput-110"
+          for="numberinput-111"
         >
           <div
             class="c4"
@@ -27356,7 +27575,7 @@ exports[`Storyshots Design System/Components/NumberInput base 1`] = `
             >
               <span>
                 <button
-                  aria-describedby="tooltip-111"
+                  aria-describedby="tooltip-112"
                   aria-label="Information about the email"
                   style="padding: 0px; background: transparent;"
                   tabindex="0"
@@ -27383,11 +27602,11 @@ exports[`Storyshots Design System/Components/NumberInput base 1`] = `
           class="c7 c8"
         >
           <input
-            aria-describedby="numberinput-110-hint"
+            aria-describedby="numberinput-111-hint"
             aria-disabled="false"
             aria-invalid="false"
             class="c9"
-            id="numberinput-110"
+            id="numberinput-111"
             name="content"
             placeholder="This is a content placeholder"
             type="text"
@@ -27446,7 +27665,7 @@ exports[`Storyshots Design System/Components/NumberInput base 1`] = `
         </div>
         <p
           class="c15"
-          id="numberinput-110-hint"
+          id="numberinput-111-hint"
         >
           Description line
         </p>
@@ -27683,7 +27902,7 @@ exports[`Storyshots Design System/Components/NumberInput disabled 1`] = `
       >
         <label
           class="c3"
-          for="numberinput-113"
+          for="numberinput-114"
         >
           <div
             class="c4"
@@ -27696,11 +27915,11 @@ exports[`Storyshots Design System/Components/NumberInput disabled 1`] = `
           disabled=""
         >
           <input
-            aria-describedby="numberinput-113-hint"
+            aria-describedby="numberinput-114-hint"
             aria-disabled="true"
             aria-invalid="false"
             class="c7"
-            id="numberinput-113"
+            id="numberinput-114"
             name="content"
             placeholder="This is a content placeholder"
             type="text"
@@ -27761,7 +27980,7 @@ exports[`Storyshots Design System/Components/NumberInput disabled 1`] = `
         </div>
         <p
           class="c13"
-          id="numberinput-113-hint"
+          id="numberinput-114-hint"
         >
           Description line
         </p>
@@ -27995,7 +28214,7 @@ exports[`Storyshots Design System/Components/NumberInput required 1`] = `
       >
         <label
           class="c3"
-          for="numberinput-114"
+          for="numberinput-115"
           required=""
         >
           <div
@@ -28013,11 +28232,11 @@ exports[`Storyshots Design System/Components/NumberInput required 1`] = `
           class="c7 c8"
         >
           <input
-            aria-describedby="numberinput-114-hint"
+            aria-describedby="numberinput-115-hint"
             aria-disabled="false"
             aria-invalid="false"
             class="c9"
-            id="numberinput-114"
+            id="numberinput-115"
             name="content"
             placeholder="This is a content placeholder"
             type="text"
@@ -28076,7 +28295,7 @@ exports[`Storyshots Design System/Components/NumberInput required 1`] = `
         </div>
         <p
           class="c15"
-          id="numberinput-114-hint"
+          id="numberinput-115-hint"
         >
           Description line
         </p>
@@ -28317,7 +28536,7 @@ exports[`Storyshots Design System/Components/NumberInput size S 1`] = `
       >
         <label
           class="c3"
-          for="numberinput-115"
+          for="numberinput-116"
         >
           <div
             class="c4"
@@ -28328,7 +28547,7 @@ exports[`Storyshots Design System/Components/NumberInput size S 1`] = `
             >
               <span>
                 <button
-                  aria-describedby="tooltip-116"
+                  aria-describedby="tooltip-117"
                   aria-label="Information about the email"
                   style="padding: 0px; background: transparent;"
                   tabindex="0"
@@ -28355,11 +28574,11 @@ exports[`Storyshots Design System/Components/NumberInput size S 1`] = `
           class="c7 c8"
         >
           <input
-            aria-describedby="numberinput-115-hint"
+            aria-describedby="numberinput-116-hint"
             aria-disabled="false"
             aria-invalid="false"
             class="c9"
-            id="numberinput-115"
+            id="numberinput-116"
             name="content"
             placeholder="This is a content placeholder"
             type="text"
@@ -28418,7 +28637,7 @@ exports[`Storyshots Design System/Components/NumberInput size S 1`] = `
         </div>
         <p
           class="c15"
-          id="numberinput-115-hint"
+          id="numberinput-116-hint"
         >
           Description line
         </p>
@@ -28667,7 +28886,7 @@ exports[`Storyshots Design System/Components/NumberInput with initial 0 1`] = `
       >
         <label
           class="c3"
-          for="numberinput-118"
+          for="numberinput-119"
         >
           <div
             class="c4"
@@ -28678,7 +28897,7 @@ exports[`Storyshots Design System/Components/NumberInput with initial 0 1`] = `
             >
               <span>
                 <button
-                  aria-describedby="tooltip-119"
+                  aria-describedby="tooltip-120"
                   aria-label="Information about the email"
                   style="padding: 0px; background: transparent;"
                   tabindex="0"
@@ -28705,11 +28924,11 @@ exports[`Storyshots Design System/Components/NumberInput with initial 0 1`] = `
           class="c7 c8"
         >
           <input
-            aria-describedby="numberinput-118-hint"
+            aria-describedby="numberinput-119-hint"
             aria-disabled="false"
             aria-invalid="false"
             class="c9"
-            id="numberinput-118"
+            id="numberinput-119"
             name="content"
             placeholder="This is a content placeholder"
             type="text"
@@ -28768,7 +28987,7 @@ exports[`Storyshots Design System/Components/NumberInput with initial 0 1`] = `
         </div>
         <p
           class="c15"
-          id="numberinput-118-hint"
+          id="numberinput-119-hint"
         >
           Description line
         </p>
@@ -28986,12 +29205,12 @@ exports[`Storyshots Design System/Components/NumberInput withoutLabel 1`] = `
           class="c3 c4"
         >
           <input
-            aria-describedby="numberinput-121-hint"
+            aria-describedby="numberinput-122-hint"
             aria-disabled="false"
             aria-invalid="false"
             aria-label="Content"
             class="c5"
-            id="numberinput-121"
+            id="numberinput-122"
             name="content"
             placeholder="This is a content placeholder"
             type="text"
@@ -29050,7 +29269,7 @@ exports[`Storyshots Design System/Components/NumberInput withoutLabel 1`] = `
         </div>
         <p
           class="c11"
-          id="numberinput-121-hint"
+          id="numberinput-122-hint"
         >
           Description line
         </p>
@@ -29962,7 +30181,7 @@ exports[`Storyshots Design System/Components/Searchbar base 1`] = `
         >
           <label
             class="c2"
-            for="field-122"
+            for="field-123"
           >
             <div
               class="c3"
@@ -30001,7 +30220,7 @@ exports[`Storyshots Design System/Components/Searchbar base 1`] = `
             aria-disabled="false"
             aria-invalid="false"
             class="c10"
-            id="field-122"
+            id="field-123"
             name="searchbar"
             placeholder="e.g: strapi-plugin-abcd"
             value=""
@@ -30182,7 +30401,7 @@ exports[`Storyshots Design System/Components/Searchbar disabled 1`] = `
       >
         <label
           class="c2"
-          for="field-123"
+          for="field-124"
         >
           <div
             class="c3"
@@ -30222,7 +30441,7 @@ exports[`Storyshots Design System/Components/Searchbar disabled 1`] = `
           aria-disabled="true"
           aria-invalid="false"
           class="c10"
-          id="field-123"
+          id="field-124"
           name="searchbar"
           placeholder="e.g: strapi-plugin-abcd"
           value=""
@@ -30402,7 +30621,7 @@ exports[`Storyshots Design System/Components/Searchbar size S 1`] = `
         >
           <label
             class="c2"
-            for="field-124"
+            for="field-125"
           >
             <div
               class="c3"
@@ -30441,7 +30660,7 @@ exports[`Storyshots Design System/Components/Searchbar size S 1`] = `
             aria-disabled="false"
             aria-invalid="false"
             class="c10"
-            id="field-124"
+            id="field-125"
             name="searchbar"
             placeholder="e.g: strapi-plugin-abcd"
             value=""
@@ -32733,7 +32952,7 @@ exports[`Storyshots Design System/Components/SimpleMenu with-custom-label 1`] = 
   </div>
   <div>
     <button
-      aria-controls="simplemenu-125"
+      aria-controls="simplemenu-126"
       aria-disabled="false"
       aria-expanded="false"
       aria-haspopup="true"
@@ -32900,11 +33119,11 @@ exports[`Storyshots Design System/Components/SimpleMenu with-iconbutton 1`] = `
   <div>
     <span>
       <button
-        aria-controls="simplemenu-126"
+        aria-controls="simplemenu-127"
         aria-disabled="false"
         aria-expanded="false"
         aria-haspopup="true"
-        aria-labelledby="tooltip-127"
+        aria-labelledby="tooltip-128"
         class="c1 c2"
         tabindex="0"
         type="button"
@@ -33110,7 +33329,7 @@ exports[`Storyshots Design System/Components/SimpleMenu with-links 1`] = `
   </div>
   <div>
     <button
-      aria-controls="simplemenu-129"
+      aria-controls="simplemenu-130"
       aria-disabled="false"
       aria-expanded="false"
       aria-haspopup="true"
@@ -33882,7 +34101,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
             <span>
               <button
                 aria-disabled="false"
-                aria-labelledby="tooltip-131"
+                aria-labelledby="tooltip-132"
                 class="c8 c9"
                 tabindex="0"
                 type="button"
@@ -33929,7 +34148,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                     class="c18"
                   >
                     <button
-                      aria-controls="subnav-list-133"
+                      aria-controls="subnav-list-134"
                       aria-expanded="true"
                       class="c1 c19"
                     >
@@ -33974,7 +34193,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                   </div>
                 </div>
                 <ul
-                  id="subnav-list-133"
+                  id="subnav-list-134"
                 >
                   <li>
                     <a
@@ -34168,7 +34387,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                     class="c18"
                   >
                     <button
-                      aria-controls="subnav-list-134"
+                      aria-controls="subnav-list-135"
                       aria-expanded="true"
                       class="c1 c19"
                     >
@@ -34213,7 +34432,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                   </div>
                 </div>
                 <ul
-                  id="subnav-list-134"
+                  id="subnav-list-135"
                 >
                   <li>
                     <div
@@ -34226,7 +34445,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           class="c18"
                         >
                           <button
-                            aria-controls="subnav-list-135"
+                            aria-controls="subnav-list-136"
                             aria-expanded="true"
                             class="c38"
                           >
@@ -34262,7 +34481,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                         </div>
                       </div>
                       <ul
-                        id="subnav-list-135"
+                        id="subnav-list-136"
                       >
                         <li>
                           <a
@@ -34568,7 +34787,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                   </div>
                 </div>
                 <ul
-                  id="subnav-list-137"
+                  id="subnav-list-138"
                 >
                   <li>
                     <a
@@ -34675,7 +34894,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                   </div>
                 </div>
                 <ul
-                  id="subnav-list-138"
+                  id="subnav-list-139"
                 >
                   <li>
                     <a
@@ -34876,7 +35095,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                   </div>
                 </div>
                 <ul
-                  id="subnav-list-140"
+                  id="subnav-list-141"
                 >
                   <li>
                     <div
@@ -34889,7 +35108,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           class="c18"
                         >
                           <button
-                            aria-controls="subnav-list-141"
+                            aria-controls="subnav-list-142"
                             aria-expanded="true"
                             class="c38"
                           >
@@ -34925,7 +35144,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                         </div>
                       </div>
                       <ul
-                        id="subnav-list-141"
+                        id="subnav-list-142"
                       >
                         <li>
                           <a
@@ -35105,7 +35324,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                   </div>
                 </div>
                 <ul
-                  id="subnav-list-142"
+                  id="subnav-list-143"
                 >
                   <li>
                     <a
@@ -36140,7 +36359,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                     <span>
                       <button
                         aria-disabled="false"
-                        aria-labelledby="tooltip-143"
+                        aria-labelledby="tooltip-144"
                         class="c19 c20"
                         tabindex="-1"
                         type="button"
@@ -36167,7 +36386,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                       <span>
                         <button
                           aria-disabled="false"
-                          aria-labelledby="tooltip-145"
+                          aria-labelledby="tooltip-146"
                           class="c19 c20"
                           tabindex="-1"
                           type="button"
@@ -36278,7 +36497,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                     <span>
                       <button
                         aria-disabled="false"
-                        aria-labelledby="tooltip-147"
+                        aria-labelledby="tooltip-148"
                         class="c19 c20"
                         tabindex="-1"
                         type="button"
@@ -36305,7 +36524,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                       <span>
                         <button
                           aria-disabled="false"
-                          aria-labelledby="tooltip-149"
+                          aria-labelledby="tooltip-150"
                           class="c19 c20"
                           tabindex="-1"
                           type="button"
@@ -36416,7 +36635,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                     <span>
                       <button
                         aria-disabled="false"
-                        aria-labelledby="tooltip-151"
+                        aria-labelledby="tooltip-152"
                         class="c19 c20"
                         tabindex="-1"
                         type="button"
@@ -36443,7 +36662,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                       <span>
                         <button
                           aria-disabled="false"
-                          aria-labelledby="tooltip-153"
+                          aria-labelledby="tooltip-154"
                           class="c19 c20"
                           tabindex="-1"
                           type="button"
@@ -36554,7 +36773,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                     <span>
                       <button
                         aria-disabled="false"
-                        aria-labelledby="tooltip-155"
+                        aria-labelledby="tooltip-156"
                         class="c19 c20"
                         tabindex="-1"
                         type="button"
@@ -36581,7 +36800,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                       <span>
                         <button
                           aria-disabled="false"
-                          aria-labelledby="tooltip-157"
+                          aria-labelledby="tooltip-158"
                           class="c19 c20"
                           tabindex="-1"
                           type="button"
@@ -36692,7 +36911,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                     <span>
                       <button
                         aria-disabled="false"
-                        aria-labelledby="tooltip-159"
+                        aria-labelledby="tooltip-160"
                         class="c19 c20"
                         tabindex="-1"
                         type="button"
@@ -36719,7 +36938,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                       <span>
                         <button
                           aria-disabled="false"
-                          aria-labelledby="tooltip-161"
+                          aria-labelledby="tooltip-162"
                           class="c19 c20"
                           tabindex="-1"
                           type="button"
@@ -37362,7 +37581,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                     <span>
                       <button
                         aria-disabled="false"
-                        aria-labelledby="tooltip-163"
+                        aria-labelledby="tooltip-164"
                         class="c19 c20"
                         tabindex="-1"
                         type="button"
@@ -37389,7 +37608,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                       <span>
                         <button
                           aria-disabled="false"
-                          aria-labelledby="tooltip-165"
+                          aria-labelledby="tooltip-166"
                           class="c19 c20"
                           tabindex="-1"
                           type="button"
@@ -37500,7 +37719,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                     <span>
                       <button
                         aria-disabled="false"
-                        aria-labelledby="tooltip-167"
+                        aria-labelledby="tooltip-168"
                         class="c19 c20"
                         tabindex="-1"
                         type="button"
@@ -37527,7 +37746,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                       <span>
                         <button
                           aria-disabled="false"
-                          aria-labelledby="tooltip-169"
+                          aria-labelledby="tooltip-170"
                           class="c19 c20"
                           tabindex="-1"
                           type="button"
@@ -37638,7 +37857,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                     <span>
                       <button
                         aria-disabled="false"
-                        aria-labelledby="tooltip-171"
+                        aria-labelledby="tooltip-172"
                         class="c19 c20"
                         tabindex="-1"
                         type="button"
@@ -37665,7 +37884,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                       <span>
                         <button
                           aria-disabled="false"
-                          aria-labelledby="tooltip-173"
+                          aria-labelledby="tooltip-174"
                           class="c19 c20"
                           tabindex="-1"
                           type="button"
@@ -37776,7 +37995,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                     <span>
                       <button
                         aria-disabled="false"
-                        aria-labelledby="tooltip-175"
+                        aria-labelledby="tooltip-176"
                         class="c19 c20"
                         tabindex="-1"
                         type="button"
@@ -37803,7 +38022,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                       <span>
                         <button
                           aria-disabled="false"
-                          aria-labelledby="tooltip-177"
+                          aria-labelledby="tooltip-178"
                           class="c19 c20"
                           tabindex="-1"
                           type="button"
@@ -37914,7 +38133,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                     <span>
                       <button
                         aria-disabled="false"
-                        aria-labelledby="tooltip-179"
+                        aria-labelledby="tooltip-180"
                         class="c19 c20"
                         tabindex="-1"
                         type="button"
@@ -37941,7 +38160,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                       <span>
                         <button
                           aria-disabled="false"
-                          aria-labelledby="tooltip-181"
+                          aria-labelledby="tooltip-182"
                           class="c19 c20"
                           tabindex="-1"
                           type="button"
@@ -38426,7 +38645,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                       <span>
                         <button
                           aria-disabled="false"
-                          aria-labelledby="tooltip-183"
+                          aria-labelledby="tooltip-184"
                           class="c15 c16"
                           tabindex="-1"
                           type="button"
@@ -38633,7 +38852,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                     <span>
                       <button
                         aria-disabled="false"
-                        aria-labelledby="tooltip-185"
+                        aria-labelledby="tooltip-186"
                         class="c15 c16"
                         tabindex="-1"
                         type="button"
@@ -38660,7 +38879,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                       <span>
                         <button
                           aria-disabled="false"
-                          aria-labelledby="tooltip-187"
+                          aria-labelledby="tooltip-188"
                           class="c15 c16"
                           tabindex="-1"
                           type="button"
@@ -38771,7 +38990,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                     <span>
                       <button
                         aria-disabled="false"
-                        aria-labelledby="tooltip-189"
+                        aria-labelledby="tooltip-190"
                         class="c15 c16"
                         tabindex="-1"
                         type="button"
@@ -38798,7 +39017,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                       <span>
                         <button
                           aria-disabled="false"
-                          aria-labelledby="tooltip-191"
+                          aria-labelledby="tooltip-192"
                           class="c15 c16"
                           tabindex="-1"
                           type="button"
@@ -38909,7 +39128,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                     <span>
                       <button
                         aria-disabled="false"
-                        aria-labelledby="tooltip-193"
+                        aria-labelledby="tooltip-194"
                         class="c15 c16"
                         tabindex="-1"
                         type="button"
@@ -38936,7 +39155,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                       <span>
                         <button
                           aria-disabled="false"
-                          aria-labelledby="tooltip-195"
+                          aria-labelledby="tooltip-196"
                           class="c15 c16"
                           tabindex="-1"
                           type="button"
@@ -39047,7 +39266,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                     <span>
                       <button
                         aria-disabled="false"
-                        aria-labelledby="tooltip-197"
+                        aria-labelledby="tooltip-198"
                         class="c15 c16"
                         tabindex="-1"
                         type="button"
@@ -39074,7 +39293,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                       <span>
                         <button
                           aria-disabled="false"
-                          aria-labelledby="tooltip-199"
+                          aria-labelledby="tooltip-200"
                           class="c15 c16"
                           tabindex="-1"
                           type="button"
@@ -39185,7 +39404,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                     <span>
                       <button
                         aria-disabled="false"
-                        aria-labelledby="tooltip-201"
+                        aria-labelledby="tooltip-202"
                         class="c15 c16"
                         tabindex="-1"
                         type="button"
@@ -39212,7 +39431,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                       <span>
                         <button
                           aria-disabled="false"
-                          aria-labelledby="tooltip-203"
+                          aria-labelledby="tooltip-204"
                           class="c15 c16"
                           tabindex="-1"
                           type="button"
@@ -40617,7 +40836,7 @@ exports[`Storyshots Design System/Components/TextInput base 1`] = `
         >
           <label
             class="c3"
-            for="textinput-205"
+            for="textinput-206"
           >
             <div
               class="c4"
@@ -40628,7 +40847,7 @@ exports[`Storyshots Design System/Components/TextInput base 1`] = `
               >
                 <span>
                   <button
-                    aria-describedby="tooltip-206"
+                    aria-describedby="tooltip-207"
                     aria-label="Information about the email"
                     style="padding: 0px; background: transparent;"
                     tabindex="0"
@@ -40655,11 +40874,11 @@ exports[`Storyshots Design System/Components/TextInput base 1`] = `
             class="c7 c8"
           >
             <input
-              aria-describedby="textinput-205-hint"
+              aria-describedby="textinput-206-hint"
               aria-disabled="false"
               aria-invalid="false"
               class="c9"
-              id="textinput-205"
+              id="textinput-206"
               name="content"
               placeholder="This is a content placeholder"
               value=""
@@ -40667,7 +40886,7 @@ exports[`Storyshots Design System/Components/TextInput base 1`] = `
           </div>
           <p
             class="c10"
-            id="textinput-205-hint"
+            id="textinput-206-hint"
           >
             Description line
           </p>
@@ -40852,7 +41071,7 @@ exports[`Storyshots Design System/Components/TextInput disabled 1`] = `
         >
           <label
             class="c3"
-            for="textinput-208"
+            for="textinput-209"
           >
             <div
               class="c4"
@@ -40863,7 +41082,7 @@ exports[`Storyshots Design System/Components/TextInput disabled 1`] = `
               >
                 <span>
                   <button
-                    aria-describedby="tooltip-209"
+                    aria-describedby="tooltip-210"
                     aria-label="Information about the email"
                     style="padding: 0px; background: transparent;"
                     tabindex="0"
@@ -40891,11 +41110,11 @@ exports[`Storyshots Design System/Components/TextInput disabled 1`] = `
             disabled=""
           >
             <input
-              aria-describedby="textinput-208-hint"
+              aria-describedby="textinput-209-hint"
               aria-disabled="true"
               aria-invalid="false"
               class="c9"
-              id="textinput-208"
+              id="textinput-209"
               name="content"
               placeholder="This is a content placeholder"
               value="Disabled ontent"
@@ -40903,7 +41122,7 @@ exports[`Storyshots Design System/Components/TextInput disabled 1`] = `
           </div>
           <p
             class="c10"
-            id="textinput-208-hint"
+            id="textinput-209-hint"
           >
             Description line
           </p>
@@ -41085,7 +41304,7 @@ exports[`Storyshots Design System/Components/TextInput password 1`] = `
         >
           <label
             class="c3"
-            for="textinput-211"
+            for="textinput-212"
           >
             <div
               class="c4"
@@ -41096,7 +41315,7 @@ exports[`Storyshots Design System/Components/TextInput password 1`] = `
               >
                 <span>
                   <button
-                    aria-describedby="tooltip-212"
+                    aria-describedby="tooltip-213"
                     aria-label="Information about the email"
                     style="padding: 0px; background: transparent;"
                     tabindex="0"
@@ -41123,11 +41342,11 @@ exports[`Storyshots Design System/Components/TextInput password 1`] = `
             class="c7 c8"
           >
             <input
-              aria-describedby="textinput-211-hint"
+              aria-describedby="textinput-212-hint"
               aria-disabled="false"
               aria-invalid="false"
               class="c9"
-              id="textinput-211"
+              id="textinput-212"
               name="password"
               placeholder="This is a password placeholder"
               type="password"
@@ -41136,7 +41355,7 @@ exports[`Storyshots Design System/Components/TextInput password 1`] = `
           </div>
           <p
             class="c10"
-            id="textinput-211-hint"
+            id="textinput-212-hint"
           >
             Description line
           </p>
@@ -41318,7 +41537,7 @@ exports[`Storyshots Design System/Components/TextInput size S 1`] = `
         >
           <label
             class="c3"
-            for="textinput-214"
+            for="textinput-215"
           >
             <div
               class="c4"
@@ -41329,7 +41548,7 @@ exports[`Storyshots Design System/Components/TextInput size S 1`] = `
               >
                 <span>
                   <button
-                    aria-describedby="tooltip-215"
+                    aria-describedby="tooltip-216"
                     aria-label="Information about the email"
                     style="padding: 0px; background: transparent;"
                     tabindex="0"
@@ -41356,11 +41575,11 @@ exports[`Storyshots Design System/Components/TextInput size S 1`] = `
             class="c7 c8"
           >
             <input
-              aria-describedby="textinput-214-hint"
+              aria-describedby="textinput-215-hint"
               aria-disabled="false"
               aria-invalid="false"
               class="c9"
-              id="textinput-214"
+              id="textinput-215"
               name="content"
               placeholder="This is a content placeholder"
               value="size S input"
@@ -41368,7 +41587,7 @@ exports[`Storyshots Design System/Components/TextInput size S 1`] = `
           </div>
           <p
             class="c10"
-            id="textinput-214-hint"
+            id="textinput-215-hint"
           >
             Description line
           </p>
@@ -41550,7 +41769,7 @@ exports[`Storyshots Design System/Components/TextInput with error 1`] = `
         >
           <label
             class="c3"
-            for="textinput-217"
+            for="textinput-218"
           >
             <div
               class="c4"
@@ -41561,7 +41780,7 @@ exports[`Storyshots Design System/Components/TextInput with error 1`] = `
               >
                 <span>
                   <button
-                    aria-describedby="tooltip-218"
+                    aria-describedby="tooltip-219"
                     aria-label="Information about the email"
                     style="padding: 0px; background: transparent;"
                     tabindex="0"
@@ -41588,11 +41807,11 @@ exports[`Storyshots Design System/Components/TextInput with error 1`] = `
             class="c7 c8"
           >
             <input
-              aria-describedby="textinput-217-error"
+              aria-describedby="textinput-218-error"
               aria-disabled="false"
               aria-invalid="true"
               class="c9"
-              id="textinput-217"
+              id="textinput-218"
               name="content"
               placeholder="This is a content placeholder"
               value="content"
@@ -41601,7 +41820,7 @@ exports[`Storyshots Design System/Components/TextInput with error 1`] = `
           <p
             class="c10"
             data-strapi-field-error="true"
-            id="textinput-217-error"
+            id="textinput-218-error"
           >
             Content is too long
           </p>
@@ -41752,12 +41971,12 @@ exports[`Storyshots Design System/Components/TextInput withoutLabel 1`] = `
             class="c3 c4"
           >
             <input
-              aria-describedby="textinput-220-hint"
+              aria-describedby="textinput-221-hint"
               aria-disabled="false"
               aria-invalid="false"
               aria-label="Password"
               class="c5"
-              id="textinput-220"
+              id="textinput-221"
               name="password"
               placeholder="This is a password placeholder"
               type="password"
@@ -41766,7 +41985,7 @@ exports[`Storyshots Design System/Components/TextInput withoutLabel 1`] = `
           </div>
           <p
             class="c6"
-            id="textinput-220-hint"
+            id="textinput-221-hint"
           >
             Description line
           </p>
@@ -41967,7 +42186,7 @@ exports[`Storyshots Design System/Components/Textarea base 1`] = `
           >
             <label
               class="c5"
-              for="textarea-221"
+              for="textarea-222"
             >
               <div
                 class="c4"
@@ -41978,7 +42197,7 @@ exports[`Storyshots Design System/Components/Textarea base 1`] = `
                 >
                   <span>
                     <button
-                      aria-describedby="tooltip-222"
+                      aria-describedby="tooltip-223"
                       aria-label="Information about the email"
                       style="padding: 0px; background: transparent;"
                       tabindex="0"
@@ -42006,10 +42225,10 @@ exports[`Storyshots Design System/Components/Textarea base 1`] = `
             class="c8"
           >
             <textarea
-              aria-describedby="textarea-221-error"
+              aria-describedby="textarea-222-error"
               aria-invalid="true"
               class="c9"
-              id="textarea-221"
+              id="textarea-222"
               name="content"
               placeholder="This is a content placeholder"
             />
@@ -42017,7 +42236,7 @@ exports[`Storyshots Design System/Components/Textarea base 1`] = `
           <p
             class="c10"
             data-strapi-field-error="true"
-            id="textarea-221-error"
+            id="textarea-222-error"
           >
             Content is too short
           </p>
@@ -42218,7 +42437,7 @@ exports[`Storyshots Design System/Components/Textarea disabled 1`] = `
           >
             <label
               class="c5"
-              for="textarea-224"
+              for="textarea-225"
             >
               <div
                 class="c4"
@@ -42229,7 +42448,7 @@ exports[`Storyshots Design System/Components/Textarea disabled 1`] = `
                 >
                   <span>
                     <button
-                      aria-describedby="tooltip-225"
+                      aria-describedby="tooltip-226"
                       aria-label="Information about the email"
                       style="padding: 0px; background: transparent;"
                       tabindex="0"
@@ -42258,18 +42477,18 @@ exports[`Storyshots Design System/Components/Textarea disabled 1`] = `
             disabled=""
           >
             <textarea
-              aria-describedby="textarea-224-hint"
+              aria-describedby="textarea-225-hint"
               aria-invalid="false"
               class="c9"
               disabled=""
-              id="textarea-224"
+              id="textarea-225"
               name="content"
               placeholder="This is a content placeholder"
             />
           </div>
           <p
             class="c10"
-            id="textarea-224-hint"
+            id="textarea-225-hint"
           >
             Description line
           </p>
@@ -44622,7 +44841,7 @@ exports[`Storyshots Design System/Components/ToggleInput base 1`] = `
       >
         <label
           class="c4"
-          for="toggleinput-227"
+          for="toggleinput-228"
         >
           <div
             class="c3"
@@ -44633,7 +44852,7 @@ exports[`Storyshots Design System/Components/ToggleInput base 1`] = `
             >
               <span>
                 <button
-                  aria-describedby="tooltip-228"
+                  aria-describedby="tooltip-229"
                   aria-label="Information about the email"
                   style="padding: 0px; background: transparent;"
                   tabindex="0"
@@ -44692,7 +44911,7 @@ exports[`Storyshots Design System/Components/ToggleInput base 1`] = `
             aria-disabled="false"
             checked=""
             class="c15"
-            id="toggleinput-227"
+            id="toggleinput-228"
             name="enable-provider"
             type="checkbox"
           />
@@ -44700,7 +44919,7 @@ exports[`Storyshots Design System/Components/ToggleInput base 1`] = `
       </label>
       <p
         class="c16"
-        id="toggleinput-227-hint"
+        id="toggleinput-228-hint"
       >
         Enable provider
       </p>
@@ -44863,7 +45082,7 @@ exports[`Storyshots Design System/Components/ToggleInput error 1`] = `
       >
         <label
           class="c4"
-          for="toggleinput-230"
+          for="toggleinput-231"
         >
           <div
             class="c3"
@@ -44906,7 +45125,7 @@ exports[`Storyshots Design System/Components/ToggleInput error 1`] = `
           <input
             aria-disabled="false"
             class="c13"
-            id="toggleinput-230"
+            id="toggleinput-231"
             name="enable-provider"
             type="checkbox"
           />
@@ -44915,7 +45134,7 @@ exports[`Storyshots Design System/Components/ToggleInput error 1`] = `
       <p
         class="c14"
         data-strapi-field-error="true"
-        id="toggleinput-230-error"
+        id="toggleinput-231-error"
       >
         this field is required
       </p>
@@ -45072,7 +45291,7 @@ exports[`Storyshots Design System/Components/ToggleInput null-value 1`] = `
       >
         <label
           class="c4"
-          for="toggleinput-231"
+          for="toggleinput-232"
         >
           <div
             class="c3"
@@ -45115,7 +45334,7 @@ exports[`Storyshots Design System/Components/ToggleInput null-value 1`] = `
           <input
             aria-disabled="false"
             class="c12"
-            id="toggleinput-231"
+            id="toggleinput-232"
             name="enable-provider"
             type="checkbox"
           />
@@ -45123,7 +45342,7 @@ exports[`Storyshots Design System/Components/ToggleInput null-value 1`] = `
       </label>
       <p
         class="c13"
-        id="toggleinput-231-hint"
+        id="toggleinput-232-hint"
       >
         Enable provider
       </p>
@@ -45286,7 +45505,7 @@ exports[`Storyshots Design System/Components/ToggleInput size S 1`] = `
       >
         <label
           class="c4"
-          for="toggleinput-232"
+          for="toggleinput-233"
         >
           <div
             class="c3"
@@ -45329,7 +45548,7 @@ exports[`Storyshots Design System/Components/ToggleInput size S 1`] = `
           <input
             aria-disabled="false"
             class="c13"
-            id="toggleinput-232"
+            id="toggleinput-233"
             name="enable-provider"
             type="checkbox"
           />
@@ -45338,7 +45557,7 @@ exports[`Storyshots Design System/Components/ToggleInput size S 1`] = `
       <p
         class="c14"
         data-strapi-field-error="true"
-        id="toggleinput-232-error"
+        id="toggleinput-233-error"
       >
         this field is required
       </p>
@@ -45374,7 +45593,7 @@ exports[`Storyshots Design System/Components/Tooltip base 1`] = `
     </p>
     <span>
       <span
-        aria-describedby="tooltip-233"
+        aria-describedby="tooltip-234"
         tabindex="0"
       >
         Show tooltip
@@ -45446,7 +45665,7 @@ exports[`Storyshots Design System/Components/Tooltip grid 1`] = `
       >
         <span>
           <button
-            aria-describedby="tooltip-235"
+            aria-describedby="tooltip-236"
             tabindex="0"
           >
             Default tooltip
@@ -45462,7 +45681,7 @@ exports[`Storyshots Design System/Components/Tooltip grid 1`] = `
       >
         <span>
           <button
-            aria-describedby="tooltip-237"
+            aria-describedby="tooltip-238"
             tabindex="0"
           >
             Bottom
@@ -45478,7 +45697,7 @@ exports[`Storyshots Design System/Components/Tooltip grid 1`] = `
       >
         <span>
           <button
-            aria-describedby="tooltip-239"
+            aria-describedby="tooltip-240"
             tabindex="0"
           >
             Right
@@ -45494,7 +45713,7 @@ exports[`Storyshots Design System/Components/Tooltip grid 1`] = `
       >
         <span>
           <button
-            aria-describedby="tooltip-241"
+            aria-describedby="tooltip-242"
             tabindex="0"
           >
             Left
@@ -45530,7 +45749,7 @@ exports[`Storyshots Design System/Components/Tooltip with text inside 1`] = `
   <div>
     <span>
       <span
-        aria-describedby="tooltip-243"
+        aria-describedby="tooltip-244"
         tabindex="0"
       >
         Show tooltip
@@ -45540,7 +45759,7 @@ exports[`Storyshots Design System/Components/Tooltip with text inside 1`] = `
   <div>
     <span>
       <button
-        aria-describedby="tooltip-245"
+        aria-describedby="tooltip-246"
         tabindex="0"
       >
         A longer CTA with longer content


### PR DESCRIPTION
This PR adds two new props the the `DatePicker` component:

- `minDate`: minimum date which is used by the year select
- `maxDate`: maximum date which is used by the year select

It also extends the default range of the `DatePicker` component to minus 200 years and plus 15 years and replaces the default placeholder with the current date instead of 1970.

💡 I didn't name the prop `minYear` or `maxYear` because these could also be used at some point to validate the input for a max/ min value.

## Demo

- https://design-system-git-content-132-min-max-date-strapijs.vercel.app/?path=/story/design-system-components-datepicker--min-max-date

Refs: https://github.com/strapi/strapi/issues/12441
Refs: https://strapi-inc.atlassian.net/browse/CONTENT-132