### PR TITLE
DatePicker: allow passing in a placeholder, to fix a flaky test

### DIFF
--- a/packages/strapi-design-system/src/DatePicker/DatePicker.js
+++ b/packages/strapi-design-system/src/DatePicker/DatePicker.js
@@ -22,6 +22,7 @@ export const DatePicker = ({
   disabled,
   minDate,
   maxDate,
+  placeholder,
   id,
   ...props
 }) => {
@@ -30,7 +31,6 @@ export const DatePicker = ({
   const inputRef = useRef(null);
   const datePickerButtonRef = useRef(null);
   const formattedDate = selectedDate ? formatDate(selectedDate) : '';
-  const placeholder = formatDate(new Date());
 
   const toggleVisibility = () => {
     if (disabled) return;
@@ -57,7 +57,7 @@ export const DatePicker = ({
         // Prevent input from changing for now
         onChange={() => {}}
         value={formattedDate}
-        placeholder={placeholder}
+        placeholder={placeholder || formatDate(new Date(1970, 0, 1))}
         size={size}
         startAction={
           <DatePickerButton
@@ -108,6 +108,7 @@ DatePicker.defaultProps = {
   label: undefined,
   initialDate: new Date(),
   onClear: undefined,
+  placeholder: undefined,
   selectedDate: undefined,
   size: 'M',
 };
@@ -123,6 +124,7 @@ DatePicker.propTypes = {
   minDate: PropTypes.instanceOf(Date),
   onChange: PropTypes.func.isRequired,
   onClear: PropTypes.func,
+  placeholder: PropTypes.string,
   selectedDate: PropTypes.instanceOf(Date),
   selectedDateLabel: PropTypes.func.isRequired,
   size: PropTypes.oneOf(Object.keys(sizes.input)),

--- a/packages/strapi-design-system/src/DatePicker/DatePicker.stories.mdx
+++ b/packages/strapi-design-system/src/DatePicker/DatePicker.stories.mdx
@@ -125,6 +125,7 @@ By passing in `minDate` or `maxDate` it is possible to define the range of years
           name="datepicker"
           clearLabel={'Clear the datepicker'}
           onClear={() => setDate(undefined)}
+          placeholder="03/01/1970"
           selectedDateLabel={(formattedDate) => `Date picker, current is ${formattedDate}`}
           minDate={new Date(2000, 1, 1)}
           maxDate={new Date(2040, 1, 1)}

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -11741,7 +11741,7 @@ exports[`Storyshots Design System/Components/DatePicker base 1`] = `
                 class="c8"
                 id="datepicker-45"
                 name="datepicker"
-                placeholder="3/1/2022"
+                placeholder="1/1/1970"
                 value=""
               />
             </div>
@@ -11974,7 +11974,7 @@ exports[`Storyshots Design System/Components/DatePicker disabled 1`] = `
                 class="c8"
                 id="datepicker-46"
                 name="datepicker"
-                placeholder="3/1/2022"
+                placeholder="1/1/1970"
                 value=""
               />
             </div>
@@ -12201,7 +12201,7 @@ exports[`Storyshots Design System/Components/DatePicker min/ max date 1`] = `
               class="c8"
               id="datepicker-47"
               name="datepicker"
-              placeholder="3/1/2022"
+              placeholder="03/01/1970"
               value=""
             />
           </div>
@@ -12421,7 +12421,7 @@ exports[`Storyshots Design System/Components/DatePicker size S 1`] = `
                 class="c8"
                 id="datepicker-48"
                 name="datepicker"
-                placeholder="3/1/2022"
+                placeholder="1/1/1970"
                 value=""
               />
             </div>


### PR DESCRIPTION
Restores behavior from before https://github.com/strapi/design-system/pull/554, but allows to pass in a placeholder attribute manually.