### PR TITLE
[Logo customization] Logo dimensions contained

### DIFF
--- a/packages/strapi-design-system/src/MainNav/NavBrand.js
+++ b/packages/strapi-design-system/src/MainNav/NavBrand.js
@@ -9,9 +9,10 @@ import { useMainNav } from './MainNavContext';
 import { VisuallyHidden } from '../VisuallyHidden';
 
 const BrandIconWrapper = styled.div`
-  border-radius: ${({ theme }) => theme.borderRadius};
   svg,
   img {
+    border-radius: ${({ theme }) => theme.borderRadius};
+    object-fit: contain;
     height: ${({ condensed }) => (condensed ? `${40 / 16}rem` : `${32 / 16}rem`)};
     width: ${({ condensed }) => (condensed ? `${40 / 16}rem` : `${32 / 16}rem`)};
   }

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -26272,12 +26272,10 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
   border-top: 1px solid #eaeaef;
 }
 
-.c7 {
-  border-radius: 4px;
-}
-
 .c7 svg,
 .c7 img {
+  border-radius: 4px;
+  object-fit: contain;
   height: 2rem;
   width: 2rem;
 }
@@ -27124,12 +27122,10 @@ exports[`Storyshots Design System/Components/MainNav notifications 1`] = `
   border-top: 1px solid #eaeaef;
 }
 
-.c7 {
-  border-radius: 4px;
-}
-
 .c7 svg,
 .c7 img {
+  border-radius: 4px;
+  object-fit: contain;
   height: 2rem;
   width: 2rem;
 }


### PR DESCRIPTION
## What

Updated BrandIconWrapper inside NavBrand component to allow other image format than squared one
Prevent image being stretched
Radius will only be applied on squared images

## Snapshot

<img width="278" alt="Screenshot 2022-04-08 at 14 18 53" src="https://user-images.githubusercontent.com/71838159/162436148-6049752c-f08d-4407-bc8c-f0f23a8a1bfe.png">
<img width="271" alt="Screenshot 2022-04-08 at 14 19 16" src="https://user-images.githubusercontent.com/71838159/162436150-81e7c0b0-f5b9-4950-9545-71fddd83592b.png">
<img width="282" alt="Screenshot 2022-04-08 at 14 19 35" src="https://user-images.githubusercontent.com/71838159/162436153-07867d91-1acf-4257-b3e1-2db497ec4280.png">
<img width="275" alt="Screenshot 2022-04-08 at 14 19 49" src="https://user-images.githubusercontent.com/71838159/162436156-1609c278-7d6f-4529-8085-2ee0a06c8c38.png">
<img width="262" alt="Screenshot 2022-04-08 at 14 18 34" src="https://user-images.githubusercontent.com/71838159/162436145-4bab003e-fec4-4931-8c4d-0f3e4f803993.png">

