### PR TITLE
ToggleCheckbox: improve disabled state styles and show default value

### DIFF
--- a/packages/strapi-design-system/src/ToggleCheckbox/ToggleCheckbox.js
+++ b/packages/strapi-design-system/src/ToggleCheckbox/ToggleCheckbox.js
@@ -25,10 +25,9 @@ const ToggleCheckboxWrapper = styled(Box)`
 const ValueBox = styled(Flex).attrs({
   hasRadius: true,
 })`
-  background-color: ${({ theme, disabled, checked }) => (checked && !disabled ? theme.colors.neutral0 : 'transparent')};
+  background-color: ${({ theme, checked }) => (checked ? theme.colors.neutral0 : 'transparent')};
   border: 1px solid
-    ${({ theme, disabled, checked }) =>
-      checked && checked !== null && !disabled ? theme.colors.neutral200 : theme.colors.neutral100};
+    ${({ theme, checked }) => (checked && checked !== null ? theme.colors.neutral200 : theme.colors.neutral100)};
   position: relative;
   user-select: none;
   z-index: 2;
@@ -76,35 +75,23 @@ export const ToggleCheckbox = React.forwardRef(
           borderWidth="1px"
           borderColor="neutral200"
         >
-          <ValueBox
-            paddingLeft={7}
-            paddingRight={7}
-            aria-hidden={true}
-            checked={checked === null ? false : !checked}
-            disabled={disabled}
-          >
+          <ValueBox paddingLeft={7} paddingRight={7} aria-hidden={true} checked={checked === null ? false : !checked}>
             <Typography
               variant="pi"
               fontWeight="bold"
               textTransform="uppercase"
-              textColor={disabled ? 'neutral600' : offCheckboxLabelColor}
+              textColor={disabled ? 'neutral500' : offCheckboxLabelColor}
             >
               {offLabel}
             </Typography>
           </ValueBox>
 
-          <ValueBox
-            paddingLeft={7}
-            paddingRight={7}
-            aria-hidden={true}
-            checked={checked === null ? false : checked}
-            disabled={disabled}
-          >
+          <ValueBox paddingLeft={7} paddingRight={7} aria-hidden={true} checked={checked === null ? false : checked}>
             <Typography
               variant="pi"
               fontWeight="bold"
               textTransform="uppercase"
-              textColor={disabled ? 'neutral600' : onCheckboxLabelColor}
+              textColor={disabled ? 'neutral500' : onCheckboxLabelColor}
             >
               {onLabel}
             </Typography>

--- a/packages/strapi-design-system/src/ToggleCheckbox/ToggleCheckbox.js
+++ b/packages/strapi-design-system/src/ToggleCheckbox/ToggleCheckbox.js
@@ -25,9 +25,21 @@ const ToggleCheckboxWrapper = styled(Box)`
 const ValueBox = styled(Flex).attrs({
   hasRadius: true,
 })`
-  background-color: ${({ theme, checked }) => (checked ? theme.colors.neutral0 : 'transparent')};
+  background-color: ${({ theme, checked, disabled }) => {
+    if (checked) {
+      return disabled ? theme.colors.neutral200 : theme.colors.neutral0;
+    }
+
+    return 'transparent';
+  }};
   border: 1px solid
-    ${({ theme, checked }) => (checked && checked !== null ? theme.colors.neutral200 : theme.colors.neutral100)};
+    ${({ theme, checked, disabled }) => {
+      if (checked && checked !== null) {
+        return disabled ? theme.colors.neutral300 : theme.colors.neutral200;
+      }
+
+      return disabled ? theme.colors.neutral150 : theme.colors.neutral100;
+    }};
   position: relative;
   user-select: none;
   z-index: 2;
@@ -64,34 +76,45 @@ export const ToggleCheckbox = React.forwardRef(
         <VisuallyHidden>{children}</VisuallyHidden>
 
         <ToggleCheckboxWrapper
-          background="neutral100"
           hasRadius
           size={size}
           disabled={disabled}
           padding={1}
           display="inline-flex"
-          backgroundColor="neutral100"
+          background={disabled ? 'neutral150' : 'neutral100'}
           borderStyle="solid"
           borderWidth="1px"
           borderColor="neutral200"
         >
-          <ValueBox paddingLeft={7} paddingRight={7} aria-hidden={true} checked={checked === null ? false : !checked}>
+          <ValueBox
+            paddingLeft={7}
+            paddingRight={7}
+            aria-hidden={true}
+            checked={checked === null ? false : !checked}
+            disabled={disabled}
+          >
             <Typography
               variant="pi"
               fontWeight="bold"
               textTransform="uppercase"
-              textColor={disabled ? 'neutral500' : offCheckboxLabelColor}
+              textColor={disabled ? 'neutral700' : offCheckboxLabelColor}
             >
               {offLabel}
             </Typography>
           </ValueBox>
 
-          <ValueBox paddingLeft={7} paddingRight={7} aria-hidden={true} checked={checked === null ? false : checked}>
+          <ValueBox
+            paddingLeft={7}
+            paddingRight={7}
+            aria-hidden={true}
+            checked={checked === null ? false : checked}
+            disabled={disabled}
+          >
             <Typography
               variant="pi"
               fontWeight="bold"
               textTransform="uppercase"
-              textColor={disabled ? 'neutral500' : onCheckboxLabelColor}
+              textColor={disabled ? 'neutral700' : onCheckboxLabelColor}
             >
               {onLabel}
             </Typography>

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -47827,7 +47827,7 @@ exports[`Storyshots Design System/Components/ToggleCheckbox disabled 1`] = `
 
 .c9 {
   font-weight: 600;
-  color: #666687;
+  color: #8e8ea9;
   text-transform: uppercase;
   font-size: 0.75rem;
   line-height: 1.33;
@@ -47881,6 +47881,17 @@ exports[`Storyshots Design System/Components/ToggleCheckbox disabled 1`] = `
 }
 
 .c10 {
+  background-color: #ffffff;
+  border: 1px solid #dcdce4;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  z-index: 2;
+}
+
+.c11 {
   height: 100%;
   left: 0;
   opacity: 0;
@@ -47921,7 +47932,6 @@ exports[`Storyshots Design System/Components/ToggleCheckbox disabled 1`] = `
           <div
             aria-hidden="true"
             class="c6 c7 c8"
-            disabled=""
           >
             <span
               class="c9"
@@ -47931,8 +47941,7 @@ exports[`Storyshots Design System/Components/ToggleCheckbox disabled 1`] = `
           </div>
           <div
             aria-hidden="true"
-            class="c6 c7 c8"
-            disabled=""
+            class="c6 c7 c10"
           >
             <span
               class="c9"
@@ -47943,7 +47952,7 @@ exports[`Storyshots Design System/Components/ToggleCheckbox disabled 1`] = `
           <input
             aria-disabled="true"
             checked=""
-            class="c10"
+            class="c11"
             type="checkbox"
           />
         </div>

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -47807,7 +47807,7 @@ exports[`Storyshots Design System/Components/ToggleCheckbox disabled 1`] = `
 }
 
 .c4 {
-  background: #f6f6f9;
+  background: #eaeaef;
   padding: 4px;
   border-radius: 4px;
   border-style: solid;
@@ -47827,7 +47827,7 @@ exports[`Storyshots Design System/Components/ToggleCheckbox disabled 1`] = `
 
 .c9 {
   font-weight: 600;
-  color: #8e8ea9;
+  color: #4a4a6a;
   text-transform: uppercase;
   font-size: 0.75rem;
   line-height: 1.33;
@@ -47871,7 +47871,7 @@ exports[`Storyshots Design System/Components/ToggleCheckbox disabled 1`] = `
 
 .c8 {
   background-color: transparent;
-  border: 1px solid #f6f6f9;
+  border: 1px solid #eaeaef;
   position: relative;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -47881,8 +47881,8 @@ exports[`Storyshots Design System/Components/ToggleCheckbox disabled 1`] = `
 }
 
 .c10 {
-  background-color: #ffffff;
-  border: 1px solid #dcdce4;
+  background-color: #dcdce4;
+  border: 1px solid #c0c0cf;
   position: relative;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -47932,6 +47932,7 @@ exports[`Storyshots Design System/Components/ToggleCheckbox disabled 1`] = `
           <div
             aria-hidden="true"
             class="c6 c7 c8"
+            disabled=""
           >
             <span
               class="c9"
@@ -47942,6 +47943,7 @@ exports[`Storyshots Design System/Components/ToggleCheckbox disabled 1`] = `
           <div
             aria-hidden="true"
             class="c6 c7 c10"
+            disabled=""
           >
             <span
               class="c9"


### PR DESCRIPTION
With the latest refactoring in https://github.com/strapi/design-system/pull/538 it is not possible anymore:


- to visually distinguish the disabled `ToggleCheckbox`: this PR lightens the styles, in this case, a bit (contrast is still accessible)
- to show the default value, if the component is disabled: I didn't think about this case - this PR restores the previous behavior

---

- Fixes https://github.com/strapi/design-system/issues/584
- Example https://design-system-git-fix-toggle-disabled-strapijs.vercel.app/?path=/story/design-system-components-togglecheckbox--disabled