### PR TITLE
[CONTENT-233] Card component border

### DIFF
--- a/packages/strapi-design-system/src/Card/Card.js
+++ b/packages/strapi-design-system/src/Card/Card.js
@@ -14,6 +14,9 @@ export const Card = ({ id, ...props }) => {
         tabIndex={0}
         hasRadius
         background="neutral0"
+        borderStyle="solid"
+        borderWidth="1px"
+        borderColor="neutral150"
         shadow="tableShadow"
         as="article"
         aria-labelledby={`${generatedId}-title`}

--- a/packages/strapi-design-system/src/Card/CardAsset.js
+++ b/packages/strapi-design-system/src/Card/CardAsset.js
@@ -26,6 +26,8 @@ const CardAssetWrapper = styled.div`
   width: 100%;
   background: repeating-conic-gradient(${({ theme }) => theme.colors.neutral100} 0% 25%, transparent 0% 50%) 50% / 20px
     20px;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
 `;
 
 export const CardAsset = ({ size, children, ...props }) => {

--- a/packages/strapi-design-system/src/Card/CardAsset.js
+++ b/packages/strapi-design-system/src/Card/CardAsset.js
@@ -26,8 +26,8 @@ const CardAssetWrapper = styled.div`
   width: 100%;
   background: repeating-conic-gradient(${({ theme }) => theme.colors.neutral100} 0% 25%, transparent 0% 50%) 50% / 20px
     20px;
-  border-top-left-radius: 4px;
-  border-top-right-radius: 4px;
+  border-top-left-radius: ${({ theme }) => theme.borderRadius};
+  border-top-right-radius: ${({ theme }) => theme.borderRadius};
 `;
 
 export const CardAsset = ({ size, children, ...props }) => {

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -6563,6 +6563,9 @@ exports[`Storyshots Design System/Components/Card base 1`] = `
 .c3 {
   background: #ffffff;
   border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  border-color: #eaeaef;
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
 }
 
@@ -6885,6 +6888,8 @@ exports[`Storyshots Design System/Components/Card base 1`] = `
   height: 10.25rem;
   width: 100%;
   background: repeating-conic-gradient(#f6f6f9 0% 25%,transparent 0% 50%) 50% / 20px 20px;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
 }
 
 .c25 {
@@ -7073,6 +7078,9 @@ exports[`Storyshots Design System/Components/Card keyboard navigable 1`] = `
 .c3 {
   background: #ffffff;
   border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  border-color: #eaeaef;
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
 }
 
@@ -7465,6 +7473,9 @@ exports[`Storyshots Design System/Components/Card with asset icon 1`] = `
 .c3 {
   background: #ffffff;
   border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  border-color: #eaeaef;
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
 }
 
@@ -7677,6 +7688,8 @@ exports[`Storyshots Design System/Components/Card with asset icon 1`] = `
   height: 10.25rem;
   width: 100%;
   background: repeating-conic-gradient(#f6f6f9 0% 25%,transparent 0% 50%) 50% / 20px 20px;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
 }
 
 .c20 {
@@ -7844,6 +7857,9 @@ exports[`Storyshots Design System/Components/Card without asset 1`] = `
 .c3 {
   background: #ffffff;
   border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  border-color: #eaeaef;
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
 }
 
@@ -8046,6 +8062,9 @@ exports[`Storyshots Design System/Components/Card without asset action 1`] = `
 .c3 {
   background: #ffffff;
   border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  border-color: #eaeaef;
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
 }
 
@@ -8266,6 +8285,8 @@ exports[`Storyshots Design System/Components/Card without asset action 1`] = `
   height: 10.25rem;
   width: 100%;
   background: repeating-conic-gradient(#f6f6f9 0% 25%,transparent 0% 50%) 50% / 20px 20px;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
 }
 
 .c21 {
@@ -8419,6 +8440,9 @@ exports[`Storyshots Design System/Components/Card without asset action nor timer
 .c3 {
   background: #ffffff;
   border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  border-color: #eaeaef;
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
 }
 
@@ -8626,6 +8650,8 @@ exports[`Storyshots Design System/Components/Card without asset action nor timer
   height: 10.25rem;
   width: 100%;
   background: repeating-conic-gradient(#f6f6f9 0% 25%,transparent 0% 50%) 50% / 20px 20px;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
 }
 
 .c18 {


### PR DESCRIPTION
## What

- Added a border to improve the accessibility of the Card component with Dark mode
- Fixed CardAsset not applying top `border-radius` on the `repeating-conic-gradient` background (see images below)

<img width="606" alt="image" src="https://user-images.githubusercontent.com/71838159/174663262-51bfded1-b1ee-4e53-84e0-d1a0ccd0448e.png">

## Snapshots

CardAsset background overflowing Card `border-radius` (not visible on the right side because `repeating-conic-gradient` property uses `neutral100` and transparent:
<img width="698" alt="Screenshot 2022-06-20 at 20 43 13" src="https://user-images.githubusercontent.com/71838159/174663484-a00e8973-f297-4e42-b17b-ebb47d35b6db.png">

Fix by adding `border-top-left-radius` and right (overflow hidden on Card component could also be a solution):
<img width="777" alt="Screenshot 2022-06-20 at 20 48 58" src="https://user-images.githubusercontent.com/71838159/174663693-5e6c9175-b6b1-4e6d-b77b-e12d262c6560.png">


