### PR TITLE
Fix simple menu click and fix some stories props

### DIFF
--- a/packages/strapi-design-system/src/Box/BoxProps.js
+++ b/packages/strapi-design-system/src/Box/BoxProps.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const BoxProps = (props) => <div {...props} />;
+export const BoxProps = (props) => <div {...props} />;
 
 export const boxDefaultProps = {
   background: undefined,

--- a/packages/strapi-design-system/src/Flex/FlexProps.js
+++ b/packages/strapi-design-system/src/Flex/FlexProps.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const FlexProps = (props) => <div {...props} />;
+export const FlexProps = (props) => <div {...props} />;
 
 export const flexDefaultProps = {
   alignItems: 'center',

--- a/packages/strapi-design-system/src/Portal/Portal.stories.mdx
+++ b/packages/strapi-design-system/src/Portal/Portal.stories.mdx
@@ -2,6 +2,7 @@
 
 import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { Portal } from './Portal';
+import { Typography } from '../Typography';
 
 <Meta title="Design System/Technical Components/Portal" component={Portal} />
 
@@ -24,7 +25,9 @@ Creates a portal using a Declarative API
 <Canvas>
   <Story name="base">
     <Portal>
-      <aside>This is outside the root react app</aside>
+      <aside>
+        <Typography>This is rendered outside the root react app</Typography>
+      </aside>
     </Portal>
   </Story>
 </Canvas>

--- a/packages/strapi-design-system/src/SimpleMenu/SimpleMenu.js
+++ b/packages/strapi-design-system/src/SimpleMenu/SimpleMenu.js
@@ -170,7 +170,8 @@ export const SimpleMenu = ({
     }
   };
 
-  const handleMenuButtonMouseDown = () => {
+  const handleMenuButtonMouseDown = (e) => {
+    e.preventDefault();
     setVisible((prevVisible) => !prevVisible);
   };
 

--- a/packages/strapi-design-system/src/Typography/TypographyProps.js
+++ b/packages/strapi-design-system/src/Typography/TypographyProps.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { TEXT_VARIANTS, OMEGA } from './constants';
 
-const TypographyProps = (props) => <div {...props} />;
+export const TypographyProps = (props) => <div {...props} />;
 
 export const typographyDefaultProps = {
   fontWeight: undefined,

--- a/packages/strapi-design-system/src/v2/SimpleMenu/SimpleMenu.js
+++ b/packages/strapi-design-system/src/v2/SimpleMenu/SimpleMenu.js
@@ -170,7 +170,8 @@ export const SimpleMenu = ({
     }
   };
 
-  const handleMenuButtonMouseDown = () => {
+  const handleMenuButtonMouseDown = (e) => {
+    e.preventDefault();
     setVisible((prevVisible) => !prevVisible);
   };
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Prevent default on mouse down event of the SimpleMenu component.

### Why is it needed?

Prevent a bug on React 18.

### How to test it?

Should work the same way
