### PR TITLE
fix(theme): use Typography to avoid color issue while switching theme

### DIFF
--- a/packages/strapi-design-system/src/themes/Theme.stories.mdx
+++ b/packages/strapi-design-system/src/themes/Theme.stories.mdx
@@ -41,7 +41,7 @@ This is the light colors used for the light mode
           colors.push([]);
           ruptureKey = prefix;
         }
-        colors[colors.length - 1].push({ colorKey, colorValue: color[colorKey]});
+        colors[colors.length - 1].push({ colorKey, colorValue: color[colorKey] });
       }
       return (
         <Box>
@@ -50,10 +50,7 @@ This is the light colors used for the light mode
               <GridItem key={`color-group-${idx}`} padding={4}>
                 <Stack spacing={2}>
                   {colorGroup.map(({ colorKey, colorValue }) => (
-                    <div 
-                      key={colorKey}
-                      style={{ padding: '12px', background: colorValue }}
-                    >
+                    <div key={colorKey} style={{ padding: '12px', background: colorValue }}>
                       <p style={{ color: conditions.some((v) => colorKey.includes(v)) ? 'white' : 'black' }}>
                         {colorKey}
                       </p>
@@ -88,7 +85,7 @@ This is the dark colors used for the light mode
           colors.push([]);
           ruptureKey = prefix;
         }
-        colors[colors.length - 1].push({ colorKey, colorValue: color[colorKey]});
+        colors[colors.length - 1].push({ colorKey, colorValue: color[colorKey] });
       }
       return (
         <Box>
@@ -97,10 +94,7 @@ This is the dark colors used for the light mode
               <GridItem key={`color-group-${idx}`} padding={4}>
                 <Stack spacing={2}>
                   {colorGroup.map(({ colorKey, colorValue }) => (
-                    <div 
-                      key={colorKey}
-                      style={{ padding: '12px', background: colorValue }}
-                    >
+                    <div key={colorKey} style={{ padding: '12px', background: colorValue }}>
                       <p style={{ color: conditions.some((v) => colorKey.includes(v)) ? 'black' : 'white' }}>
                         {colorKey}
                       </p>
@@ -130,7 +124,7 @@ Description...
           <Grid gap={4}>
             {shadows.map((shadow) => (
               <GridItem padding={8} shadow={shadow} background="neutral0" col={3} key={shadow}>
-                {shadow}
+                <Typography>{shadow}</Typography>
               </GridItem>
             ))}
           </Grid>

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -45606,22 +45606,28 @@ exports[`Storyshots Design System/Components/Theme shadows 1`] = `
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
 }
 
-.c7 {
+.c8 {
   background: #ffffff;
   padding: 40px;
   box-shadow: inset 2px 0px 0px rgb(39,31,224),inset 0px 2px 0px rgb(39,31,224),inset -2px 0px 0px rgb(39,31,224),inset 0px -2px 0px rgb(39,31,224);
 }
 
-.c8 {
+.c9 {
   background: #ffffff;
   padding: 40px;
   box-shadow: 0px 0px 6px rgba(76,191,255,0.75);
 }
 
-.c9 {
+.c10 {
   background: #ffffff;
   padding: 40px;
   box-shadow: 0px 2px 15px rgba(33,33,52,0.1);
+}
+
+.c7 {
+  color: #32324d;
+  font-size: 0.875rem;
+  line-height: 1.43;
 }
 
 .c4 {
@@ -45674,16 +45680,11 @@ exports[`Storyshots Design System/Components/Theme shadows 1`] = `
             <div
               class="c6"
             >
-              filterShadow
-            </div>
-          </div>
-          <div
-            class="c5"
-          >
-            <div
-              class="c7"
-            >
-              focus
+              <span
+                class="c7"
+              >
+                filterShadow
+              </span>
             </div>
           </div>
           <div
@@ -45692,7 +45693,11 @@ exports[`Storyshots Design System/Components/Theme shadows 1`] = `
             <div
               class="c8"
             >
-              focusShadow
+              <span
+                class="c7"
+              >
+                focus
+              </span>
             </div>
           </div>
           <div
@@ -45701,7 +45706,24 @@ exports[`Storyshots Design System/Components/Theme shadows 1`] = `
             <div
               class="c9"
             >
-              popupShadow
+              <span
+                class="c7"
+              >
+                focusShadow
+              </span>
+            </div>
+          </div>
+          <div
+            class="c5"
+          >
+            <div
+              class="c10"
+            >
+              <span
+                class="c7"
+              >
+                popupShadow
+              </span>
             </div>
           </div>
           <div
@@ -45710,7 +45732,11 @@ exports[`Storyshots Design System/Components/Theme shadows 1`] = `
             <div
               class="c6"
             >
-              tableShadow
+              <span
+                class="c7"
+              >
+                tableShadow
+              </span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

This PR replaces regular text with the Typography component in Theme stories. It fixes the dark text color on a dark background while switching between the Storybook themes.

### Why is it needed?

The text is almost impossible to read right now.

![Zrzut ekranu 2022-05-26 o 14 20 44](https://user-images.githubusercontent.com/23500678/170486655-76005a11-3c29-46b4-a237-d77550c6af38.png)


### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

-
