### PR TITLE
FolderCard: create new component

### DIFF
--- a/packages/strapi-design-system/src/BaseLink/BaseLink.js
+++ b/packages/strapi-design-system/src/BaseLink/BaseLink.js
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 const A = styled.a`
   cursor: pointer;
+  text-decoration: ${({ textDecoration }) => textDecoration || 'underline'};
 `;
 
 export const BaseLink = React.forwardRef(({ href, rel, target, disabled, isExternal, ...props }, ref) => {

--- a/packages/strapi-design-system/src/FolderCard/FolderCard.js
+++ b/packages/strapi-design-system/src/FolderCard/FolderCard.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+import { BaseLink } from '../BaseLink';
+import { FolderCardContext } from './FolderCardContext';
+import Folder from '@strapi/icons/Folder';
+import { Box } from '../Box';
+import { Stack } from '../Stack';
+import { useId } from '../helpers/useId';
+
+const LinkWrapper = styled(BaseLink)`
+  height: 100%;
+  left: 0;
+  position: absolute;
+  opacity: 0;
+  top: 0;
+  width: 100%;
+
+  &:hover,
+  &:focus {
+    text-decoration: none;
+  }
+`;
+
+const StyledFolder = styled(Folder)`
+  path {
+    fill: currentColor;
+  }
+`;
+
+export const FolderCard = ({ children, id, startAction, ariaLabel, href, ...props }) => {
+  const generatedId = useId('folder-card', id);
+
+  return (
+    <FolderCardContext.Provider value={{ id: generatedId }}>
+      <Box position="relative" {...props}>
+        <LinkWrapper
+          href={href}
+          textDecoration="none"
+          onClick={(event) => event.preventDefault()}
+          onDoubleClick={() => console.log('navigate to?', href)}
+          zIndex={1}
+          tabIndex={-1}
+          aria-label={ariaLabel}
+          aria-hidden
+        />
+
+        <Stack
+          hasRadius
+          background="neutral0"
+          shadow="tableShadow"
+          paddingBottom={3}
+          paddingLeft={4}
+          paddingRight={4}
+          paddingTop={3}
+          spacing={3}
+          horizontal
+          cursor="pointer"
+        >
+          {startAction}
+
+          <Box
+            hasRadius
+            background="secondary100"
+            color="secondary500"
+            paddingBottom={2}
+            paddingLeft={3}
+            paddingRight={3}
+            paddingTop={2}
+          >
+            <StyledFolder />
+          </Box>
+
+          {children}
+        </Stack>
+      </Box>
+    </FolderCardContext.Provider>
+  );
+};
+
+FolderCard.displayName = 'FolderCard';
+
+FolderCard.defaultProps = {
+  id: undefined,
+  startAction: undefined,
+};
+
+FolderCard.propTypes = {
+  ariaLabel: PropTypes.string.isRequired,
+  children: PropTypes.node,
+  href: PropTypes.string.isRequired,
+  id: PropTypes.string,
+  startAction: PropTypes.element.isRequired,
+};

--- a/packages/strapi-design-system/src/FolderCard/FolderCard.stories.mdx
+++ b/packages/strapi-design-system/src/FolderCard/FolderCard.stories.mdx
@@ -1,0 +1,62 @@
+<!--- FolderCard.stories.mdx --->
+
+import { useState } from 'react';
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
+import { ArgsTable } from '@storybook/addon-docs';
+import Pencil from '@strapi/icons/Pencil';
+import { BaseLink } from '../BaseLink';
+import { Flex } from '../Flex';
+import { Stack } from '../Stack';
+import { FolderCard } from './FolderCard';
+import { FolderCardBody } from './FolderCardBody';
+import { FolderCardCheckbox } from './FolderCardCheckbox';
+import { Typography } from '../Typography';
+import { VisuallyHidden } from '../VisuallyHidden';
+
+<Meta title="Design System/Components/FolderCard" component={FolderCard} />
+
+# FolderCard
+
+tbd
+
+## Imports
+
+```js
+import {
+  FolderCard,
+} from '@strapi/design-system/FolderCard';
+```
+
+## Usage
+
+tbd
+
+<Canvas>
+  <Story name="base">
+    {() => {
+        const [checked, setChecked] = useState(false);
+        const href = "https://strapi.io";
+        return (
+            <FolderCard style={{ width: '310px' }} id="card-one" href={href} startAction={<FolderCardCheckbox value={checked} onValueChange={setChecked} />} ariaLabel="Pictures">
+                <FolderCardBody as="h2">
+                    <BaseLink href={href} textDecoration="none">
+                        <Flex direction="column" alignItems="flex-start">
+                            <Typography variant="omega" fontWeight="semiBold">
+                                Pictures
+                                <VisuallyHidden>:</VisuallyHidden>
+                            </Typography>
+                            <Typography variant="pi" textColor="neutral600">
+                                7 folders, 16 assets
+                            </Typography>
+                        </Flex>
+                    </BaseLink>
+                </FolderCardBody>
+            </FolderCard>
+        )
+    }}
+  </Story>
+</Canvas>
+
+## Props
+
+<ArgsTable of={FolderCard} />

--- a/packages/strapi-design-system/src/FolderCard/FolderCardAction.js
+++ b/packages/strapi-design-system/src/FolderCard/FolderCardAction.js
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+import { Stack } from '../Stack';
+
+export const FolderCardAction = styled(Stack).attrs({
+  horizontal: true,
+  spacing: 2,
+})`
+  position: absolute;
+  top: ${({ theme }) => theme.spaces[3]};
+  right: ${({ position, theme }) => (position === 'end' ? theme.spaces[3] : undefined)};
+  left: ${({ position, theme }) => (position === 'start' ? theme.spaces[3] : undefined)};
+`;

--- a/packages/strapi-design-system/src/FolderCard/FolderCardBody.js
+++ b/packages/strapi-design-system/src/FolderCard/FolderCardBody.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { Flex } from '../Flex';
+
+const StyledBox = styled(Flex)`
+  user-select: none;
+`;
+
+export const FolderCardBody = (props) => {
+  return <StyledBox {...props} alignItems="flex-start" direction="column" position="relative" zIndex={3} />;
+};

--- a/packages/strapi-design-system/src/FolderCard/FolderCardCheckbox.js
+++ b/packages/strapi-design-system/src/FolderCard/FolderCardCheckbox.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Box } from '../Box';
+import { BaseCheckbox } from '../BaseCheckbox';
+import { useFolderCard } from './FolderCardContext';
+
+export const FolderCardCheckbox = (props) => {
+  const { id } = useFolderCard();
+
+  return (
+    <Box position="relative" zIndex={2}>
+      <BaseCheckbox aria-labelledby={`${id}-title`} {...props} />
+    </Box>
+  );
+};

--- a/packages/strapi-design-system/src/FolderCard/FolderCardContext.js
+++ b/packages/strapi-design-system/src/FolderCard/FolderCardContext.js
@@ -1,0 +1,5 @@
+import { createContext, useContext } from 'react';
+
+export const FolderCardContext = createContext();
+
+export const useFolderCard = () => useContext(FolderCardContext);

--- a/packages/strapi-design-system/src/FolderCard/__tests__/FolderCard.e2e.js
+++ b/packages/strapi-design-system/src/FolderCard/__tests__/FolderCard.e2e.js
@@ -1,0 +1,13 @@
+const { injectAxe, checkA11y } = require('axe-playwright');
+
+const { test } = require('@playwright/test');
+
+test.describe('FolderCard', () => {
+  test.describe('base', () => {
+    test('triggers axe on the document', async ({ page }) => {
+      await page.goto('/iframe.html?id=design-system-components-foldercard--base&viewMode=story');
+      await injectAxe(page);
+      await checkA11y(page);
+    });
+  });
+});

--- a/packages/strapi-design-system/src/FolderCard/index.js
+++ b/packages/strapi-design-system/src/FolderCard/index.js
@@ -1,0 +1,4 @@
+export * from './FolderCard';
+export * from './FolderCardAction';
+export * from './FolderCardBody';
+export * from './FolderCardCheckbox';


### PR DESCRIPTION
## Description

This PR adds a new component called `FolderCard` which should look like the following:

<img width="666" alt="Screenshot 2022-03-09 at 16 13 16" src="https://user-images.githubusercontent.com/2244375/157470482-cdf7c0f6-01c6-4401-94a0-91e296f2f841.png">

ℹ️ Why `FolderCard` instead of `Folder`? I found `Folder` ambiguous and too generic. Also, the component will most certainly appear in the context of other `Card` components, which are often called `ImageCard`, `AssetCard` ...

### Behavior

- on double click on the whole area, it should navigate to a given target
- on single click on the folder name, it should navigate to the given target

### TODO:

- [ ] Do we have a way to programmatically call `navigate()` on double click? Could we pass it in from `react-router-dom`? https://reactrouter.com/docs/en/v6/api#usenavigate
- [ ] Is there an easier way to style the `FolderIcon`?
- [ ] Does the naming work?

Figma: https://www.figma.com/file/doUJzYdMJTjpgtw6Lyaa7D/%5B%E2%9C%85Done%5D-Content-squad---Media-folders?node-id=671%3A4833

## Demo

- https://design-system-git-feat-ml-folder-strapijs.vercel.app/?path=/story/design-system-components-foldercard--base