### PR TITLE
ToggleInput: stop forwarding onClear to ToggleCheckbox

### DIFF
--- a/packages/strapi-design-system/src/ToggleCheckbox/ToggleCheckbox.js
+++ b/packages/strapi-design-system/src/ToggleCheckbox/ToggleCheckbox.js
@@ -130,7 +130,6 @@ ToggleCheckbox.defaultProps = {
   disabled: false,
   checked: false,
   onChange: undefined,
-  onClear: undefined,
   size: 'M',
 };
 
@@ -140,7 +139,6 @@ ToggleCheckbox.propTypes = {
   disabled: PropTypes.bool,
   offLabel: PropTypes.string.isRequired,
   onChange: PropTypes.func,
-  onClear: PropTypes.func,
   onLabel: PropTypes.string.isRequired,
   size: PropTypes.oneOf(Object.keys(sizes.input)),
 };

--- a/packages/strapi-design-system/src/ToggleInput/ToggleInput.js
+++ b/packages/strapi-design-system/src/ToggleInput/ToggleInput.js
@@ -43,7 +43,7 @@ export const ToggleInput = ({
           </FieldLabel>
           {clearLabel && onClear && checked !== null && <ClearButton onClick={onClear}>{clearLabel}</ClearButton>}
         </Flex>
-        <ToggleCheckbox id={generatedId} size={size} name={name} onClear={onClear} checked={checked} {...props}>
+        <ToggleCheckbox id={generatedId} size={size} name={name} checked={checked} {...props}>
           {label}
         </ToggleCheckbox>
         <FieldHint />


### PR DESCRIPTION
In https://github.com/strapi/design-system/pull/538 I accidentally forwarded the `onClear` prop to `ToggleCheckbox` which is not handled nor needed there.

Refs: https://github.com/strapi/strapi/pull/12791