### PR TITLE
DS: Fix global apple system font-family

### DIFF
--- a/packages/strapi-design-system/src/ThemeProvider/ThemeProvider.js
+++ b/packages/strapi-design-system/src/ThemeProvider/ThemeProvider.js
@@ -153,7 +153,7 @@ const GlobalStyle = createGlobalStyle`
     height: 100%;
   }
   body {
-    font-family: --apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   }
 
   button {


### PR DESCRIPTION
### What does it do?

Fixes https://github.com/strapi/design-system/issues/629. On MacOS we are currently using the wrong system-font notation. Github uses the same notion (`-apple-system` instead of `--apple-system`).

| Before  | After  | 
|---|---|
| ![Screen Shot 2022-06-21 at 17 45 19-fullpage](https://user-images.githubusercontent.com/2244375/174842174-3b96531b-cbc3-4314-b756-17a5b18e2476.png)  | ![Screen Shot 2022-06-21 at 17 45 13-fullpage](https://user-images.githubusercontent.com/2244375/174842185-36fb3327-b288-4238-8246-7b1aded9a7c9.png)  |
| ![Screen Shot 2022-06-21 at 17 46 08-fullpage](https://user-images.githubusercontent.com/2244375/174842298-bd69033e-7657-4426-9e28-453cac8fb0f6.png)  | ![Screen Shot 2022-06-21 at 17 46 15-fullpage](https://user-images.githubusercontent.com/2244375/174842278-b96fe673-26fb-4449-8a6e-3f2e92f70298.png)  |
| ![Screen Shot 2022-06-21 at 17 49 20-fullpage](https://user-images.githubusercontent.com/2244375/174842957-b21ede72-f203-4865-8311-9f0da6a6edc5.png) | ![Screen Shot 2022-06-21 at 17 49 24-fullpage](https://user-images.githubusercontent.com/2244375/174842968-84cca457-1cdf-438e-a75e-b738507282be.png) |

### Why is it needed?

To display proper fonts.


### Related issues

- Fixes https://github.com/strapi/design-system/issues/629
