### PR TITLE
DatePicker: fix onSelect event

### DIFF
--- a/packages/strapi-design-system/src/DatePicker/DatePicker.js
+++ b/packages/strapi-design-system/src/DatePicker/DatePicker.js
@@ -49,6 +49,10 @@ export const DatePicker = ({
     setVisible(false);
   };
 
+  const handleEscape = () => {
+    setVisible(false);
+  };
+
   return (
     <DatePickerWrapper bold={visible}>
       <TextInput
@@ -90,6 +94,7 @@ export const DatePicker = ({
           selectedDate={selectedDate}
           initialDate={initialDate}
           onChange={handleChange}
+          onEscape={handleEscape}
           popoverSource={inputRef.current.inputWrapperRef}
           label={label || ariaLabel}
           minDate={minDate}

--- a/packages/strapi-design-system/src/DatePicker/DatePickerCalendar.js
+++ b/packages/strapi-design-system/src/DatePicker/DatePickerCalendar.js
@@ -11,7 +11,16 @@ import { DatePickerTd } from './DatePickerTd';
 import { FocusTrap } from '../FocusTrap';
 import { getMonths, getDayOfWeek, generateWeeks, getYears, formatDate } from './utils';
 
-export const DatePickerCalendar = ({ selectedDate, initialDate, popoverSource, onChange, label, minDate, maxDate }) => {
+export const DatePickerCalendar = ({
+  selectedDate,
+  initialDate,
+  popoverSource,
+  onChange,
+  label,
+  minDate,
+  maxDate,
+  onEscape,
+}) => {
   const [date, setDate] = useState(initialDate);
   const [weeks, activeRow, activeCol] = generateWeeks(date, selectedDate);
   const { sun, mon, tue, wed, thu, fri, sat } = getDayOfWeek();
@@ -38,7 +47,7 @@ export const DatePickerCalendar = ({ selectedDate, initialDate, popoverSource, o
 
   return (
     <DatePickerPopover source={popoverSource} role="dialog" aria-modal="true" aria-label={label} spacing={4}>
-      <FocusTrap onEscape={() => setVisible(false)}>
+      <FocusTrap onEscape={onEscape}>
         <Box padding={4}>
           <Box paddingBottom={4} paddingLeft={2} paddingRight={2}>
             <Flex>
@@ -117,6 +126,7 @@ DatePickerCalendar.propTypes = {
 
   minDate: PropTypes.instanceOf(Date),
   onChange: PropTypes.func.isRequired,
+  onEscape: PropTypes.func.isRequired,
   popoverSource: PropTypes.shape({ current: PropTypes.instanceOf(Element) }).isRequired,
   selectedDate: PropTypes.instanceOf(Date),
 };


### PR DESCRIPTION
Fixes the `onEscape` callback of the `DatePickerCalendar` component. Before, it wasn't possible (anymore) to escape the focus trap.

https://user-images.githubusercontent.com/2244375/156546491-0136f981-bb76-41aa-94f1-966f60f1fc35.mp4

Demo: https://design-system-git-fix-datepicker-escape-strapijs.vercel.app/?path=/story/design-system-components-datepicker--base

