### PR TITLE
Fixing @strapi/icons peer dependency in design system

### DIFF
--- a/packages/strapi-design-system/package.json
+++ b/packages/strapi-design-system/package.json
@@ -41,7 +41,7 @@
     "webpack-cli": "^4.5.0"
   },
   "peerDependencies": {
-    "@strapi/icons": "^0.0.1-alpha.73",
+    "@strapi/icons": "^1.1.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",


### PR DESCRIPTION


Strapi design system requires an alpha version of strapi. This change just fixes that

Describe the technical changes you did.

Updated version for @strapi/icons to 1.1.1 in @strapi/design-system

### Why is it needed?
To keep dependencies accurate and explicit

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
