### PR TITLE
Fixes radio button not being checked when mounting radio group with a value passed in

### DIFF
--- a/packages/strapi-design-system/src/BaseRadio/BaseRadio.js
+++ b/packages/strapi-design-system/src/BaseRadio/BaseRadio.js
@@ -48,6 +48,7 @@ export const BaseRadio = React.forwardRef(({ value, disabled, ...props }, ref) =
       value={value}
       tabIndex={isSelected ? 0 : -1}
       aria-checked={isSelected}
+      checked={isSelected}
       disabled={disabled}
       size={size}
       onChange={onChange}

--- a/packages/strapi-design-system/src/Radio/__tests__/Radio.spec.js
+++ b/packages/strapi-design-system/src/Radio/__tests__/Radio.spec.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { RadioGroup, Radio } from '../';
+import { ThemeProvider } from '../../ThemeProvider';
+import { lightTheme } from '../../themes';
+
+describe('Radio/RadioGroup', () => {
+  it('selects a Radio button when a value is passed in to RadioGroup', () => {
+    const onChangeMock = jest.fn();
+    const { getByRole } = render(
+      <ThemeProvider theme={lightTheme}>
+        <p id="food">Food choices</p>
+        <RadioGroup labelledBy="food" onChange={onChangeMock} value="pizza" name="meal">
+          <Radio value="pizza">Pizza</Radio>
+          <Radio value="bagel">Bagel</Radio>
+        </RadioGroup>
+      </ThemeProvider>,
+    );
+
+    expect(getByRole('radio', { name: 'Bagel' })).not.toBeChecked();
+    expect(getByRole('radio', { name: 'Pizza' })).toBeChecked();
+  });
+
+  it('keeps all radio buttons unselected when value passed into RadioGroup is empty', () => {
+    const onChangeMock = jest.fn();
+    const { getByRole } = render(
+      <ThemeProvider theme={lightTheme}>
+        <p id="food">Food choices</p>
+        <RadioGroup labelledBy="food" onChange={onChangeMock} value="" name="meal">
+          <Radio value="pizza">Pizza</Radio>
+          <Radio value="bagel">Bagel</Radio>
+        </RadioGroup>
+      </ThemeProvider>,
+    );
+
+    expect(getByRole('radio', { name: 'Bagel' })).not.toBeChecked();
+    expect(getByRole('radio', { name: 'Pizza' })).not.toBeChecked();
+  });
+
+  it('calls onChange prop when Radio button is clicked', () => {
+    const onChangeMock = jest.fn();
+    const { getByRole } = render(
+      <ThemeProvider theme={lightTheme}>
+        <p id="food">Food choices</p>
+        <RadioGroup labelledBy="food" onChange={onChangeMock} value="" name="meal">
+          <Radio value="pizza">Pizza</Radio>
+          <Radio value="bagel">Bagel</Radio>
+        </RadioGroup>
+      </ThemeProvider>,
+    );
+
+    fireEvent.click(getByRole('radio', { name: 'Pizza' }));
+
+    expect(onChangeMock.mock.calls[0][0].target.value).toBe('pizza');
+  });
+});

--- a/packages/strapi-design-system/yarn.lock
+++ b/packages/strapi-design-system/yarn.lock
@@ -1954,7 +1954,7 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@playwright/test@^1.20.0":
+"@playwright/test@1.20.0":
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.20.0.tgz#df5b1b45976d11c365e6cb60f8ec1ca7cccb84cf"
   integrity sha512-UpI5HTcgNLckR0kqXqwNvbcIXtRaDxk+hnO0OBwPSjfbBjRfRgAJ2ClA/b30C5E3UW5dJa17zhsy2qrk66l5cg==


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Fixes #607 
passes `checked` prop to `RadioInput` component in `BaseRadio.js`

### Why is it needed?

To fix implementation of `RadioGroup`/`Radio`

### How to test it?

Tested by automation tests

### Related issue(s)/PR(s)

#607 
