### PR TITLE
ModalBody: Decrease horizontal paddings

### DIFF
--- a/packages/strapi-design-system/src/ModalLayout/ModalBody.js
+++ b/packages/strapi-design-system/src/ModalLayout/ModalBody.js
@@ -8,5 +8,5 @@ const ModalBodyWrapper = styled(Box)`
 `;
 
 export const ModalBody = (props) => {
-  return <ModalBodyWrapper paddingTop={6} paddingBottom={6} paddingLeft={8} paddingRight={8} {...props} />;
+  return <ModalBodyWrapper padding={7} {...props} />;
 };

--- a/packages/strapi-design-system/src/ModalLayout/__tests__/ModalLayout.spec.js
+++ b/packages/strapi-design-system/src/ModalLayout/__tests__/ModalLayout.spec.js
@@ -64,10 +64,7 @@ describe('ModalLayout', () => {
       }
 
       .c10 {
-        padding-top: 24px;
-        padding-right: 40px;
-        padding-bottom: 24px;
-        padding-left: 40px;
+        padding: 32px;
       }
 
       .c8 {


### PR DESCRIPTION
### What does it do?

During the tests for media library folders Maeva discovered the paddings of all modals should look different.

Refs: https://github.com/strapi/strapi/pull/13499

### Why is it needed?

Consistent and beautiful styles.

