### PR TITLE
Icon Component: Add width and height

### DIFF
--- a/packages/strapi-design-system/src/Icon/Icon.js
+++ b/packages/strapi-design-system/src/Icon/Icon.js
@@ -4,6 +4,9 @@ import { Box } from '../Box';
 import styled from 'styled-components';
 
 const IconWrapper = styled(Box)`
+  width: ${({ theme, width }) => theme.spaces[width]};
+  height: ${({ theme, height }) => theme.spaces[height]};
+
   path {
     fill: ${({ color, theme }) => theme.colors[color]};
   }
@@ -19,9 +22,13 @@ Icon.displayName = 'Icon';
 Icon.defaultProps = {
   color: 'neutral600',
   colors: () => undefined,
+  height: 1,
+  width: 1,
 };
 
 Icon.propTypes = {
   color: PropTypes.string,
   colors: PropTypes.func,
+  height: PropTypes.number,
+  width: PropTypes.number,
 };


### PR DESCRIPTION
# Add width and height to Icon Component

## Description
Use theme spaces instead of just CSS for width and height. 

## Demo
Example on: 
 
## API
```jsx
<Icon width={6} height={6} color="danger500" as={Trash} />
```