### PR TITLE
Loader: add small usage to docs, use theme spaces

### DIFF
--- a/packages/strapi-design-system/src/Loader/Loader.js
+++ b/packages/strapi-design-system/src/Loader/Loader.js
@@ -15,7 +15,7 @@ const rotation = keyframes`
 
 const LoaderImg = styled.img`
   animation: ${rotation} 1s infinite linear;
-  ${({ small }) => small && `width: 25px; height: 25px;`}
+  ${({ small, theme }) => small && `width: ${theme.spaces[6]}; height: ${theme.spaces[6]};`}
 `;
 
 export const Loader = forwardRef(({ children, small, ...props }, ref) => {

--- a/packages/strapi-design-system/src/Loader/Loader.stories.mdx
+++ b/packages/strapi-design-system/src/Loader/Loader.stories.mdx
@@ -37,6 +37,16 @@ Loaders shows an action has been processed. Moreover, details about what is happ
   </Story>
 </Canvas>
 
+### Small
+
+A loader can receive a `small` prop, which renders the component much smaller.
+
+<Canvas>
+  <Story name="small">
+    <Loader small>Loading content...</Loader>
+  </Story>
+</Canvas>
+
 ## Props
 
 <ArgsTable of={Loader} />

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -25342,6 +25342,52 @@ exports[`Storyshots Design System/Components/Loader base 1`] = `
 </main>
 `;
 
+exports[`Storyshots Design System/Components/Loader small 1`] = `
+.c0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c1 {
+  -webkit-animation: gzYjWD 1s infinite linear;
+  animation: gzYjWD 1s infinite linear;
+  width: 24px;
+  height: 24px;
+}
+
+<main>
+  <div
+    class="c0"
+  >
+    <h1>
+      Storybook story
+    </h1>
+  </div>
+  <div
+    aria-live="assertive"
+    role="alert"
+  >
+    <div
+      class="c0"
+    >
+      Loading content...
+    </div>
+    <img
+      aria-hidden="true"
+      class="c1"
+      src="test-file-stub"
+    />
+  </div>
+</main>
+`;
+
 exports[`Storyshots Design System/Components/MainNav base 1`] = `
 .c0 {
   border: 0;


### PR DESCRIPTION
This PR adds documentation on how to use the `small` prop and a preview how it will look like. It also removes the hard coded `25px` and replaces it with a design-system constant, which will result in `24px`.

