### PR TITLE
Add indentation styling to SubNavLinkSection child elements

### DIFF
--- a/packages/strapi-design-system/src/SubNav/SubNav.stories.mdx
+++ b/packages/strapi-design-system/src/SubNav/SubNav.stories.mdx
@@ -112,7 +112,7 @@ import {
                 <SubNavSection label="Single Type" collapsable badgeLabel={links.length.toString()}>
                   <SubNavLinkSection label="Default">
                     {links.map((link) => (
-                      <SubNavLink to={link.to} subSectionChild={true} key={link.id}>
+                      <SubNavLink to={link.to} isSubSectionChild key={link.id}>
                         {link.label}
                       </SubNavLink>
                     ))}
@@ -168,7 +168,7 @@ import {
                         to={link.to}
                         active={link.active}
                         icon={link.icon}
-                        subSectionChild={true}
+                        isSubSectionChild
                         key={link.id}
                       >
                         {link.label}

--- a/packages/strapi-design-system/src/SubNav/SubNav.stories.mdx
+++ b/packages/strapi-design-system/src/SubNav/SubNav.stories.mdx
@@ -106,7 +106,7 @@ import {
                     </SubNavLink>
                   ))}
                 </SubNavSection>
-                <Box paddingLeft={7}>
+                <Box paddingLeft={7} paddingBottom={3}>
                   <TextButton startIcon={<Plus />}>Click on me</TextButton>
                 </Box>
                 <SubNavSection label="Single Type" collapsable badgeLabel={links.length.toString()}>

--- a/packages/strapi-design-system/src/SubNav/SubNav.stories.mdx
+++ b/packages/strapi-design-system/src/SubNav/SubNav.stories.mdx
@@ -112,7 +112,7 @@ import {
                 <SubNavSection label="Single Type" collapsable badgeLabel={links.length.toString()}>
                   <SubNavLinkSection label="Default">
                     {links.map((link) => (
-                      <SubNavLink to={link.to} key={link.id}>
+                      <SubNavLink to={link.to} subSectionChild={true} key={link.id}>
                         {link.label}
                       </SubNavLink>
                     ))}
@@ -164,7 +164,13 @@ import {
                 <SubNavSection label="Global Settings">
                   <SubNavLinkSection label="Sub section">
                     {links.map((link) => (
-                      <SubNavLink to={link.to} active={link.active} icon={link.icon} key={link.id}>
+                      <SubNavLink
+                        to={link.to}
+                        active={link.active}
+                        icon={link.icon}
+                        subSectionChild={true}
+                        key={link.id}
+                      >
                         {link.label}
                       </SubNavLink>
                     ))}

--- a/packages/strapi-design-system/src/SubNav/SubNavLink.js
+++ b/packages/strapi-design-system/src/SubNav/SubNavLink.js
@@ -51,15 +51,15 @@ const IconWrapper = styled.div`
   }
 `;
 
-export const SubNavLink = ({ children, icon, withBullet, ...props }) => {
+export const SubNavLink = ({ children, icon, withBullet, subSectionChild = false, ...props }) => {
   return (
     <SubNavLinkWrapper
       as={NavLink}
       icon={icon}
       background="neutral100"
-      paddingLeft={7}
-      paddingBottom={2}
-      paddingTop={2}
+      paddingLeft={subSectionChild ? 9 : 7}
+      paddingBottom={1}
+      paddingTop={1}
       {...props}
     >
       <Flex>
@@ -86,5 +86,6 @@ SubNavLink.propTypes = {
   children: PropTypes.node,
   icon: PropTypes.element,
   link: PropTypes.element,
+  subSectionChild: PropTypes.bool,
   withBullet: PropTypes.bool,
 };

--- a/packages/strapi-design-system/src/SubNav/SubNavLink.js
+++ b/packages/strapi-design-system/src/SubNav/SubNavLink.js
@@ -51,13 +51,13 @@ const IconWrapper = styled.div`
   }
 `;
 
-export const SubNavLink = ({ children, icon, withBullet, subSectionChild = false, ...props }) => {
+export const SubNavLink = ({ children, icon, withBullet, isSubSectionChild, ...props }) => {
   return (
     <SubNavLinkWrapper
       as={NavLink}
       icon={icon}
       background="neutral100"
-      paddingLeft={subSectionChild ? 9 : 7}
+      paddingLeft={isSubSectionChild ? 9 : 7}
       paddingBottom={2}
       paddingTop={2}
       {...props}
@@ -80,12 +80,13 @@ export const SubNavLink = ({ children, icon, withBullet, subSectionChild = false
 SubNavLink.displayName = 'SubNavLink';
 SubNavLink.defaultProps = {
   icon: null,
+  isSubSectionChild: false,
   withBullet: false,
 };
 SubNavLink.propTypes = {
   children: PropTypes.node,
   icon: PropTypes.element,
+  isSubSectionChild: PropTypes.bool,
   link: PropTypes.element,
-  subSectionChild: PropTypes.bool,
   withBullet: PropTypes.bool,
 };

--- a/packages/strapi-design-system/src/SubNav/SubNavLink.js
+++ b/packages/strapi-design-system/src/SubNav/SubNavLink.js
@@ -58,8 +58,8 @@ export const SubNavLink = ({ children, icon, withBullet, subSectionChild = false
       icon={icon}
       background="neutral100"
       paddingLeft={subSectionChild ? 9 : 7}
-      paddingBottom={1}
-      paddingTop={1}
+      paddingBottom={2}
+      paddingTop={2}
       {...props}
     >
       <Flex>

--- a/packages/strapi-design-system/src/SubNav/SubNavLinkSection.js
+++ b/packages/strapi-design-system/src/SubNav/SubNavLinkSection.js
@@ -8,7 +8,6 @@ import { Typography } from '../Typography';
 import { useId } from '../helpers/useId';
 
 const SubNavLinkSectionWrapper = styled(Box)`
-  max-height: ${32 / 16}rem;
   svg {
     height: ${4 / 16}rem;
     path {

--- a/packages/strapi-design-system/src/SubNav/SubNavSection.js
+++ b/packages/strapi-design-system/src/SubNav/SubNavSection.js
@@ -2,7 +2,6 @@ import React, { Children, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Box } from '../Box';
-import { Flex } from '../Flex';
 import { Badge } from '../Badge';
 import { SubNavSectionLabel } from './SubNavSectionLabel';
 import { useId } from '../helpers/useId';
@@ -18,6 +17,7 @@ const SubNavSectionWrapper = styled(Box)`
 const SubNavSectionBadge = styled(Badge)`
   display: flex;
   align-items: center;
+  transform: translateY(-50%);
 `;
 
 export const SubNavSection = ({ collapsable, label, badgeLabel, children, id }) => {
@@ -30,8 +30,8 @@ export const SubNavSection = ({ collapsable, label, badgeLabel, children, id }) 
 
   return (
     <Box>
-      <SubNavSectionWrapper paddingLeft={6} paddingTop={0} paddingBottom={0} paddingRight={4} marginBottom={1}>
-        <Flex justifyContent="space-between">
+      <SubNavSectionWrapper paddingLeft={6} paddingTop={1} paddingBottom={1} paddingRight={4} marginBottom={1}>
+        <Box position="relative">
           <SubNavSectionLabel
             onClick={handleClick}
             ariaExpanded={isOpen}
@@ -40,18 +40,24 @@ export const SubNavSection = ({ collapsable, label, badgeLabel, children, id }) 
             label={label}
           />
           {badgeLabel && (
-            <SubNavSectionBadge backgroundColor="neutral150" textColor="neutral600">
+            <SubNavSectionBadge
+              backgroundColor="neutral150"
+              textColor="neutral600"
+              position="absolute"
+              right={0}
+              top="50%"
+            >
               {badgeLabel}
             </SubNavSectionBadge>
           )}
-        </Flex>
+        </Box>
       </SubNavSectionWrapper>
       {(!collapsable || isOpen) && (
-        <ul id={listId}>
+        <ol id={listId}>
           {Children.map(children, (child, index) => {
             return <li key={index}>{child}</li>;
           })}
-        </ul>
+        </ol>
       )}
     </Box>
   );

--- a/packages/strapi-design-system/src/SubNav/SubNavSection.js
+++ b/packages/strapi-design-system/src/SubNav/SubNavSection.js
@@ -5,6 +5,7 @@ import { Box } from '../Box';
 import { Badge } from '../Badge';
 import { SubNavSectionLabel } from './SubNavSectionLabel';
 import { useId } from '../helpers/useId';
+import { Stack } from '../Stack';
 
 const SubNavSectionWrapper = styled(Box)`
   svg {
@@ -13,11 +14,6 @@ const SubNavSectionWrapper = styled(Box)`
       fill: ${({ theme }) => theme.colors.neutral500};
     }
   }
-`;
-const SubNavSectionBadge = styled(Badge)`
-  display: flex;
-  align-items: center;
-  transform: translateY(-50%);
 `;
 
 export const SubNavSection = ({ collapsable, label, badgeLabel, children, id }) => {
@@ -29,9 +25,9 @@ export const SubNavSection = ({ collapsable, label, badgeLabel, children, id }) 
   };
 
   return (
-    <Box>
-      <SubNavSectionWrapper paddingLeft={6} paddingTop={1} paddingBottom={1} paddingRight={4} marginBottom={1}>
-        <Box position="relative">
+    <Stack spacing={1}>
+      <SubNavSectionWrapper paddingLeft={6} paddingTop={1} paddingBottom={1} paddingRight={4}>
+        <Box position="relative" paddingRight={badgeLabel ? 6 : 0}>
           <SubNavSectionLabel
             onClick={handleClick}
             ariaExpanded={isOpen}
@@ -40,15 +36,16 @@ export const SubNavSection = ({ collapsable, label, badgeLabel, children, id }) 
             label={label}
           />
           {badgeLabel && (
-            <SubNavSectionBadge
+            <Badge
               backgroundColor="neutral150"
               textColor="neutral600"
               position="absolute"
               right={0}
               top="50%"
+              transform="translateY(-50%)"
             >
               {badgeLabel}
-            </SubNavSectionBadge>
+            </Badge>
           )}
         </Box>
       </SubNavSectionWrapper>
@@ -59,7 +56,7 @@ export const SubNavSection = ({ collapsable, label, badgeLabel, children, id }) 
           })}
         </ol>
       )}
-    </Box>
+    </Stack>
   );
 };
 

--- a/packages/strapi-design-system/src/SubNav/SubNavSection.js
+++ b/packages/strapi-design-system/src/SubNav/SubNavSection.js
@@ -8,7 +8,6 @@ import { SubNavSectionLabel } from './SubNavSectionLabel';
 import { useId } from '../helpers/useId';
 
 const SubNavSectionWrapper = styled(Box)`
-  max-height: ${32 / 16}rem;
   svg {
     height: ${4 / 16}rem;
     path {

--- a/packages/strapi-design-system/src/SubNav/SubNavSection.js
+++ b/packages/strapi-design-system/src/SubNav/SubNavSection.js
@@ -30,7 +30,7 @@ export const SubNavSection = ({ collapsable, label, badgeLabel, children, id }) 
 
   return (
     <Box>
-      <SubNavSectionWrapper paddingLeft={6} paddingTop={2} paddingBottom={2} paddingRight={4}>
+      <SubNavSectionWrapper paddingLeft={6} paddingTop={0} paddingBottom={0} paddingRight={4} marginBottom={1}>
         <Flex justifyContent="space-between">
           <SubNavSectionLabel
             onClick={handleClick}

--- a/packages/strapi-design-system/src/SubNav/SubNavSectionLabel.js
+++ b/packages/strapi-design-system/src/SubNav/SubNavSectionLabel.js
@@ -25,6 +25,7 @@ export const SubNavSectionLabel = ({ collapsable, label, onClick, ariaExpanded, 
         onClick={onClick}
         aria-expanded={ariaExpanded}
         aria-controls={ariaControls}
+        textAlign="left"
       >
         <Box paddingRight={1}>
           <Typography variant="sigma" textColor="neutral600">

--- a/packages/strapi-design-system/src/SubNav/SubNavSections.js
+++ b/packages/strapi-design-system/src/SubNav/SubNavSections.js
@@ -6,7 +6,7 @@ import { Box } from '../Box';
 export const SubNavSections = ({ children, ...props }) => {
   return (
     <Box paddingTop={2} paddingBottom={4}>
-      <Stack as="ul" spacing={2} {...props}>
+      <Stack as="ul" spacing={3} {...props}>
         {Children.map(children, (child, index) => {
           return <li key={index}>{child}</li>;
         })}

--- a/packages/strapi-design-system/src/SubNav/SubNavSections.js
+++ b/packages/strapi-design-system/src/SubNav/SubNavSections.js
@@ -6,7 +6,7 @@ import { Box } from '../Box';
 export const SubNavSections = ({ children, ...props }) => {
   return (
     <Box paddingTop={2} paddingBottom={4}>
-      <Stack as="ol" spacing={3} {...props}>
+      <Stack as="ol" spacing={2} {...props}>
         {Children.map(children, (child, index) => {
           return <li key={index}>{child}</li>;
         })}

--- a/packages/strapi-design-system/src/SubNav/SubNavSections.js
+++ b/packages/strapi-design-system/src/SubNav/SubNavSections.js
@@ -6,7 +6,7 @@ import { Box } from '../Box';
 export const SubNavSections = ({ children, ...props }) => {
   return (
     <Box paddingTop={2} paddingBottom={4}>
-      <Stack as="ul" spacing={3} {...props}>
+      <Stack as="ol" spacing={3} {...props}>
         {Children.map(children, (child, index) => {
           return <li key={index}>{child}</li>;
         })}

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -20170,10 +20170,15 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
 }
 
 .c20 {
-  padding-top: 8px;
+  padding-top: 4px;
   padding-right: 16px;
-  padding-bottom: 8px;
+  padding-bottom: 4px;
   padding-left: 24px;
+  margin-bottom: 4px;
+}
+
+.c22 {
+  position: relative;
 }
 
 .c25 {
@@ -20184,13 +20189,16 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   background: #eaeaef;
   padding: 4px;
   border-radius: 4px;
+  position: absolute;
+  right: 0px;
+  top: 50%;
   min-width: 20px;
 }
 
 .c31 {
   background: #f6f6f9;
-  padding-top: 4px;
-  padding-bottom: 4px;
+  padding-top: 8px;
+  padding-bottom: 8px;
   padding-left: 32px;
 }
 
@@ -20205,11 +20213,11 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   padding-left: 32px;
 }
 
-.c41 {
+.c42 {
   padding-bottom: 56px;
 }
 
-.c43 {
+.c44 {
   background: #f6f6f9;
   padding-top: 40px;
   padding-right: 56px;
@@ -20217,28 +20225,28 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   padding-left: 56px;
 }
 
-.c45 {
+.c46 {
   padding-left: 16px;
 }
 
-.c47 {
+.c48 {
   padding-right: 8px;
 }
 
-.c52 {
+.c53 {
   padding-right: 56px;
   padding-left: 56px;
 }
 
-.c53 {
+.c54 {
   padding-bottom: 16px;
 }
 
-.c56 {
+.c57 {
   padding-top: 8px;
 }
 
-.c57 {
+.c58 {
   background: #f0f0ff;
   color: #4945ff;
   padding-right: 12px;
@@ -20250,31 +20258,31 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   height: 2rem;
 }
 
-.c64 {
+.c65 {
   background: #ffffff;
   border-radius: 4px;
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
 }
 
-.c67 {
+.c68 {
   padding-right: 24px;
   padding-left: 24px;
 }
 
-.c79 {
+.c80 {
   padding-left: 4px;
 }
 
-.c80 {
+.c81 {
   background: #f0f0ff;
   padding: 20px;
 }
 
-.c82 {
+.c83 {
   background: #d9d8ff;
 }
 
-.c84 {
+.c85 {
   padding-left: 12px;
 }
 
@@ -20299,41 +20307,41 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   line-height: 1.43;
 }
 
-.c40 {
+.c41 {
   font-weight: 500;
   color: #32324d;
   font-size: 0.875rem;
   line-height: 1.43;
 }
 
-.c44 {
+.c45 {
   color: #32324d;
   font-weight: 600;
   font-size: 2rem;
   line-height: 1.25;
 }
 
-.c49 {
+.c50 {
   font-weight: 600;
   color: #32324d;
   font-size: 0.75rem;
   line-height: 1.33;
 }
 
-.c51 {
+.c52 {
   color: #666687;
   font-size: 1rem;
   line-height: 1.5;
 }
 
-.c63 {
+.c64 {
   font-weight: 600;
   color: #32324d;
   font-size: 0.875rem;
   line-height: 1.43;
 }
 
-.c75 {
+.c76 {
   color: #32324d;
   font-weight: 600;
   font-size: 0.6875rem;
@@ -20341,7 +20349,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   text-transform: uppercase;
 }
 
-.c85 {
+.c86 {
   font-weight: 600;
   color: #4945ff;
   font-size: 0.75rem;
@@ -20380,24 +20388,6 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   flex-direction: column;
 }
 
-.c22 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
 .c23 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -20430,7 +20420,25 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   justify-content: center;
 }
 
-.c54 {
+.c38 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c55 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -20453,7 +20461,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
 }
 
 .c19 > * + * {
-  margin-top: 8px;
+  margin-top: 12px;
 }
 
 .c11 {
@@ -20554,19 +20562,19 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   fill: #666687;
 }
 
-.c78 {
+.c79 {
   border-radius: 50%;
   display: block;
   position: relative;
 }
 
-.c77 {
+.c78 {
   position: relative;
   width: 1.625rem;
   height: 1.625rem;
 }
 
-.c73 {
+.c74 {
   margin: 0;
   height: 18px;
   min-width: 18px;
@@ -20577,12 +20585,12 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   cursor: pointer;
 }
 
-.c73:checked {
+.c74:checked {
   background-color: #4945ff;
   border: 1px solid #4945ff;
 }
 
-.c73:checked:after {
+.c74:checked:after {
   content: '';
   display: block;
   position: relative;
@@ -20596,21 +20604,21 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   transform: translateX(-50%) translateY(-50%);
 }
 
-.c73:checked:disabled:after {
+.c74:checked:disabled:after {
   background: url(test-file-stub) no-repeat no-repeat center center;
 }
 
-.c73:disabled {
+.c74:disabled {
   background-color: #dcdce4;
   border: 1px solid #c0c0cf;
 }
 
-.c73:indeterminate {
+.c74:indeterminate {
   background-color: #4945ff;
   border: 1px solid #4945ff;
 }
 
-.c73:indeterminate:after {
+.c74:indeterminate:after {
   content: '';
   display: block;
   position: relative;
@@ -20625,20 +20633,20 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   transform: translateX(-50%) translateY(-50%);
 }
 
-.c73:indeterminate:disabled {
+.c74:indeterminate:disabled {
   background-color: #dcdce4;
   border: 1px solid #c0c0cf;
 }
 
-.c73:indeterminate:disabled:after {
+.c74:indeterminate:disabled:after {
   background-color: #8e8ea9;
 }
 
-.c48 {
+.c49 {
   height: 100%;
 }
 
-.c46 {
+.c47 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -20650,7 +20658,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   background: #ffffff;
 }
 
-.c46 .c0 {
+.c47 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -20661,56 +20669,56 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   align-items: center;
 }
 
-.c46 .c9 {
+.c47 .c9 {
   color: #ffffff;
 }
 
-.c46[aria-disabled='true'] {
+.c47[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c46[aria-disabled='true'] .c9 {
+.c47[aria-disabled='true'] .c9 {
   color: #666687;
 }
 
-.c46[aria-disabled='true'] svg > g,
-.c46[aria-disabled='true'] svg path {
+.c47[aria-disabled='true'] svg > g,
+.c47[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c46[aria-disabled='true']:active {
+.c47[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c46[aria-disabled='true']:active .c9 {
+.c47[aria-disabled='true']:active .c9 {
   color: #666687;
 }
 
-.c46[aria-disabled='true']:active svg > g,
-.c46[aria-disabled='true']:active svg path {
+.c47[aria-disabled='true']:active svg > g,
+.c47[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c46:hover {
+.c47:hover {
   background-color: #f6f6f9;
 }
 
-.c46:active {
+.c47:active {
   background-color: #eaeaef;
 }
 
-.c46 .c9 {
+.c47 .c9 {
   color: #32324d;
 }
 
-.c46 svg > g,
-.c46 svg path {
+.c47 svg > g,
+.c47 svg path {
   fill: #32324d;
 }
 
-.c50 {
+.c51 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -20720,7 +20728,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   border: 1px solid #4945ff;
 }
 
-.c50 .c0 {
+.c51 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -20731,54 +20739,54 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   align-items: center;
 }
 
-.c50 .c9 {
+.c51 .c9 {
   color: #ffffff;
 }
 
-.c50[aria-disabled='true'] {
+.c51[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c50[aria-disabled='true'] .c9 {
+.c51[aria-disabled='true'] .c9 {
   color: #666687;
 }
 
-.c50[aria-disabled='true'] svg > g,
-.c50[aria-disabled='true'] svg path {
+.c51[aria-disabled='true'] svg > g,
+.c51[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c50[aria-disabled='true']:active {
+.c51[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c50[aria-disabled='true']:active .c9 {
+.c51[aria-disabled='true']:active .c9 {
   color: #666687;
 }
 
-.c50[aria-disabled='true']:active svg > g,
-.c50[aria-disabled='true']:active svg path {
+.c51[aria-disabled='true']:active svg > g,
+.c51[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c50:hover {
+.c51:hover {
   border: 1px solid #7b79ff;
   background: #7b79ff;
 }
 
-.c50:active {
+.c51:active {
   border: 1px solid #4945ff;
   background: #4945ff;
 }
 
-.c50 svg > g,
-.c50 svg path {
+.c51 svg > g,
+.c51 svg path {
   fill: #ffffff;
 }
 
-.c62 {
+.c63 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -20790,7 +20798,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   background: #ffffff;
 }
 
-.c62 .c0 {
+.c63 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -20801,52 +20809,52 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   align-items: center;
 }
 
-.c62 .c9 {
+.c63 .c9 {
   color: #ffffff;
 }
 
-.c62[aria-disabled='true'] {
+.c63[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c62[aria-disabled='true'] .c9 {
+.c63[aria-disabled='true'] .c9 {
   color: #666687;
 }
 
-.c62[aria-disabled='true'] svg > g,
-.c62[aria-disabled='true'] svg path {
+.c63[aria-disabled='true'] svg > g,
+.c63[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c62[aria-disabled='true']:active {
+.c63[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c62[aria-disabled='true']:active .c9 {
+.c63[aria-disabled='true']:active .c9 {
   color: #666687;
 }
 
-.c62[aria-disabled='true']:active svg > g,
-.c62[aria-disabled='true']:active svg path {
+.c63[aria-disabled='true']:active svg > g,
+.c63[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c62:hover {
+.c63:hover {
   background-color: #f6f6f9;
 }
 
-.c62:active {
+.c63:active {
   background-color: #eaeaef;
 }
 
-.c62 .c9 {
+.c63 .c9 {
   color: #32324d;
 }
 
-.c62 svg > g,
-.c62 svg path {
+.c63 svg > g,
+.c63 svg path {
   fill: #32324d;
 }
 
@@ -20922,10 +20930,6 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   fill: #666687;
 }
 
-.c37 {
-  max-height: 2rem;
-}
-
 .c37 svg {
   height: 0.25rem;
 }
@@ -20934,7 +20938,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   fill: #4a4a6a;
 }
 
-.c38 {
+.c39 {
   border: none;
   padding: 0;
   background: transparent;
@@ -20948,7 +20952,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   align-items: center;
 }
 
-.c39 {
+.c40 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -20983,10 +20987,6 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   transform: rotateX(0deg);
 }
 
-.c21 {
-  max-height: 2rem;
-}
-
 .c21 svg {
   height: 0.25rem;
 }
@@ -21004,6 +21004,9 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
 }
 
 .c5 {
@@ -21011,43 +21014,43 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   grid-template-columns: auto 1fr;
 }
 
-.c42 {
+.c43 {
   overflow-x: hidden;
 }
 
-.c55 > * + * {
-  margin-left: 8px;
-}
-
-.c60 {
-  margin-left: auto;
-}
-
-.c60 > * + * {
+.c56 > * + * {
   margin-left: 8px;
 }
 
 .c61 {
+  margin-left: auto;
+}
+
+.c61 > * + * {
+  margin-left: 8px;
+}
+
+.c62 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c65 {
+.c66 {
   overflow: hidden;
   border: 1px solid #eaeaef;
 }
 
-.c69 {
+.c70 {
   width: 100%;
   white-space: nowrap;
 }
 
-.c66 {
+.c67 {
   position: relative;
 }
 
-.c66:before {
+.c67:before {
   background: linear-gradient(90deg,#c0c0cf 0%,rgba(0,0,0,0) 100%);
   opacity: 0.2;
   position: absolute;
@@ -21057,7 +21060,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   left: 0;
 }
 
-.c66:after {
+.c67:after {
   background: linear-gradient(270deg,#c0c0cf 0%,rgba(0,0,0,0) 100%);
   opacity: 0.2;
   position: absolute;
@@ -21068,54 +21071,54 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   top: 0;
 }
 
-.c68 {
+.c69 {
   overflow-x: auto;
 }
 
-.c76 tr:last-of-type {
+.c77 tr:last-of-type {
   border-bottom: none;
-}
-
-.c70 {
-  border-bottom: 1px solid #eaeaef;
 }
 
 .c71 {
   border-bottom: 1px solid #eaeaef;
 }
 
-.c71 td,
-.c71 th {
+.c72 {
+  border-bottom: 1px solid #eaeaef;
+}
+
+.c72 td,
+.c72 th {
   padding: 16px;
 }
 
-.c71 td:first-of-type,
-.c71 th:first-of-type {
+.c72 td:first-of-type,
+.c72 th:first-of-type {
   padding: 0 4px;
 }
 
-.c71 th {
+.c72 th {
   padding-top: 0;
   padding-bottom: 0;
   height: 3.5rem;
 }
 
-.c72 {
+.c73 {
   vertical-align: middle;
   text-align: left;
   color: #666687;
   outline-offset: -4px;
 }
 
-.c72 input {
+.c73 input {
   vertical-align: sub;
 }
 
-.c74 svg {
+.c75 svg {
   height: 0.25rem;
 }
 
-.c83 {
+.c84 {
   height: 1.5rem;
   width: 1.5rem;
   border-radius: 50%;
@@ -21133,32 +21136,32 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   align-items: center;
 }
 
-.c83 svg {
+.c84 svg {
   height: 0.625rem;
   width: 0.625rem;
 }
 
-.c83 svg path {
+.c84 svg path {
   fill: #4945ff;
 }
 
-.c81 {
+.c82 {
   border-radius: 0 0 4px 4px;
   display: block;
   width: 100%;
   border: none;
 }
 
-.c58 svg {
+.c59 svg {
   height: 0.5rem;
   width: 0.5rem;
 }
 
-.c58 svg path {
+.c59 svg path {
   fill: #4945ff;
 }
 
-.c59 {
+.c60 {
   border-right: 1px solid #d9d8ff;
   color: inherit;
   padding-right: 8px;
@@ -21238,7 +21241,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
             >
               <ul
                 class="c0 c18 c19"
-                spacing="2"
+                spacing="3"
               >
                 <li>
                   <div
@@ -21295,7 +21298,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                         </div>
                       </div>
                     </div>
-                    <ul
+                    <ol
                       id="subnav-list-88"
                     >
                       <li>
@@ -21438,7 +21441,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </div>
                         </a>
                       </li>
-                    </ul>
+                    </ol>
                   </div>
                 </li>
                 <li>
@@ -21496,7 +21499,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                         </div>
                       </div>
                     </div>
-                    <ul
+                    <ol
                       id="subnav-list-89"
                     >
                       <li>
@@ -21507,15 +21510,15 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                             class="c0 c36 c37"
                           >
                             <div
-                              class="c0 c22"
+                              class="c0 c38"
                             >
                               <button
                                 aria-controls="subnav-list-90"
                                 aria-expanded="true"
-                                class="c38"
+                                class="c39"
                               >
                                 <div
-                                  class="c39"
+                                  class="c40"
                                 >
                                   <svg
                                     aria-hidden="true"
@@ -21537,7 +21540,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                                   class="c0 c34"
                                 >
                                   <span
-                                    class="c9 c40"
+                                    class="c9 c41"
                                   >
                                     Default
                                   </span>
@@ -21691,44 +21694,44 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </ul>
                         </div>
                       </li>
-                    </ul>
+                    </ol>
                   </div>
                 </li>
               </ul>
             </div>
           </nav>
           <div
-            class="c0 c41 c42"
+            class="c0 c42 c43"
           >
             <div
               style="height: 0px;"
             >
               <div
-                class="c0 c43"
+                class="c0 c44"
                 data-strapi-header="true"
               >
                 <div
-                  class="c0 c22"
+                  class="c0 c38"
                 >
                   <div
                     class="c0 c23"
                   >
                     <h2
-                      class="c9 c44"
+                      class="c9 c45"
                     >
                       Other CT
                     </h2>
                     <div
-                      class="c0 c45"
+                      class="c0 c46"
                     >
                       <button
                         aria-disabled="false"
-                        class="c11 c46"
+                        class="c11 c47"
                         type="button"
                       >
                         <div
                           aria-hidden="true"
-                          class="c0 c47 c48"
+                          class="c0 c48 c49"
                         >
                           <svg
                             fill="none"
@@ -21746,7 +21749,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </svg>
                         </div>
                         <span
-                          class="c9 c49"
+                          class="c9 c50"
                         >
                           Edit
                         </span>
@@ -21755,12 +21758,12 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                   </div>
                   <button
                     aria-disabled="false"
-                    class="c11 c50"
+                    class="c11 c51"
                     type="button"
                   >
                     <div
                       aria-hidden="true"
-                      class="c0 c47 c48"
+                      class="c0 c48 c49"
                     >
                       <svg
                         fill="none"
@@ -21776,45 +21779,45 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </svg>
                     </div>
                     <span
-                      class="c9 c49"
+                      class="c9 c50"
                     >
                       Add an entry
                     </span>
                   </button>
                 </div>
                 <p
-                  class="c9 c51"
+                  class="c9 c52"
                 >
                   36 entries found
                 </p>
               </div>
             </div>
             <div
-              class="c0 c52"
+              class="c0 c53"
             >
               <div
-                class="c0 c53"
+                class="c0 c54"
               >
                 <div
                   class="c0 c8"
                 >
                   <div
-                    class="c0 c54 c55"
+                    class="c0 c55 c56"
                     wrap="wrap"
                   >
                     <div
-                      class="c0 c56"
+                      class="c0 c57"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c57 c58"
+                        class="c0 c58 c59"
                         height="2rem"
                       >
                         <div
                           class="c0 c23"
                         >
                           <span
-                            class="c9 c49 c59"
+                            class="c9 c50 c60"
                           >
                             Hello world 
                             0
@@ -21844,18 +21847,18 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c56"
+                      class="c0 c57"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c57 c58"
+                        class="c0 c58 c59"
                         height="2rem"
                       >
                         <div
                           class="c0 c23"
                         >
                           <span
-                            class="c9 c49 c59"
+                            class="c9 c50 c60"
                           >
                             Hello world 
                             1
@@ -21885,18 +21888,18 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c56"
+                      class="c0 c57"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c57 c58"
+                        class="c0 c58 c59"
                         height="2rem"
                       >
                         <div
                           class="c0 c23"
                         >
                           <span
-                            class="c9 c49 c59"
+                            class="c9 c50 c60"
                           >
                             Hello world 
                             2
@@ -21926,18 +21929,18 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c56"
+                      class="c0 c57"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c57 c58"
+                        class="c0 c58 c59"
                         height="2rem"
                       >
                         <div
                           class="c0 c23"
                         >
                           <span
-                            class="c9 c49 c59"
+                            class="c9 c50 c60"
                           >
                             Hello world 
                             3
@@ -21967,18 +21970,18 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c56"
+                      class="c0 c57"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c57 c58"
+                        class="c0 c58 c59"
                         height="2rem"
                       >
                         <div
                           class="c0 c23"
                         >
                           <span
-                            class="c9 c49 c59"
+                            class="c9 c50 c60"
                           >
                             Hello world 
                             4
@@ -22008,18 +22011,18 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c56"
+                      class="c0 c57"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c57 c58"
+                        class="c0 c58 c59"
                         height="2rem"
                       >
                         <div
                           class="c0 c23"
                         >
                           <span
-                            class="c9 c49 c59"
+                            class="c9 c50 c60"
                           >
                             Hello world 
                             5
@@ -22049,18 +22052,18 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c56"
+                      class="c0 c57"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c57 c58"
+                        class="c0 c58 c59"
                         height="2rem"
                       >
                         <div
                           class="c0 c23"
                         >
                           <span
-                            class="c9 c49 c59"
+                            class="c9 c50 c60"
                           >
                             Hello world 
                             6
@@ -22090,18 +22093,18 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c56"
+                      class="c0 c57"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c57 c58"
+                        class="c0 c58 c59"
                         height="2rem"
                       >
                         <div
                           class="c0 c23"
                         >
                           <span
-                            class="c9 c49 c59"
+                            class="c9 c50 c60"
                           >
                             Hello world 
                             7
@@ -22131,18 +22134,18 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c56"
+                      class="c0 c57"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c57 c58"
+                        class="c0 c58 c59"
                         height="2rem"
                       >
                         <div
                           class="c0 c23"
                         >
                           <span
-                            class="c9 c49 c59"
+                            class="c9 c50 c60"
                           >
                             Hello world 
                             8
@@ -22172,18 +22175,18 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c56"
+                      class="c0 c57"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c57 c58"
+                        class="c0 c58 c59"
                         height="2rem"
                       >
                         <div
                           class="c0 c23"
                         >
                           <span
-                            class="c9 c49 c59"
+                            class="c9 c50 c60"
                           >
                             Hello world 
                             9
@@ -22213,18 +22216,18 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c56"
+                      class="c0 c57"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c57 c58"
+                        class="c0 c58 c59"
                         height="2rem"
                       >
                         <div
                           class="c0 c23"
                         >
                           <span
-                            class="c9 c49 c59"
+                            class="c9 c50 c60"
                           >
                             Hello world 
                             10
@@ -22254,18 +22257,18 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c56"
+                      class="c0 c57"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c57 c58"
+                        class="c0 c58 c59"
                         height="2rem"
                       >
                         <div
                           class="c0 c23"
                         >
                           <span
-                            class="c9 c49 c59"
+                            class="c9 c50 c60"
                           >
                             Hello world 
                             11
@@ -22295,18 +22298,18 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c56"
+                      class="c0 c57"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c57 c58"
+                        class="c0 c58 c59"
                         height="2rem"
                       >
                         <div
                           class="c0 c23"
                         >
                           <span
-                            class="c9 c49 c59"
+                            class="c9 c50 c60"
                           >
                             Hello world 
                             12
@@ -22336,18 +22339,18 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c56"
+                      class="c0 c57"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c57 c58"
+                        class="c0 c58 c59"
                         height="2rem"
                       >
                         <div
                           class="c0 c23"
                         >
                           <span
-                            class="c9 c49 c59"
+                            class="c9 c50 c60"
                           >
                             Hello world 
                             13
@@ -22377,18 +22380,18 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c56"
+                      class="c0 c57"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c57 c58"
+                        class="c0 c58 c59"
                         height="2rem"
                       >
                         <div
                           class="c0 c23"
                         >
                           <span
-                            class="c9 c49 c59"
+                            class="c9 c50 c60"
                           >
                             Hello world 
                             14
@@ -22418,18 +22421,18 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c56"
+                      class="c0 c57"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c57 c58"
+                        class="c0 c58 c59"
                         height="2rem"
                       >
                         <div
                           class="c0 c23"
                         >
                           <span
-                            class="c9 c49 c59"
+                            class="c9 c50 c60"
                           >
                             Hello world 
                             15
@@ -22459,18 +22462,18 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c56"
+                      class="c0 c57"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c57 c58"
+                        class="c0 c58 c59"
                         height="2rem"
                       >
                         <div
                           class="c0 c23"
                         >
                           <span
-                            class="c9 c49 c59"
+                            class="c9 c50 c60"
                           >
                             Hello world 
                             16
@@ -22500,18 +22503,18 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c56"
+                      class="c0 c57"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c57 c58"
+                        class="c0 c58 c59"
                         height="2rem"
                       >
                         <div
                           class="c0 c23"
                         >
                           <span
-                            class="c9 c49 c59"
+                            class="c9 c50 c60"
                           >
                             Hello world 
                             17
@@ -22541,18 +22544,18 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c56"
+                      class="c0 c57"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c57 c58"
+                        class="c0 c58 c59"
                         height="2rem"
                       >
                         <div
                           class="c0 c23"
                         >
                           <span
-                            class="c9 c49 c59"
+                            class="c9 c50 c60"
                           >
                             Hello world 
                             18
@@ -22582,18 +22585,18 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c56"
+                      class="c0 c57"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c57 c58"
+                        class="c0 c58 c59"
                         height="2rem"
                       >
                         <div
                           class="c0 c23"
                         >
                           <span
-                            class="c9 c49 c59"
+                            class="c9 c50 c60"
                           >
                             Hello world 
                             19
@@ -22624,26 +22627,26 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c0 c23 c60 c61"
+                    class="c0 c23 c61 c62"
                   >
                     <button
                       aria-disabled="false"
-                      class="c11 c62"
+                      class="c11 c63"
                       type="button"
                     >
                       <span
-                        class="c9 c63"
+                        class="c9 c64"
                       >
                         Settings
                       </span>
                     </button>
                     <button
                       aria-disabled="false"
-                      class="c11 c62"
+                      class="c11 c63"
                       type="button"
                     >
                       <span
-                        class="c9 c63"
+                        class="c9 c64"
                       >
                         Settings
                       </span>
@@ -22653,140 +22656,140 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
               </div>
             </div>
             <div
-              class="c0 c52"
+              class="c0 c53"
             >
               <div
-                class="c0 c64 c65"
+                class="c0 c65 c66"
               >
                 <div
-                  class="c0 c66"
+                  class="c0 c67"
                 >
                   <div
-                    class="c0 c67 c68"
+                    class="c0 c68 c69"
                   >
                     <table
                       aria-colcount="10"
                       aria-rowcount="6"
-                      class="c69"
+                      class="c70"
                     >
                       <thead
-                        class="c70"
+                        class="c71"
                       >
                         <tr
                           aria-rowindex="1"
-                          class="c0 c71"
+                          class="c0 c72"
                         >
                           <th
                             aria-colindex="1"
-                            class="c0 c72"
+                            class="c0 c73"
                           >
                             <div
                               class="c0 c23"
                             >
                               <input
                                 aria-label="Select all entries"
-                                class="c73"
+                                class="c74"
                                 tabindex="0"
                                 type="checkbox"
                               />
                               <span
-                                class="c74"
+                                class="c75"
                               />
                             </div>
                           </th>
                           <th
                             aria-colindex="2"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <div
                               class="c0 c23"
                             >
                               <span
-                                class="c9 c75"
+                                class="c9 c76"
                               >
                                 ID
                               </span>
                               <span
-                                class="c74"
+                                class="c75"
                               />
                             </div>
                           </th>
                           <th
                             aria-colindex="3"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <div
                               class="c0 c23"
                             >
                               <span
-                                class="c9 c75"
+                                class="c9 c76"
                               >
                                 Cover
                               </span>
                               <span
-                                class="c74"
+                                class="c75"
                               />
                             </div>
                           </th>
                           <th
                             aria-colindex="4"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <div
                               class="c0 c23"
                             >
                               <span
-                                class="c9 c75"
+                                class="c9 c76"
                               >
                                 Description
                               </span>
                               <span
-                                class="c74"
+                                class="c75"
                               />
                             </div>
                           </th>
                           <th
                             aria-colindex="5"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <div
                               class="c0 c23"
                             >
                               <span
-                                class="c9 c75"
+                                class="c9 c76"
                               >
                                 Categories
                               </span>
                               <span
-                                class="c74"
+                                class="c75"
                               />
                             </div>
                           </th>
                           <th
                             aria-colindex="6"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <div
                               class="c0 c23"
                             >
                               <span
-                                class="c9 c75"
+                                class="c9 c76"
                               >
                                 Contact
                               </span>
                               <span
-                                class="c74"
+                                class="c75"
                               />
                             </div>
                           </th>
                           <th
                             aria-colindex="7"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <div
@@ -22794,13 +22797,13 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                             >
                               More
                               <span
-                                class="c74"
+                                class="c75"
                               />
                             </div>
                           </th>
                           <th
                             aria-colindex="8"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <div
@@ -22808,13 +22811,13 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                             >
                               More
                               <span
-                                class="c74"
+                                class="c75"
                               />
                             </div>
                           </th>
                           <th
                             aria-colindex="9"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <div
@@ -22822,13 +22825,13 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                             >
                               More
                               <span
-                                class="c74"
+                                class="c75"
                               />
                             </div>
                           </th>
                           <th
                             aria-colindex="10"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <div
@@ -22840,33 +22843,33 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                                 Actions
                               </div>
                               <span
-                                class="c74"
+                                class="c75"
                               />
                             </div>
                           </th>
                         </tr>
                       </thead>
                       <tbody
-                        class="c76"
+                        class="c77"
                       >
                         <tr
                           aria-rowindex="2"
-                          class="c0 c71"
+                          class="c0 c72"
                         >
                           <td
                             aria-colindex="1"
-                            class="c0 c72"
+                            class="c0 c73"
                           >
                             <input
                               aria-label="Select Leon Lafrite"
-                              class="c73"
+                              class="c74"
                               tabindex="-1"
                               type="checkbox"
                             />
                           </td>
                           <td
                             aria-colindex="2"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -22877,16 +22880,16 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="3"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span>
                               <div
-                                class="c77"
+                                class="c78"
                               >
                                 <img
                                   alt="Leon Lafrite"
-                                  class="c78"
+                                  class="c79"
                                   height="26px"
                                   src="https://avatars.githubusercontent.com/u/3874873?v=4"
                                   width="26px"
@@ -22896,7 +22899,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="4"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -22907,7 +22910,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="5"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -22918,7 +22921,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="6"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -22929,7 +22932,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="7"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -22940,7 +22943,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="8"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -22951,7 +22954,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="9"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -22962,7 +22965,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="10"
-                            class="c0 c72"
+                            class="c0 c73"
                           >
                             <div
                               class="c0 c23"
@@ -22992,7 +22995,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                                 </button>
                               </span>
                               <div
-                                class="c0 c79"
+                                class="c0 c80"
                               >
                                 <span>
                                   <button
@@ -23022,22 +23025,22 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                         </tr>
                         <tr
                           aria-rowindex="3"
-                          class="c0 c71"
+                          class="c0 c72"
                         >
                           <td
                             aria-colindex="1"
-                            class="c0 c72"
+                            class="c0 c73"
                           >
                             <input
                               aria-label="Select Leon Lafrite"
-                              class="c73"
+                              class="c74"
                               tabindex="-1"
                               type="checkbox"
                             />
                           </td>
                           <td
                             aria-colindex="2"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -23048,16 +23051,16 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="3"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span>
                               <div
-                                class="c77"
+                                class="c78"
                               >
                                 <img
                                   alt="Leon Lafrite"
-                                  class="c78"
+                                  class="c79"
                                   height="26px"
                                   src="https://avatars.githubusercontent.com/u/3874873?v=4"
                                   width="26px"
@@ -23067,7 +23070,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="4"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -23078,7 +23081,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="5"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -23089,7 +23092,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="6"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -23100,7 +23103,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="7"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -23111,7 +23114,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="8"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -23122,7 +23125,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="9"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -23133,7 +23136,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="10"
-                            class="c0 c72"
+                            class="c0 c73"
                           >
                             <div
                               class="c0 c23"
@@ -23163,7 +23166,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                                 </button>
                               </span>
                               <div
-                                class="c0 c79"
+                                class="c0 c80"
                               >
                                 <span>
                                   <button
@@ -23193,22 +23196,22 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                         </tr>
                         <tr
                           aria-rowindex="4"
-                          class="c0 c71"
+                          class="c0 c72"
                         >
                           <td
                             aria-colindex="1"
-                            class="c0 c72"
+                            class="c0 c73"
                           >
                             <input
                               aria-label="Select Leon Lafrite"
-                              class="c73"
+                              class="c74"
                               tabindex="-1"
                               type="checkbox"
                             />
                           </td>
                           <td
                             aria-colindex="2"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -23219,16 +23222,16 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="3"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span>
                               <div
-                                class="c77"
+                                class="c78"
                               >
                                 <img
                                   alt="Leon Lafrite"
-                                  class="c78"
+                                  class="c79"
                                   height="26px"
                                   src="https://avatars.githubusercontent.com/u/3874873?v=4"
                                   width="26px"
@@ -23238,7 +23241,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="4"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -23249,7 +23252,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="5"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -23260,7 +23263,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="6"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -23271,7 +23274,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="7"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -23282,7 +23285,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="8"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -23293,7 +23296,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="9"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -23304,7 +23307,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="10"
-                            class="c0 c72"
+                            class="c0 c73"
                           >
                             <div
                               class="c0 c23"
@@ -23334,7 +23337,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                                 </button>
                               </span>
                               <div
-                                class="c0 c79"
+                                class="c0 c80"
                               >
                                 <span>
                                   <button
@@ -23364,22 +23367,22 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                         </tr>
                         <tr
                           aria-rowindex="5"
-                          class="c0 c71"
+                          class="c0 c72"
                         >
                           <td
                             aria-colindex="1"
-                            class="c0 c72"
+                            class="c0 c73"
                           >
                             <input
                               aria-label="Select Leon Lafrite"
-                              class="c73"
+                              class="c74"
                               tabindex="-1"
                               type="checkbox"
                             />
                           </td>
                           <td
                             aria-colindex="2"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -23390,16 +23393,16 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="3"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span>
                               <div
-                                class="c77"
+                                class="c78"
                               >
                                 <img
                                   alt="Leon Lafrite"
-                                  class="c78"
+                                  class="c79"
                                   height="26px"
                                   src="https://avatars.githubusercontent.com/u/3874873?v=4"
                                   width="26px"
@@ -23409,7 +23412,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="4"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -23420,7 +23423,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="5"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -23431,7 +23434,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="6"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -23442,7 +23445,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="7"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -23453,7 +23456,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="8"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -23464,7 +23467,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="9"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -23475,7 +23478,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="10"
-                            class="c0 c72"
+                            class="c0 c73"
                           >
                             <div
                               class="c0 c23"
@@ -23505,7 +23508,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                                 </button>
                               </span>
                               <div
-                                class="c0 c79"
+                                class="c0 c80"
                               >
                                 <span>
                                   <button
@@ -23535,22 +23538,22 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                         </tr>
                         <tr
                           aria-rowindex="6"
-                          class="c0 c71"
+                          class="c0 c72"
                         >
                           <td
                             aria-colindex="1"
-                            class="c0 c72"
+                            class="c0 c73"
                           >
                             <input
                               aria-label="Select Leon Lafrite"
-                              class="c73"
+                              class="c74"
                               tabindex="-1"
                               type="checkbox"
                             />
                           </td>
                           <td
                             aria-colindex="2"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -23561,16 +23564,16 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="3"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span>
                               <div
-                                class="c77"
+                                class="c78"
                               >
                                 <img
                                   alt="Leon Lafrite"
-                                  class="c78"
+                                  class="c79"
                                   height="26px"
                                   src="https://avatars.githubusercontent.com/u/3874873?v=4"
                                   width="26px"
@@ -23580,7 +23583,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="4"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -23591,7 +23594,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="5"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -23602,7 +23605,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="6"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -23613,7 +23616,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="7"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -23624,7 +23627,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="8"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -23635,7 +23638,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="9"
-                            class="c0 c72"
+                            class="c0 c73"
                             tabindex="-1"
                           >
                             <span
@@ -23646,7 +23649,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="10"
-                            class="c0 c72"
+                            class="c0 c73"
                           >
                             <div
                               class="c0 c23"
@@ -23676,7 +23679,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                                 </button>
                               </span>
                               <div
-                                class="c0 c79"
+                                class="c0 c80"
                               >
                                 <span>
                                   <button
@@ -23713,14 +23716,14 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                     class="c0 c14 c15"
                   />
                   <button
-                    class="c0 c80 c81"
+                    class="c0 c81 c82"
                   >
                     <div
                       class="c0 c23"
                     >
                       <div
                         aria-hidden="true"
-                        class="c0 c82 c83"
+                        class="c0 c83 c84"
                       >
                         <svg
                           fill="none"
@@ -23736,10 +23739,10 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                         </svg>
                       </div>
                       <div
-                        class="c0 c84"
+                        class="c0 c85"
                       >
                         <span
-                          class="c9 c85"
+                          class="c9 c86"
                         >
                           Add another field to this collection type
                         </span>
@@ -35983,10 +35986,15 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
 }
 
 .c19 {
-  padding-top: 8px;
+  padding-top: 4px;
   padding-right: 16px;
-  padding-bottom: 8px;
+  padding-bottom: 4px;
   padding-left: 24px;
+  margin-bottom: 4px;
+}
+
+.c21 {
+  position: relative;
 }
 
 .c23 {
@@ -35997,13 +36005,16 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   background: #eaeaef;
   padding: 4px;
   border-radius: 4px;
+  position: absolute;
+  right: 0px;
+  top: 50%;
   min-width: 20px;
 }
 
 .c29 {
   background: #f6f6f9;
-  padding-top: 4px;
-  padding-bottom: 4px;
+  padding-top: 8px;
+  padding-bottom: 8px;
   padding-left: 32px;
 }
 
@@ -36012,6 +36023,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
 }
 
 .c34 {
+  padding-bottom: 12px;
   padding-left: 32px;
 }
 
@@ -36026,14 +36038,18 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   padding-left: 32px;
 }
 
-.c43 {
+.c44 {
   background: #f6f6f9;
-  padding-top: 4px;
-  padding-bottom: 4px;
+  padding-top: 8px;
+  padding-bottom: 8px;
   padding-left: 48px;
 }
 
 .c45 {
+  padding-left: 32px;
+}
+
+.c47 {
   padding-right: 16px;
 }
 
@@ -36064,7 +36080,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   line-height: 1.33;
 }
 
-.c42 {
+.c43 {
   font-weight: 500;
   color: #32324d;
   font-size: 0.875rem;
@@ -36117,24 +36133,6 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   flex-direction: column;
 }
 
-.c21 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
 .c27 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -36151,6 +36149,24 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
+}
+
+.c40 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
 }
 
 .c35 {
@@ -36216,7 +36232,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
 }
 
 .c18 > * + * {
-  margin-top: 8px;
+  margin-top: 12px;
 }
 
 .c10 {
@@ -36389,22 +36405,18 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   fill: #666687;
 }
 
-.c46 {
+.c48 {
   width: 0.75rem;
   height: 0.25rem;
 }
 
-.c46 * {
+.c48 * {
   fill: #4945ff;
 }
 
-.c44 svg {
+.c46 svg {
   height: 0.75rem;
   width: 0.75rem;
-}
-
-.c39 {
-  max-height: 2rem;
 }
 
 .c39 svg {
@@ -36415,7 +36427,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   fill: #4a4a6a;
 }
 
-.c40 {
+.c41 {
   border: none;
   padding: 0;
   background: transparent;
@@ -36429,7 +36441,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   align-items: center;
 }
 
-.c41 {
+.c42 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -36464,10 +36476,6 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   transform: rotateX(0deg);
 }
 
-.c20 {
-  max-height: 2rem;
-}
-
 .c20 svg {
   height: 0.25rem;
 }
@@ -36485,6 +36493,9 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
 }
 
 <div
@@ -36562,7 +36573,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
             >
               <ul
                 class="c17 c18"
-                spacing="2"
+                spacing="3"
               >
                 <li>
                   <div
@@ -36619,7 +36630,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                         </div>
                       </div>
                     </div>
-                    <ul
+                    <ol
                       id="subnav-list-139"
                     >
                       <li>
@@ -36762,7 +36773,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           </div>
                         </a>
                       </li>
-                    </ul>
+                    </ol>
                   </div>
                 </li>
                 <li>
@@ -36854,7 +36865,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                         </div>
                       </div>
                     </div>
-                    <ul
+                    <ol
                       id="subnav-list-140"
                     >
                       <li>
@@ -36865,15 +36876,15 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             class="c38 c39"
                           >
                             <div
-                              class="c21"
+                              class="c40"
                             >
                               <button
                                 aria-controls="subnav-list-141"
                                 aria-expanded="true"
-                                class="c40"
+                                class="c41"
                               >
                                 <div
-                                  class="c41"
+                                  class="c42"
                                 >
                                   <svg
                                     aria-hidden="true"
@@ -36895,7 +36906,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                                   class="c32"
                                 >
                                   <span
-                                    class="c8 c42"
+                                    class="c8 c43"
                                   >
                                     Default
                                   </span>
@@ -36908,7 +36919,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           >
                             <li>
                               <a
-                                class="c43 c30"
+                                class="c44 c30"
                                 href="/address"
                               >
                                 <div
@@ -36943,7 +36954,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             </li>
                             <li>
                               <a
-                                class="c43 c30"
+                                class="c44 c30"
                                 href="/category"
                               >
                                 <div
@@ -36978,7 +36989,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             </li>
                             <li>
                               <a
-                                class="c43 c30"
+                                class="c44 c30"
                                 href="/city"
                               >
                                 <div
@@ -37013,7 +37024,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             </li>
                             <li>
                               <a
-                                class="c43 c30"
+                                class="c44 c30"
                                 href="/country"
                               >
                                 <div
@@ -37049,12 +37060,12 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           </ul>
                         </div>
                       </li>
-                    </ul>
+                    </ol>
                   </div>
                 </li>
                 <li>
                   <div
-                    class="c34"
+                    class="c45"
                   >
                     <button
                       aria-disabled="false"
@@ -37123,7 +37134,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
             >
               <ul
                 class="c17 c18"
-                spacing="2"
+                spacing="3"
               >
                 <li>
                   <a
@@ -37134,7 +37145,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       class="c3"
                     >
                       <div
-                        class="c44"
+                        class="c46"
                       >
                         <svg
                           fill="none"
@@ -37160,10 +37171,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       </div>
                     </div>
                     <div
-                      class="c3 sc-gsDKAQ c45"
+                      class="c3 sc-gsDKAQ c47"
                     >
                       <svg
-                        class="c46"
+                        class="c48"
                         fill="none"
                         height="1em"
                         viewBox="0 0 4 4"
@@ -37205,7 +37216,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                         </div>
                       </div>
                     </div>
-                    <ul
+                    <ol
                       id="subnav-list-143"
                     >
                       <li>
@@ -37217,7 +37228,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             class="c3"
                           >
                             <div
-                              class="c44"
+                              class="c46"
                             >
                               <svg
                                 fill="none"
@@ -37254,7 +37265,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             class="c3"
                           >
                             <div
-                              class="c44"
+                              class="c46"
                             >
                               <svg
                                 fill="none"
@@ -37282,7 +37293,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                         </a>
                       </li>
                       <li />
-                    </ul>
+                    </ol>
                   </div>
                 </li>
                 <li>
@@ -37310,7 +37321,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                         </div>
                       </div>
                     </div>
-                    <ul
+                    <ol
                       id="subnav-list-144"
                     >
                       <li>
@@ -37322,7 +37333,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             class="c3"
                           >
                             <div
-                              class="c44"
+                              class="c46"
                             >
                               <svg
                                 fill="none"
@@ -37359,7 +37370,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             class="c3"
                           >
                             <div
-                              class="c44"
+                              class="c46"
                             >
                               <svg
                                 fill="none"
@@ -37387,7 +37398,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                         </a>
                       </li>
                       <li />
-                    </ul>
+                    </ol>
                   </div>
                 </li>
               </ul>
@@ -37427,7 +37438,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
             >
               <ul
                 class="c17 c18"
-                spacing="2"
+                spacing="3"
               >
                 <li>
                   <a
@@ -37438,7 +37449,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       class="c3"
                     >
                       <div
-                        class="c44"
+                        class="c46"
                       >
                         <svg
                           fill="none"
@@ -37464,10 +37475,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       </div>
                     </div>
                     <div
-                      class="c3 sc-gsDKAQ c45"
+                      class="c3 sc-gsDKAQ c47"
                     >
                       <svg
-                        class="c46"
+                        class="c48"
                         fill="none"
                         height="1em"
                         viewBox="0 0 4 4"
@@ -37509,7 +37520,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                         </div>
                       </div>
                     </div>
-                    <ul
+                    <ol
                       id="subnav-list-146"
                     >
                       <li>
@@ -37520,15 +37531,15 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             class="c38 c39"
                           >
                             <div
-                              class="c21"
+                              class="c40"
                             >
                               <button
                                 aria-controls="subnav-list-147"
                                 aria-expanded="true"
-                                class="c40"
+                                class="c41"
                               >
                                 <div
-                                  class="c41"
+                                  class="c42"
                                 >
                                   <svg
                                     aria-hidden="true"
@@ -37550,7 +37561,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                                   class="c32"
                                 >
                                   <span
-                                    class="c8 c42"
+                                    class="c8 c43"
                                   >
                                     Sub section
                                   </span>
@@ -37563,14 +37574,14 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           >
                             <li>
                               <a
-                                class="c43 c30"
+                                class="c44 c30"
                                 href="/address"
                               >
                                 <div
                                   class="c3"
                                 >
                                   <div
-                                    class="c44"
+                                    class="c46"
                                   >
                                     <svg
                                       fill="none"
@@ -37599,7 +37610,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             </li>
                             <li>
                               <a
-                                class="c43 c30"
+                                class="c44 c30"
                                 href="/category"
                               >
                                 <div
@@ -37634,14 +37645,14 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             </li>
                             <li>
                               <a
-                                class="c43 c30"
+                                class="c44 c30"
                                 href="/city"
                               >
                                 <div
                                   class="c3"
                                 >
                                   <div
-                                    class="c44"
+                                    class="c46"
                                   >
                                     <svg
                                       fill="none"
@@ -37670,7 +37681,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             </li>
                             <li>
                               <a
-                                class="c43 c30"
+                                class="c44 c30"
                                 href="/country"
                               >
                                 <div
@@ -37706,7 +37717,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           </ul>
                         </div>
                       </li>
-                    </ul>
+                    </ol>
                   </div>
                 </li>
                 <li>
@@ -37734,7 +37745,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                         </div>
                       </div>
                     </div>
-                    <ul
+                    <ol
                       id="subnav-list-148"
                     >
                       <li>
@@ -37746,7 +37757,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             class="c3"
                           >
                             <div
-                              class="c44"
+                              class="c46"
                             >
                               <svg
                                 fill="none"
@@ -37817,7 +37828,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             class="c3"
                           >
                             <div
-                              class="c44"
+                              class="c46"
                             >
                               <svg
                                 fill="none"
@@ -37879,7 +37890,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           </div>
                         </a>
                       </li>
-                    </ul>
+                    </ol>
                   </div>
                 </li>
               </ul>

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -20169,23 +20169,27 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   padding-bottom: 16px;
 }
 
-.c20 {
+.c21 {
   padding-top: 4px;
   padding-right: 16px;
   padding-bottom: 4px;
   padding-left: 24px;
-  margin-bottom: 4px;
 }
 
-.c22 {
+.c23 {
+  padding-right: 24px;
   position: relative;
 }
 
-.c25 {
+.c24 {
+  text-align: left;
+}
+
+.c27 {
   padding-right: 4px;
 }
 
-.c28 {
+.c30 {
   background: #eaeaef;
   padding: 4px;
   border-radius: 4px;
@@ -20193,31 +20197,34 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   right: 0px;
   top: 50%;
   min-width: 20px;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
 }
 
-.c31 {
+.c32 {
   background: #f6f6f9;
   padding-top: 8px;
   padding-bottom: 8px;
   padding-left: 32px;
 }
 
-.c34 {
+.c35 {
   padding-left: 8px;
 }
 
-.c36 {
+.c37 {
   padding-top: 8px;
   padding-right: 16px;
   padding-bottom: 8px;
   padding-left: 32px;
 }
 
-.c42 {
+.c43 {
   padding-bottom: 56px;
 }
 
-.c44 {
+.c45 {
   background: #f6f6f9;
   padding-top: 40px;
   padding-right: 56px;
@@ -20225,28 +20232,28 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   padding-left: 56px;
 }
 
-.c46 {
+.c47 {
   padding-left: 16px;
 }
 
-.c48 {
+.c49 {
   padding-right: 8px;
 }
 
-.c53 {
+.c54 {
   padding-right: 56px;
   padding-left: 56px;
 }
 
-.c54 {
+.c55 {
   padding-bottom: 16px;
 }
 
-.c57 {
+.c58 {
   padding-top: 8px;
 }
 
-.c58 {
+.c59 {
   background: #f0f0ff;
   color: #4945ff;
   padding-right: 12px;
@@ -20258,31 +20265,31 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   height: 2rem;
 }
 
-.c65 {
+.c66 {
   background: #ffffff;
   border-radius: 4px;
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
 }
 
-.c68 {
+.c69 {
   padding-right: 24px;
   padding-left: 24px;
 }
 
-.c80 {
+.c81 {
   padding-left: 4px;
 }
 
-.c81 {
+.c82 {
   background: #f0f0ff;
   padding: 20px;
 }
 
-.c83 {
+.c84 {
   background: #d9d8ff;
 }
 
-.c85 {
+.c86 {
   padding-left: 12px;
 }
 
@@ -20293,7 +20300,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   line-height: 1.22;
 }
 
-.c26 {
+.c28 {
   color: #666687;
   font-weight: 600;
   font-size: 0.6875rem;
@@ -20301,47 +20308,47 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   text-transform: uppercase;
 }
 
-.c35 {
+.c36 {
   color: #32324d;
   font-size: 0.875rem;
   line-height: 1.43;
 }
 
-.c41 {
+.c42 {
   font-weight: 500;
   color: #32324d;
   font-size: 0.875rem;
   line-height: 1.43;
 }
 
-.c45 {
+.c46 {
   color: #32324d;
   font-weight: 600;
   font-size: 2rem;
   line-height: 1.25;
 }
 
-.c50 {
+.c51 {
   font-weight: 600;
   color: #32324d;
   font-size: 0.75rem;
   line-height: 1.33;
 }
 
-.c52 {
+.c53 {
   color: #666687;
   font-size: 1rem;
   line-height: 1.5;
 }
 
-.c64 {
+.c65 {
   font-weight: 600;
   color: #32324d;
   font-size: 0.875rem;
   line-height: 1.43;
 }
 
-.c76 {
+.c77 {
   color: #32324d;
   font-weight: 600;
   font-size: 0.6875rem;
@@ -20349,7 +20356,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   text-transform: uppercase;
 }
 
-.c86 {
+.c87 {
   font-weight: 600;
   color: #4945ff;
   font-size: 0.75rem;
@@ -20388,7 +20395,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   flex-direction: column;
 }
 
-.c23 {
+.c25 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -20402,7 +20409,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   flex-direction: row;
 }
 
-.c29 {
+.c31 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -20420,7 +20427,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   justify-content: center;
 }
 
-.c38 {
+.c39 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -20438,7 +20445,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   justify-content: space-between;
 }
 
-.c55 {
+.c56 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -20461,7 +20468,16 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
 }
 
 .c19 > * + * {
-  margin-top: 12px;
+  margin-top: 8px;
+}
+
+.c20 > * {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.c20 > * + * {
+  margin-top: 4px;
 }
 
 .c11 {
@@ -20562,19 +20578,19 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   fill: #666687;
 }
 
-.c79 {
+.c80 {
   border-radius: 50%;
   display: block;
   position: relative;
 }
 
-.c78 {
+.c79 {
   position: relative;
   width: 1.625rem;
   height: 1.625rem;
 }
 
-.c74 {
+.c75 {
   margin: 0;
   height: 18px;
   min-width: 18px;
@@ -20585,12 +20601,12 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   cursor: pointer;
 }
 
-.c74:checked {
+.c75:checked {
   background-color: #4945ff;
   border: 1px solid #4945ff;
 }
 
-.c74:checked:after {
+.c75:checked:after {
   content: '';
   display: block;
   position: relative;
@@ -20604,21 +20620,21 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   transform: translateX(-50%) translateY(-50%);
 }
 
-.c74:checked:disabled:after {
+.c75:checked:disabled:after {
   background: url(test-file-stub) no-repeat no-repeat center center;
 }
 
-.c74:disabled {
+.c75:disabled {
   background-color: #dcdce4;
   border: 1px solid #c0c0cf;
 }
 
-.c74:indeterminate {
+.c75:indeterminate {
   background-color: #4945ff;
   border: 1px solid #4945ff;
 }
 
-.c74:indeterminate:after {
+.c75:indeterminate:after {
   content: '';
   display: block;
   position: relative;
@@ -20633,20 +20649,20 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   transform: translateX(-50%) translateY(-50%);
 }
 
-.c74:indeterminate:disabled {
+.c75:indeterminate:disabled {
   background-color: #dcdce4;
   border: 1px solid #c0c0cf;
 }
 
-.c74:indeterminate:disabled:after {
+.c75:indeterminate:disabled:after {
   background-color: #8e8ea9;
 }
 
-.c49 {
+.c50 {
   height: 100%;
 }
 
-.c47 {
+.c48 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -20658,7 +20674,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   background: #ffffff;
 }
 
-.c47 .c0 {
+.c48 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -20669,56 +20685,56 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   align-items: center;
 }
 
-.c47 .c9 {
+.c48 .c9 {
   color: #ffffff;
 }
 
-.c47[aria-disabled='true'] {
+.c48[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c47[aria-disabled='true'] .c9 {
+.c48[aria-disabled='true'] .c9 {
   color: #666687;
 }
 
-.c47[aria-disabled='true'] svg > g,
-.c47[aria-disabled='true'] svg path {
+.c48[aria-disabled='true'] svg > g,
+.c48[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c47[aria-disabled='true']:active {
+.c48[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c47[aria-disabled='true']:active .c9 {
+.c48[aria-disabled='true']:active .c9 {
   color: #666687;
 }
 
-.c47[aria-disabled='true']:active svg > g,
-.c47[aria-disabled='true']:active svg path {
+.c48[aria-disabled='true']:active svg > g,
+.c48[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c47:hover {
+.c48:hover {
   background-color: #f6f6f9;
 }
 
-.c47:active {
+.c48:active {
   background-color: #eaeaef;
 }
 
-.c47 .c9 {
+.c48 .c9 {
   color: #32324d;
 }
 
-.c47 svg > g,
-.c47 svg path {
+.c48 svg > g,
+.c48 svg path {
   fill: #32324d;
 }
 
-.c51 {
+.c52 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -20728,7 +20744,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   border: 1px solid #4945ff;
 }
 
-.c51 .c0 {
+.c52 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -20739,54 +20755,54 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   align-items: center;
 }
 
-.c51 .c9 {
+.c52 .c9 {
   color: #ffffff;
 }
 
-.c51[aria-disabled='true'] {
+.c52[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c51[aria-disabled='true'] .c9 {
+.c52[aria-disabled='true'] .c9 {
   color: #666687;
 }
 
-.c51[aria-disabled='true'] svg > g,
-.c51[aria-disabled='true'] svg path {
+.c52[aria-disabled='true'] svg > g,
+.c52[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c51[aria-disabled='true']:active {
+.c52[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c51[aria-disabled='true']:active .c9 {
+.c52[aria-disabled='true']:active .c9 {
   color: #666687;
 }
 
-.c51[aria-disabled='true']:active svg > g,
-.c51[aria-disabled='true']:active svg path {
+.c52[aria-disabled='true']:active svg > g,
+.c52[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c51:hover {
+.c52:hover {
   border: 1px solid #7b79ff;
   background: #7b79ff;
 }
 
-.c51:active {
+.c52:active {
   border: 1px solid #4945ff;
   background: #4945ff;
 }
 
-.c51 svg > g,
-.c51 svg path {
+.c52 svg > g,
+.c52 svg path {
   fill: #ffffff;
 }
 
-.c63 {
+.c64 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -20798,7 +20814,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   background: #ffffff;
 }
 
-.c63 .c0 {
+.c64 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -20809,52 +20825,52 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   align-items: center;
 }
 
-.c63 .c9 {
+.c64 .c9 {
   color: #ffffff;
 }
 
-.c63[aria-disabled='true'] {
+.c64[aria-disabled='true'] {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c63[aria-disabled='true'] .c9 {
+.c64[aria-disabled='true'] .c9 {
   color: #666687;
 }
 
-.c63[aria-disabled='true'] svg > g,
-.c63[aria-disabled='true'] svg path {
+.c64[aria-disabled='true'] svg > g,
+.c64[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c63[aria-disabled='true']:active {
+.c64[aria-disabled='true']:active {
   border: 1px solid #dcdce4;
   background: #eaeaef;
 }
 
-.c63[aria-disabled='true']:active .c9 {
+.c64[aria-disabled='true']:active .c9 {
   color: #666687;
 }
 
-.c63[aria-disabled='true']:active svg > g,
-.c63[aria-disabled='true']:active svg path {
+.c64[aria-disabled='true']:active svg > g,
+.c64[aria-disabled='true']:active svg path {
   fill: #666687;
 }
 
-.c63:hover {
+.c64:hover {
   background-color: #f6f6f9;
 }
 
-.c63:active {
+.c64:active {
   background-color: #eaeaef;
 }
 
-.c63 .c9 {
+.c64 .c9 {
   color: #32324d;
 }
 
-.c63 svg > g,
-.c63 svg path {
+.c64 svg > g,
+.c64 svg path {
   fill: #32324d;
 }
 
@@ -20881,7 +20897,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   background-color: #dcdce4;
 }
 
-.c32 {
+.c33 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -20899,46 +20915,46 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   color: #32324d;
 }
 
-.c32 svg > * {
+.c33 svg > * {
   fill: #666687;
 }
 
-.c32.active {
+.c33.active {
   background-color: #f0f0ff;
   border-right: 2px solid #4945ff;
 }
 
-.c32.active svg > * {
+.c33.active svg > * {
   fill: #271fe0;
 }
 
-.c32.active .c9 {
+.c33.active .c9 {
   color: #271fe0;
   font-weight: 500;
 }
 
-.c32:focus-visible {
+.c33:focus-visible {
   outline-offset: -2px;
 }
 
-.c33 {
+.c34 {
   width: 0.75rem;
   height: 0.25rem;
 }
 
-.c33 * {
+.c34 * {
   fill: #666687;
 }
 
-.c37 svg {
+.c38 svg {
   height: 0.25rem;
 }
 
-.c37 svg path {
+.c38 svg path {
   fill: #4a4a6a;
 }
 
-.c39 {
+.c40 {
   border: none;
   padding: 0;
   background: transparent;
@@ -20952,7 +20968,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   align-items: center;
 }
 
-.c40 {
+.c41 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -20967,13 +20983,13 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   transform: rotateX(0deg);
 }
 
-.c24 {
+.c26 {
   border: none;
   padding: 0;
   background: transparent;
 }
 
-.c27 {
+.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -20987,26 +21003,12 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   transform: rotateX(0deg);
 }
 
-.c21 svg {
+.c22 svg {
   height: 0.25rem;
 }
 
-.c21 svg path {
+.c22 svg path {
   fill: #8e8ea9;
-}
-
-.c30 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
 }
 
 .c5 {
@@ -21014,43 +21016,43 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   grid-template-columns: auto 1fr;
 }
 
-.c43 {
+.c44 {
   overflow-x: hidden;
 }
 
-.c56 > * + * {
-  margin-left: 8px;
-}
-
-.c61 {
-  margin-left: auto;
-}
-
-.c61 > * + * {
+.c57 > * + * {
   margin-left: 8px;
 }
 
 .c62 {
+  margin-left: auto;
+}
+
+.c62 > * + * {
+  margin-left: 8px;
+}
+
+.c63 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c66 {
+.c67 {
   overflow: hidden;
   border: 1px solid #eaeaef;
 }
 
-.c70 {
+.c71 {
   width: 100%;
   white-space: nowrap;
 }
 
-.c67 {
+.c68 {
   position: relative;
 }
 
-.c67:before {
+.c68:before {
   background: linear-gradient(90deg,#c0c0cf 0%,rgba(0,0,0,0) 100%);
   opacity: 0.2;
   position: absolute;
@@ -21060,7 +21062,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   left: 0;
 }
 
-.c67:after {
+.c68:after {
   background: linear-gradient(270deg,#c0c0cf 0%,rgba(0,0,0,0) 100%);
   opacity: 0.2;
   position: absolute;
@@ -21071,54 +21073,54 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   top: 0;
 }
 
-.c69 {
+.c70 {
   overflow-x: auto;
 }
 
-.c77 tr:last-of-type {
+.c78 tr:last-of-type {
   border-bottom: none;
-}
-
-.c71 {
-  border-bottom: 1px solid #eaeaef;
 }
 
 .c72 {
   border-bottom: 1px solid #eaeaef;
 }
 
-.c72 td,
-.c72 th {
+.c73 {
+  border-bottom: 1px solid #eaeaef;
+}
+
+.c73 td,
+.c73 th {
   padding: 16px;
 }
 
-.c72 td:first-of-type,
-.c72 th:first-of-type {
+.c73 td:first-of-type,
+.c73 th:first-of-type {
   padding: 0 4px;
 }
 
-.c72 th {
+.c73 th {
   padding-top: 0;
   padding-bottom: 0;
   height: 3.5rem;
 }
 
-.c73 {
+.c74 {
   vertical-align: middle;
   text-align: left;
   color: #666687;
   outline-offset: -4px;
 }
 
-.c73 input {
+.c74 input {
   vertical-align: sub;
 }
 
-.c75 svg {
+.c76 svg {
   height: 0.25rem;
 }
 
-.c84 {
+.c85 {
   height: 1.5rem;
   width: 1.5rem;
   border-radius: 50%;
@@ -21136,32 +21138,32 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
   align-items: center;
 }
 
-.c84 svg {
+.c85 svg {
   height: 0.625rem;
   width: 0.625rem;
 }
 
-.c84 svg path {
+.c85 svg path {
   fill: #4945ff;
 }
 
-.c82 {
+.c83 {
   border-radius: 0 0 4px 4px;
   display: block;
   width: 100%;
   border: none;
 }
 
-.c59 svg {
+.c60 svg {
   height: 0.5rem;
   width: 0.5rem;
 }
 
-.c59 svg path {
+.c60 svg path {
   fill: #4945ff;
 }
 
-.c60 {
+.c61 {
   border-right: 1px solid #d9d8ff;
   color: inherit;
   padding-right: 8px;
@@ -21239,36 +21241,37 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
             <div
               class="c0 c17"
             >
-              <ul
+              <ol
                 class="c0 c18 c19"
-                spacing="3"
+                spacing="2"
               >
                 <li>
                   <div
-                    class="c0 "
+                    class="c0 c18 c20"
+                    spacing="1"
                   >
                     <div
-                      class="c0 c20 c21"
+                      class="c0 c21 c22"
                     >
                       <div
-                        class="c0 c22"
+                        class="c0 c23"
                       >
                         <button
                           aria-controls="subnav-list-88"
                           aria-expanded="true"
-                          class="c0 c23 c24"
+                          class="c0 c24 c25 c26"
                         >
                           <div
-                            class="c0 c25"
+                            class="c0 c27"
                           >
                             <span
-                              class="c9 c26"
+                              class="c9 c28"
                             >
                               Collection Type
                             </span>
                           </div>
                           <div
-                            class="c27"
+                            class="c29"
                           >
                             <svg
                               aria-hidden="true"
@@ -21288,10 +21291,11 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </div>
                         </button>
                         <div
-                          class="c0 c28 c29 c30"
+                          class="c0 c30 c31"
+                          transform="translateY(-50%)"
                         >
                           <span
-                            class="c9 c26"
+                            class="c9 c28"
                           >
                             4
                           </span>
@@ -21303,14 +21307,14 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                     >
                       <li>
                         <a
-                          class="c0 c31 c32"
+                          class="c0 c32 c33"
                           href="/address"
                         >
                           <div
-                            class="c0 c23"
+                            class="c0 c25"
                           >
                             <svg
-                              class="c33"
+                              class="c34"
                               fill="none"
                               height="1em"
                               viewBox="0 0 4 4"
@@ -21325,10 +21329,10 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                               />
                             </svg>
                             <div
-                              class="c0 c34"
+                              class="c0 c35"
                             >
                               <span
-                                class="c9 c35"
+                                class="c9 c36"
                               >
                                 Addresses
                               </span>
@@ -21338,14 +21342,14 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </li>
                       <li>
                         <a
-                          class="c0 c31 c32"
+                          class="c0 c32 c33"
                           href="/category"
                         >
                           <div
-                            class="c0 c23"
+                            class="c0 c25"
                           >
                             <svg
-                              class="c33"
+                              class="c34"
                               fill="none"
                               height="1em"
                               viewBox="0 0 4 4"
@@ -21360,10 +21364,10 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                               />
                             </svg>
                             <div
-                              class="c0 c34"
+                              class="c0 c35"
                             >
                               <span
-                                class="c9 c35"
+                                class="c9 c36"
                               >
                                 Categories
                               </span>
@@ -21373,14 +21377,14 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </li>
                       <li>
                         <a
-                          class="c0 c31 c32"
+                          class="c0 c32 c33"
                           href="/city"
                         >
                           <div
-                            class="c0 c23"
+                            class="c0 c25"
                           >
                             <svg
-                              class="c33"
+                              class="c34"
                               fill="none"
                               height="1em"
                               viewBox="0 0 4 4"
@@ -21395,10 +21399,10 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                               />
                             </svg>
                             <div
-                              class="c0 c34"
+                              class="c0 c35"
                             >
                               <span
-                                class="c9 c35"
+                                class="c9 c36"
                               >
                                 Cities
                               </span>
@@ -21408,14 +21412,14 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </li>
                       <li>
                         <a
-                          class="c0 c31 c32"
+                          class="c0 c32 c33"
                           href="/country"
                         >
                           <div
-                            class="c0 c23"
+                            class="c0 c25"
                           >
                             <svg
-                              class="c33"
+                              class="c34"
                               fill="none"
                               height="1em"
                               viewBox="0 0 4 4"
@@ -21430,10 +21434,10 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                               />
                             </svg>
                             <div
-                              class="c0 c34"
+                              class="c0 c35"
                             >
                               <span
-                                class="c9 c35"
+                                class="c9 c36"
                               >
                                 Countries
                               </span>
@@ -21446,30 +21450,31 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                 </li>
                 <li>
                   <div
-                    class="c0 "
+                    class="c0 c18 c20"
+                    spacing="1"
                   >
                     <div
-                      class="c0 c20 c21"
+                      class="c0 c21 c22"
                     >
                       <div
-                        class="c0 c22"
+                        class="c0 c23"
                       >
                         <button
                           aria-controls="subnav-list-89"
                           aria-expanded="true"
-                          class="c0 c23 c24"
+                          class="c0 c24 c25 c26"
                         >
                           <div
-                            class="c0 c25"
+                            class="c0 c27"
                           >
                             <span
-                              class="c9 c26"
+                              class="c9 c28"
                             >
                               Single Type
                             </span>
                           </div>
                           <div
-                            class="c27"
+                            class="c29"
                           >
                             <svg
                               aria-hidden="true"
@@ -21489,10 +21494,11 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </div>
                         </button>
                         <div
-                          class="c0 c28 c29 c30"
+                          class="c0 c30 c31"
+                          transform="translateY(-50%)"
                         >
                           <span
-                            class="c9 c26"
+                            class="c9 c28"
                           >
                             4
                           </span>
@@ -21507,18 +21513,18 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           class="c0 "
                         >
                           <div
-                            class="c0 c36 c37"
+                            class="c0 c37 c38"
                           >
                             <div
-                              class="c0 c38"
+                              class="c0 c39"
                             >
                               <button
                                 aria-controls="subnav-list-90"
                                 aria-expanded="true"
-                                class="c39"
+                                class="c40"
                               >
                                 <div
-                                  class="c40"
+                                  class="c41"
                                 >
                                   <svg
                                     aria-hidden="true"
@@ -21537,10 +21543,10 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                                   </svg>
                                 </div>
                                 <div
-                                  class="c0 c34"
+                                  class="c0 c35"
                                 >
                                   <span
-                                    class="c9 c41"
+                                    class="c9 c42"
                                   >
                                     Default
                                   </span>
@@ -21553,14 +21559,14 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           >
                             <li>
                               <a
-                                class="c0 c31 c32"
+                                class="c0 c32 c33"
                                 href="/address"
                               >
                                 <div
-                                  class="c0 c23"
+                                  class="c0 c25"
                                 >
                                   <svg
-                                    class="c33"
+                                    class="c34"
                                     fill="none"
                                     height="1em"
                                     viewBox="0 0 4 4"
@@ -21575,10 +21581,10 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                                     />
                                   </svg>
                                   <div
-                                    class="c0 c34"
+                                    class="c0 c35"
                                   >
                                     <span
-                                      class="c9 c35"
+                                      class="c9 c36"
                                     >
                                       Addresses
                                     </span>
@@ -21588,14 +21594,14 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                             </li>
                             <li>
                               <a
-                                class="c0 c31 c32"
+                                class="c0 c32 c33"
                                 href="/category"
                               >
                                 <div
-                                  class="c0 c23"
+                                  class="c0 c25"
                                 >
                                   <svg
-                                    class="c33"
+                                    class="c34"
                                     fill="none"
                                     height="1em"
                                     viewBox="0 0 4 4"
@@ -21610,10 +21616,10 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                                     />
                                   </svg>
                                   <div
-                                    class="c0 c34"
+                                    class="c0 c35"
                                   >
                                     <span
-                                      class="c9 c35"
+                                      class="c9 c36"
                                     >
                                       Categories
                                     </span>
@@ -21623,14 +21629,14 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                             </li>
                             <li>
                               <a
-                                class="c0 c31 c32"
+                                class="c0 c32 c33"
                                 href="/city"
                               >
                                 <div
-                                  class="c0 c23"
+                                  class="c0 c25"
                                 >
                                   <svg
-                                    class="c33"
+                                    class="c34"
                                     fill="none"
                                     height="1em"
                                     viewBox="0 0 4 4"
@@ -21645,10 +21651,10 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                                     />
                                   </svg>
                                   <div
-                                    class="c0 c34"
+                                    class="c0 c35"
                                   >
                                     <span
-                                      class="c9 c35"
+                                      class="c9 c36"
                                     >
                                       Cities
                                     </span>
@@ -21658,14 +21664,14 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                             </li>
                             <li>
                               <a
-                                class="c0 c31 c32"
+                                class="c0 c32 c33"
                                 href="/country"
                               >
                                 <div
-                                  class="c0 c23"
+                                  class="c0 c25"
                                 >
                                   <svg
-                                    class="c33"
+                                    class="c34"
                                     fill="none"
                                     height="1em"
                                     viewBox="0 0 4 4"
@@ -21680,10 +21686,10 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                                     />
                                   </svg>
                                   <div
-                                    class="c0 c34"
+                                    class="c0 c35"
                                   >
                                     <span
-                                      class="c9 c35"
+                                      class="c9 c36"
                                     >
                                       Countries
                                     </span>
@@ -21697,41 +21703,41 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                     </ol>
                   </div>
                 </li>
-              </ul>
+              </ol>
             </div>
           </nav>
           <div
-            class="c0 c42 c43"
+            class="c0 c43 c44"
           >
             <div
               style="height: 0px;"
             >
               <div
-                class="c0 c44"
+                class="c0 c45"
                 data-strapi-header="true"
               >
                 <div
-                  class="c0 c38"
+                  class="c0 c39"
                 >
                   <div
-                    class="c0 c23"
+                    class="c0 c25"
                   >
                     <h2
-                      class="c9 c45"
+                      class="c9 c46"
                     >
                       Other CT
                     </h2>
                     <div
-                      class="c0 c46"
+                      class="c0 c47"
                     >
                       <button
                         aria-disabled="false"
-                        class="c11 c47"
+                        class="c11 c48"
                         type="button"
                       >
                         <div
                           aria-hidden="true"
-                          class="c0 c48 c49"
+                          class="c0 c49 c50"
                         >
                           <svg
                             fill="none"
@@ -21749,7 +21755,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </svg>
                         </div>
                         <span
-                          class="c9 c50"
+                          class="c9 c51"
                         >
                           Edit
                         </span>
@@ -21758,12 +21764,12 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                   </div>
                   <button
                     aria-disabled="false"
-                    class="c11 c51"
+                    class="c11 c52"
                     type="button"
                   >
                     <div
                       aria-hidden="true"
-                      class="c0 c48 c49"
+                      class="c0 c49 c50"
                     >
                       <svg
                         fill="none"
@@ -21779,54 +21785,54 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </svg>
                     </div>
                     <span
-                      class="c9 c50"
+                      class="c9 c51"
                     >
                       Add an entry
                     </span>
                   </button>
                 </div>
                 <p
-                  class="c9 c52"
+                  class="c9 c53"
                 >
                   36 entries found
                 </p>
               </div>
             </div>
             <div
-              class="c0 c53"
+              class="c0 c54"
             >
               <div
-                class="c0 c54"
+                class="c0 c55"
               >
                 <div
                   class="c0 c8"
                 >
                   <div
-                    class="c0 c55 c56"
+                    class="c0 c56 c57"
                     wrap="wrap"
                   >
                     <div
-                      class="c0 c57"
+                      class="c0 c58"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c58 c59"
+                        class="c0 c59 c60"
                         height="2rem"
                       >
                         <div
-                          class="c0 c23"
+                          class="c0 c25"
                         >
                           <span
-                            class="c9 c50 c60"
+                            class="c9 c51 c61"
                           >
                             Hello world 
                             0
                           </span>
                           <div
-                            class="c0 c34"
+                            class="c0 c35"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <svg
                                 aria-hidden="true"
@@ -21847,27 +21853,27 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c57"
+                      class="c0 c58"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c58 c59"
+                        class="c0 c59 c60"
                         height="2rem"
                       >
                         <div
-                          class="c0 c23"
+                          class="c0 c25"
                         >
                           <span
-                            class="c9 c50 c60"
+                            class="c9 c51 c61"
                           >
                             Hello world 
                             1
                           </span>
                           <div
-                            class="c0 c34"
+                            class="c0 c35"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <svg
                                 aria-hidden="true"
@@ -21888,27 +21894,27 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c57"
+                      class="c0 c58"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c58 c59"
+                        class="c0 c59 c60"
                         height="2rem"
                       >
                         <div
-                          class="c0 c23"
+                          class="c0 c25"
                         >
                           <span
-                            class="c9 c50 c60"
+                            class="c9 c51 c61"
                           >
                             Hello world 
                             2
                           </span>
                           <div
-                            class="c0 c34"
+                            class="c0 c35"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <svg
                                 aria-hidden="true"
@@ -21929,27 +21935,27 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c57"
+                      class="c0 c58"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c58 c59"
+                        class="c0 c59 c60"
                         height="2rem"
                       >
                         <div
-                          class="c0 c23"
+                          class="c0 c25"
                         >
                           <span
-                            class="c9 c50 c60"
+                            class="c9 c51 c61"
                           >
                             Hello world 
                             3
                           </span>
                           <div
-                            class="c0 c34"
+                            class="c0 c35"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <svg
                                 aria-hidden="true"
@@ -21970,27 +21976,27 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c57"
+                      class="c0 c58"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c58 c59"
+                        class="c0 c59 c60"
                         height="2rem"
                       >
                         <div
-                          class="c0 c23"
+                          class="c0 c25"
                         >
                           <span
-                            class="c9 c50 c60"
+                            class="c9 c51 c61"
                           >
                             Hello world 
                             4
                           </span>
                           <div
-                            class="c0 c34"
+                            class="c0 c35"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <svg
                                 aria-hidden="true"
@@ -22011,27 +22017,27 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c57"
+                      class="c0 c58"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c58 c59"
+                        class="c0 c59 c60"
                         height="2rem"
                       >
                         <div
-                          class="c0 c23"
+                          class="c0 c25"
                         >
                           <span
-                            class="c9 c50 c60"
+                            class="c9 c51 c61"
                           >
                             Hello world 
                             5
                           </span>
                           <div
-                            class="c0 c34"
+                            class="c0 c35"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <svg
                                 aria-hidden="true"
@@ -22052,27 +22058,27 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c57"
+                      class="c0 c58"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c58 c59"
+                        class="c0 c59 c60"
                         height="2rem"
                       >
                         <div
-                          class="c0 c23"
+                          class="c0 c25"
                         >
                           <span
-                            class="c9 c50 c60"
+                            class="c9 c51 c61"
                           >
                             Hello world 
                             6
                           </span>
                           <div
-                            class="c0 c34"
+                            class="c0 c35"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <svg
                                 aria-hidden="true"
@@ -22093,27 +22099,27 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c57"
+                      class="c0 c58"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c58 c59"
+                        class="c0 c59 c60"
                         height="2rem"
                       >
                         <div
-                          class="c0 c23"
+                          class="c0 c25"
                         >
                           <span
-                            class="c9 c50 c60"
+                            class="c9 c51 c61"
                           >
                             Hello world 
                             7
                           </span>
                           <div
-                            class="c0 c34"
+                            class="c0 c35"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <svg
                                 aria-hidden="true"
@@ -22134,27 +22140,27 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c57"
+                      class="c0 c58"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c58 c59"
+                        class="c0 c59 c60"
                         height="2rem"
                       >
                         <div
-                          class="c0 c23"
+                          class="c0 c25"
                         >
                           <span
-                            class="c9 c50 c60"
+                            class="c9 c51 c61"
                           >
                             Hello world 
                             8
                           </span>
                           <div
-                            class="c0 c34"
+                            class="c0 c35"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <svg
                                 aria-hidden="true"
@@ -22175,27 +22181,27 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c57"
+                      class="c0 c58"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c58 c59"
+                        class="c0 c59 c60"
                         height="2rem"
                       >
                         <div
-                          class="c0 c23"
+                          class="c0 c25"
                         >
                           <span
-                            class="c9 c50 c60"
+                            class="c9 c51 c61"
                           >
                             Hello world 
                             9
                           </span>
                           <div
-                            class="c0 c34"
+                            class="c0 c35"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <svg
                                 aria-hidden="true"
@@ -22216,27 +22222,27 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c57"
+                      class="c0 c58"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c58 c59"
+                        class="c0 c59 c60"
                         height="2rem"
                       >
                         <div
-                          class="c0 c23"
+                          class="c0 c25"
                         >
                           <span
-                            class="c9 c50 c60"
+                            class="c9 c51 c61"
                           >
                             Hello world 
                             10
                           </span>
                           <div
-                            class="c0 c34"
+                            class="c0 c35"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <svg
                                 aria-hidden="true"
@@ -22257,27 +22263,27 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c57"
+                      class="c0 c58"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c58 c59"
+                        class="c0 c59 c60"
                         height="2rem"
                       >
                         <div
-                          class="c0 c23"
+                          class="c0 c25"
                         >
                           <span
-                            class="c9 c50 c60"
+                            class="c9 c51 c61"
                           >
                             Hello world 
                             11
                           </span>
                           <div
-                            class="c0 c34"
+                            class="c0 c35"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <svg
                                 aria-hidden="true"
@@ -22298,27 +22304,27 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c57"
+                      class="c0 c58"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c58 c59"
+                        class="c0 c59 c60"
                         height="2rem"
                       >
                         <div
-                          class="c0 c23"
+                          class="c0 c25"
                         >
                           <span
-                            class="c9 c50 c60"
+                            class="c9 c51 c61"
                           >
                             Hello world 
                             12
                           </span>
                           <div
-                            class="c0 c34"
+                            class="c0 c35"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <svg
                                 aria-hidden="true"
@@ -22339,27 +22345,27 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c57"
+                      class="c0 c58"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c58 c59"
+                        class="c0 c59 c60"
                         height="2rem"
                       >
                         <div
-                          class="c0 c23"
+                          class="c0 c25"
                         >
                           <span
-                            class="c9 c50 c60"
+                            class="c9 c51 c61"
                           >
                             Hello world 
                             13
                           </span>
                           <div
-                            class="c0 c34"
+                            class="c0 c35"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <svg
                                 aria-hidden="true"
@@ -22380,27 +22386,27 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c57"
+                      class="c0 c58"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c58 c59"
+                        class="c0 c59 c60"
                         height="2rem"
                       >
                         <div
-                          class="c0 c23"
+                          class="c0 c25"
                         >
                           <span
-                            class="c9 c50 c60"
+                            class="c9 c51 c61"
                           >
                             Hello world 
                             14
                           </span>
                           <div
-                            class="c0 c34"
+                            class="c0 c35"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <svg
                                 aria-hidden="true"
@@ -22421,27 +22427,27 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c57"
+                      class="c0 c58"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c58 c59"
+                        class="c0 c59 c60"
                         height="2rem"
                       >
                         <div
-                          class="c0 c23"
+                          class="c0 c25"
                         >
                           <span
-                            class="c9 c50 c60"
+                            class="c9 c51 c61"
                           >
                             Hello world 
                             15
                           </span>
                           <div
-                            class="c0 c34"
+                            class="c0 c35"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <svg
                                 aria-hidden="true"
@@ -22462,27 +22468,27 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c57"
+                      class="c0 c58"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c58 c59"
+                        class="c0 c59 c60"
                         height="2rem"
                       >
                         <div
-                          class="c0 c23"
+                          class="c0 c25"
                         >
                           <span
-                            class="c9 c50 c60"
+                            class="c9 c51 c61"
                           >
                             Hello world 
                             16
                           </span>
                           <div
-                            class="c0 c34"
+                            class="c0 c35"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <svg
                                 aria-hidden="true"
@@ -22503,27 +22509,27 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c57"
+                      class="c0 c58"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c58 c59"
+                        class="c0 c59 c60"
                         height="2rem"
                       >
                         <div
-                          class="c0 c23"
+                          class="c0 c25"
                         >
                           <span
-                            class="c9 c50 c60"
+                            class="c9 c51 c61"
                           >
                             Hello world 
                             17
                           </span>
                           <div
-                            class="c0 c34"
+                            class="c0 c35"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <svg
                                 aria-hidden="true"
@@ -22544,27 +22550,27 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c57"
+                      class="c0 c58"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c58 c59"
+                        class="c0 c59 c60"
                         height="2rem"
                       >
                         <div
-                          class="c0 c23"
+                          class="c0 c25"
                         >
                           <span
-                            class="c9 c50 c60"
+                            class="c9 c51 c61"
                           >
                             Hello world 
                             18
                           </span>
                           <div
-                            class="c0 c34"
+                            class="c0 c35"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <svg
                                 aria-hidden="true"
@@ -22585,27 +22591,27 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </button>
                     </div>
                     <div
-                      class="c0 c57"
+                      class="c0 c58"
                     >
                       <button
                         aria-disabled="false"
-                        class="c0 c58 c59"
+                        class="c0 c59 c60"
                         height="2rem"
                       >
                         <div
-                          class="c0 c23"
+                          class="c0 c25"
                         >
                           <span
-                            class="c9 c50 c60"
+                            class="c9 c51 c61"
                           >
                             Hello world 
                             19
                           </span>
                           <div
-                            class="c0 c34"
+                            class="c0 c35"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <svg
                                 aria-hidden="true"
@@ -22627,26 +22633,26 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c0 c23 c61 c62"
+                    class="c0 c25 c62 c63"
                   >
                     <button
                       aria-disabled="false"
-                      class="c11 c63"
+                      class="c11 c64"
                       type="button"
                     >
                       <span
-                        class="c9 c64"
+                        class="c9 c65"
                       >
                         Settings
                       </span>
                     </button>
                     <button
                       aria-disabled="false"
-                      class="c11 c63"
+                      class="c11 c64"
                       type="button"
                     >
                       <span
-                        class="c9 c64"
+                        class="c9 c65"
                       >
                         Settings
                       </span>
@@ -22656,186 +22662,186 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
               </div>
             </div>
             <div
-              class="c0 c53"
+              class="c0 c54"
             >
               <div
-                class="c0 c65 c66"
+                class="c0 c66 c67"
               >
                 <div
-                  class="c0 c67"
+                  class="c0 c68"
                 >
                   <div
-                    class="c0 c68 c69"
+                    class="c0 c69 c70"
                   >
                     <table
                       aria-colcount="10"
                       aria-rowcount="6"
-                      class="c70"
+                      class="c71"
                     >
                       <thead
-                        class="c71"
+                        class="c72"
                       >
                         <tr
                           aria-rowindex="1"
-                          class="c0 c72"
+                          class="c0 c73"
                         >
                           <th
                             aria-colindex="1"
-                            class="c0 c73"
+                            class="c0 c74"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <input
                                 aria-label="Select all entries"
-                                class="c74"
+                                class="c75"
                                 tabindex="0"
                                 type="checkbox"
                               />
                               <span
-                                class="c75"
+                                class="c76"
                               />
                             </div>
                           </th>
                           <th
                             aria-colindex="2"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <span
-                                class="c9 c76"
+                                class="c9 c77"
                               >
                                 ID
                               </span>
                               <span
-                                class="c75"
+                                class="c76"
                               />
                             </div>
                           </th>
                           <th
                             aria-colindex="3"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <span
-                                class="c9 c76"
+                                class="c9 c77"
                               >
                                 Cover
                               </span>
                               <span
-                                class="c75"
+                                class="c76"
                               />
                             </div>
                           </th>
                           <th
                             aria-colindex="4"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <span
-                                class="c9 c76"
+                                class="c9 c77"
                               >
                                 Description
                               </span>
                               <span
-                                class="c75"
+                                class="c76"
                               />
                             </div>
                           </th>
                           <th
                             aria-colindex="5"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <span
-                                class="c9 c76"
+                                class="c9 c77"
                               >
                                 Categories
                               </span>
                               <span
-                                class="c75"
+                                class="c76"
                               />
                             </div>
                           </th>
                           <th
                             aria-colindex="6"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <span
-                                class="c9 c76"
+                                class="c9 c77"
                               >
                                 Contact
                               </span>
                               <span
-                                class="c75"
+                                class="c76"
                               />
                             </div>
                           </th>
                           <th
                             aria-colindex="7"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               More
                               <span
-                                class="c75"
+                                class="c76"
                               />
                             </div>
                           </th>
                           <th
                             aria-colindex="8"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               More
                               <span
-                                class="c75"
+                                class="c76"
                               />
                             </div>
                           </th>
                           <th
                             aria-colindex="9"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               More
                               <span
-                                class="c75"
+                                class="c76"
                               />
                             </div>
                           </th>
                           <th
                             aria-colindex="10"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <div
                                 class="c2"
@@ -22843,53 +22849,53 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                                 Actions
                               </div>
                               <span
-                                class="c75"
+                                class="c76"
                               />
                             </div>
                           </th>
                         </tr>
                       </thead>
                       <tbody
-                        class="c77"
+                        class="c78"
                       >
                         <tr
                           aria-rowindex="2"
-                          class="c0 c72"
+                          class="c0 c73"
                         >
                           <td
                             aria-colindex="1"
-                            class="c0 c73"
+                            class="c0 c74"
                           >
                             <input
                               aria-label="Select Leon Lafrite"
-                              class="c74"
+                              class="c75"
                               tabindex="-1"
                               type="checkbox"
                             />
                           </td>
                           <td
                             aria-colindex="2"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               0
                             </span>
                           </td>
                           <td
                             aria-colindex="3"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span>
                               <div
-                                class="c78"
+                                class="c79"
                               >
                                 <img
                                   alt="Leon Lafrite"
-                                  class="c79"
+                                  class="c80"
                                   height="26px"
                                   src="https://avatars.githubusercontent.com/u/3874873?v=4"
                                   width="26px"
@@ -22899,76 +22905,76 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="4"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               Chez Léon is a human sized Parisian
                             </span>
                           </td>
                           <td
                             aria-colindex="5"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               French cuisine
                             </span>
                           </td>
                           <td
                             aria-colindex="6"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               Leon Lafrite
                             </span>
                           </td>
                           <td
                             aria-colindex="7"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               Chez Léon is a human sized Parisian
                             </span>
                           </td>
                           <td
                             aria-colindex="8"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               Chez Léon is a human sized Parisian
                             </span>
                           </td>
                           <td
                             aria-colindex="9"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               Chez Léon is a human sized Parisian
                             </span>
                           </td>
                           <td
                             aria-colindex="10"
-                            class="c0 c73"
+                            class="c0 c74"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <span>
                                 <button
@@ -22995,7 +23001,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                                 </button>
                               </span>
                               <div
-                                class="c0 c80"
+                                class="c0 c81"
                               >
                                 <span>
                                   <button
@@ -23025,42 +23031,42 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                         </tr>
                         <tr
                           aria-rowindex="3"
-                          class="c0 c72"
+                          class="c0 c73"
                         >
                           <td
                             aria-colindex="1"
-                            class="c0 c73"
+                            class="c0 c74"
                           >
                             <input
                               aria-label="Select Leon Lafrite"
-                              class="c74"
+                              class="c75"
                               tabindex="-1"
                               type="checkbox"
                             />
                           </td>
                           <td
                             aria-colindex="2"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               1
                             </span>
                           </td>
                           <td
                             aria-colindex="3"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span>
                               <div
-                                class="c78"
+                                class="c79"
                               >
                                 <img
                                   alt="Leon Lafrite"
-                                  class="c79"
+                                  class="c80"
                                   height="26px"
                                   src="https://avatars.githubusercontent.com/u/3874873?v=4"
                                   width="26px"
@@ -23070,76 +23076,76 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="4"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               Chez Léon is a human sized Parisian
                             </span>
                           </td>
                           <td
                             aria-colindex="5"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               French cuisine
                             </span>
                           </td>
                           <td
                             aria-colindex="6"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               Leon Lafrite
                             </span>
                           </td>
                           <td
                             aria-colindex="7"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               Chez Léon is a human sized Parisian
                             </span>
                           </td>
                           <td
                             aria-colindex="8"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               Chez Léon is a human sized Parisian
                             </span>
                           </td>
                           <td
                             aria-colindex="9"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               Chez Léon is a human sized Parisian
                             </span>
                           </td>
                           <td
                             aria-colindex="10"
-                            class="c0 c73"
+                            class="c0 c74"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <span>
                                 <button
@@ -23166,7 +23172,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                                 </button>
                               </span>
                               <div
-                                class="c0 c80"
+                                class="c0 c81"
                               >
                                 <span>
                                   <button
@@ -23196,42 +23202,42 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                         </tr>
                         <tr
                           aria-rowindex="4"
-                          class="c0 c72"
+                          class="c0 c73"
                         >
                           <td
                             aria-colindex="1"
-                            class="c0 c73"
+                            class="c0 c74"
                           >
                             <input
                               aria-label="Select Leon Lafrite"
-                              class="c74"
+                              class="c75"
                               tabindex="-1"
                               type="checkbox"
                             />
                           </td>
                           <td
                             aria-colindex="2"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               2
                             </span>
                           </td>
                           <td
                             aria-colindex="3"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span>
                               <div
-                                class="c78"
+                                class="c79"
                               >
                                 <img
                                   alt="Leon Lafrite"
-                                  class="c79"
+                                  class="c80"
                                   height="26px"
                                   src="https://avatars.githubusercontent.com/u/3874873?v=4"
                                   width="26px"
@@ -23241,76 +23247,76 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="4"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               Chez Léon is a human sized Parisian
                             </span>
                           </td>
                           <td
                             aria-colindex="5"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               French cuisine
                             </span>
                           </td>
                           <td
                             aria-colindex="6"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               Leon Lafrite
                             </span>
                           </td>
                           <td
                             aria-colindex="7"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               Chez Léon is a human sized Parisian
                             </span>
                           </td>
                           <td
                             aria-colindex="8"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               Chez Léon is a human sized Parisian
                             </span>
                           </td>
                           <td
                             aria-colindex="9"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               Chez Léon is a human sized Parisian
                             </span>
                           </td>
                           <td
                             aria-colindex="10"
-                            class="c0 c73"
+                            class="c0 c74"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <span>
                                 <button
@@ -23337,7 +23343,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                                 </button>
                               </span>
                               <div
-                                class="c0 c80"
+                                class="c0 c81"
                               >
                                 <span>
                                   <button
@@ -23367,42 +23373,42 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                         </tr>
                         <tr
                           aria-rowindex="5"
-                          class="c0 c72"
+                          class="c0 c73"
                         >
                           <td
                             aria-colindex="1"
-                            class="c0 c73"
+                            class="c0 c74"
                           >
                             <input
                               aria-label="Select Leon Lafrite"
-                              class="c74"
+                              class="c75"
                               tabindex="-1"
                               type="checkbox"
                             />
                           </td>
                           <td
                             aria-colindex="2"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               3
                             </span>
                           </td>
                           <td
                             aria-colindex="3"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span>
                               <div
-                                class="c78"
+                                class="c79"
                               >
                                 <img
                                   alt="Leon Lafrite"
-                                  class="c79"
+                                  class="c80"
                                   height="26px"
                                   src="https://avatars.githubusercontent.com/u/3874873?v=4"
                                   width="26px"
@@ -23412,76 +23418,76 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="4"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               Chez Léon is a human sized Parisian
                             </span>
                           </td>
                           <td
                             aria-colindex="5"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               French cuisine
                             </span>
                           </td>
                           <td
                             aria-colindex="6"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               Leon Lafrite
                             </span>
                           </td>
                           <td
                             aria-colindex="7"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               Chez Léon is a human sized Parisian
                             </span>
                           </td>
                           <td
                             aria-colindex="8"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               Chez Léon is a human sized Parisian
                             </span>
                           </td>
                           <td
                             aria-colindex="9"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               Chez Léon is a human sized Parisian
                             </span>
                           </td>
                           <td
                             aria-colindex="10"
-                            class="c0 c73"
+                            class="c0 c74"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <span>
                                 <button
@@ -23508,7 +23514,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                                 </button>
                               </span>
                               <div
-                                class="c0 c80"
+                                class="c0 c81"
                               >
                                 <span>
                                   <button
@@ -23538,42 +23544,42 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                         </tr>
                         <tr
                           aria-rowindex="6"
-                          class="c0 c72"
+                          class="c0 c73"
                         >
                           <td
                             aria-colindex="1"
-                            class="c0 c73"
+                            class="c0 c74"
                           >
                             <input
                               aria-label="Select Leon Lafrite"
-                              class="c74"
+                              class="c75"
                               tabindex="-1"
                               type="checkbox"
                             />
                           </td>
                           <td
                             aria-colindex="2"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               4
                             </span>
                           </td>
                           <td
                             aria-colindex="3"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span>
                               <div
-                                class="c78"
+                                class="c79"
                               >
                                 <img
                                   alt="Leon Lafrite"
-                                  class="c79"
+                                  class="c80"
                                   height="26px"
                                   src="https://avatars.githubusercontent.com/u/3874873?v=4"
                                   width="26px"
@@ -23583,76 +23589,76 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                           </td>
                           <td
                             aria-colindex="4"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               Chez Léon is a human sized Parisian
                             </span>
                           </td>
                           <td
                             aria-colindex="5"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               French cuisine
                             </span>
                           </td>
                           <td
                             aria-colindex="6"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               Leon Lafrite
                             </span>
                           </td>
                           <td
                             aria-colindex="7"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               Chez Léon is a human sized Parisian
                             </span>
                           </td>
                           <td
                             aria-colindex="8"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               Chez Léon is a human sized Parisian
                             </span>
                           </td>
                           <td
                             aria-colindex="9"
-                            class="c0 c73"
+                            class="c0 c74"
                             tabindex="-1"
                           >
                             <span
-                              class="c9 c35"
+                              class="c9 c36"
                             >
                               Chez Léon is a human sized Parisian
                             </span>
                           </td>
                           <td
                             aria-colindex="10"
-                            class="c0 c73"
+                            class="c0 c74"
                           >
                             <div
-                              class="c0 c23"
+                              class="c0 c25"
                             >
                               <span>
                                 <button
@@ -23679,7 +23685,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                                 </button>
                               </span>
                               <div
-                                class="c0 c80"
+                                class="c0 c81"
                               >
                                 <span>
                                   <button
@@ -23716,14 +23722,14 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                     class="c0 c14 c15"
                   />
                   <button
-                    class="c0 c81 c82"
+                    class="c0 c82 c83"
                   >
                     <div
-                      class="c0 c23"
+                      class="c0 c25"
                     >
                       <div
                         aria-hidden="true"
-                        class="c0 c83 c84"
+                        class="c0 c84 c85"
                       >
                         <svg
                           fill="none"
@@ -23739,10 +23745,10 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                         </svg>
                       </div>
                       <div
-                        class="c0 c85"
+                        class="c0 c86"
                       >
                         <span
-                          class="c9 c86"
+                          class="c9 c87"
                         >
                           Add another field to this collection type
                         </span>
@@ -35985,23 +35991,27 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   padding-bottom: 16px;
 }
 
-.c19 {
+.c20 {
   padding-top: 4px;
   padding-right: 16px;
   padding-bottom: 4px;
   padding-left: 24px;
-  margin-bottom: 4px;
 }
 
-.c21 {
+.c22 {
+  padding-right: 24px;
   position: relative;
 }
 
 .c23 {
+  text-align: left;
+}
+
+.c25 {
   padding-right: 4px;
 }
 
-.c26 {
+.c28 {
   background: #eaeaef;
   padding: 4px;
   border-radius: 4px;
@@ -36009,48 +36019,56 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   right: 0px;
   top: 50%;
   min-width: 20px;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
 }
 
-.c29 {
+.c30 {
   background: #f6f6f9;
   padding-top: 8px;
   padding-bottom: 8px;
   padding-left: 32px;
 }
 
-.c32 {
+.c33 {
   padding-left: 8px;
 }
 
-.c34 {
+.c35 {
   padding-bottom: 12px;
   padding-left: 32px;
 }
 
-.c36 {
+.c37 {
   padding-right: 8px;
 }
 
-.c38 {
+.c39 {
   padding-top: 8px;
   padding-right: 16px;
   padding-bottom: 8px;
   padding-left: 32px;
 }
 
-.c44 {
+.c45 {
   background: #f6f6f9;
   padding-top: 8px;
   padding-bottom: 8px;
   padding-left: 48px;
 }
 
-.c45 {
+.c46 {
   padding-left: 32px;
 }
 
-.c47 {
+.c48 {
   padding-right: 16px;
+}
+
+.c50 {
+  padding-right: 0px;
+  position: relative;
 }
 
 .c9 {
@@ -36060,7 +36078,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   line-height: 1.22;
 }
 
-.c24 {
+.c26 {
   color: #666687;
   font-weight: 600;
   font-size: 0.6875rem;
@@ -36068,19 +36086,19 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   text-transform: uppercase;
 }
 
-.c33 {
+.c34 {
   color: #32324d;
   font-size: 0.875rem;
   line-height: 1.43;
 }
 
-.c37 {
+.c38 {
   color: #4945ff;
   font-size: 0.75rem;
   line-height: 1.33;
 }
 
-.c43 {
+.c44 {
   font-weight: 500;
   color: #32324d;
   font-size: 0.875rem;
@@ -36133,7 +36151,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   flex-direction: column;
 }
 
-.c27 {
+.c29 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -36151,7 +36169,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   justify-content: center;
 }
 
-.c40 {
+.c41 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -36169,22 +36187,22 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   justify-content: space-between;
 }
 
-.c35 {
+.c36 {
   background: transparent;
   border: none;
   position: relative;
   outline: none;
 }
 
-.c35[aria-disabled='true'] {
+.c36[aria-disabled='true'] {
   pointer-events: none;
 }
 
-.c35[aria-disabled='true'] svg path {
+.c36[aria-disabled='true'] svg path {
   fill: #666687;
 }
 
-.c35 svg {
+.c36 svg {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -36192,11 +36210,11 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   font-size: 0.625rem;
 }
 
-.c35 svg path {
+.c36 svg path {
   fill: #4945ff;
 }
 
-.c35:after {
+.c36:after {
   -webkit-transition-property: all;
   transition-property: all;
   -webkit-transition-duration: 0.2s;
@@ -36211,11 +36229,11 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   border: 2px solid transparent;
 }
 
-.c35:focus-visible {
+.c36:focus-visible {
   outline: none;
 }
 
-.c35:focus-visible:after {
+.c36:focus-visible:after {
   border-radius: 8px;
   content: '';
   position: absolute;
@@ -36232,7 +36250,16 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
 }
 
 .c18 > * + * {
-  margin-top: 12px;
+  margin-top: 8px;
+}
+
+.c19 > * {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.c19 > * + * {
+  margin-top: 4px;
 }
 
 .c10 {
@@ -36356,7 +36383,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   background-color: #dcdce4;
 }
 
-.c30 {
+.c31 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -36374,60 +36401,60 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   color: #32324d;
 }
 
-.c30 svg > * {
+.c31 svg > * {
   fill: #666687;
 }
 
-.c30.active {
+.c31.active {
   background-color: #f0f0ff;
   border-right: 2px solid #4945ff;
 }
 
-.c30.active svg > * {
+.c31.active svg > * {
   fill: #271fe0;
 }
 
-.c30.active .c8 {
+.c31.active .c8 {
   color: #271fe0;
   font-weight: 500;
 }
 
-.c30:focus-visible {
+.c31:focus-visible {
   outline-offset: -2px;
 }
 
-.c31 {
+.c32 {
   width: 0.75rem;
   height: 0.25rem;
 }
 
-.c31 * {
+.c32 * {
   fill: #666687;
 }
 
-.c48 {
+.c49 {
   width: 0.75rem;
   height: 0.25rem;
 }
 
-.c48 * {
+.c49 * {
   fill: #4945ff;
 }
 
-.c46 svg {
+.c47 svg {
   height: 0.75rem;
   width: 0.75rem;
 }
 
-.c39 svg {
+.c40 svg {
   height: 0.25rem;
 }
 
-.c39 svg path {
+.c40 svg path {
   fill: #4a4a6a;
 }
 
-.c41 {
+.c42 {
   border: none;
   padding: 0;
   background: transparent;
@@ -36441,7 +36468,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   align-items: center;
 }
 
-.c42 {
+.c43 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -36456,13 +36483,13 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   transform: rotateX(0deg);
 }
 
-.c22 {
+.c24 {
   border: none;
   padding: 0;
   background: transparent;
 }
 
-.c25 {
+.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -36476,26 +36503,12 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   transform: rotateX(0deg);
 }
 
-.c20 svg {
+.c21 svg {
   height: 0.25rem;
 }
 
-.c20 svg path {
+.c21 svg path {
   fill: #8e8ea9;
-}
-
-.c28 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
 }
 
 <div
@@ -36571,36 +36584,37 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
             <div
               class="c16"
             >
-              <ul
+              <ol
                 class="c17 c18"
-                spacing="3"
+                spacing="2"
               >
                 <li>
                   <div
-                    class=""
+                    class="c17 c19"
+                    spacing="1"
                   >
                     <div
-                      class="c19 c20"
+                      class="c20 c21"
                     >
                       <div
-                        class="c21"
+                        class="c22"
                       >
                         <button
                           aria-controls="subnav-list-139"
                           aria-expanded="true"
-                          class="c3 c22"
+                          class="c23 c3 c24"
                         >
                           <div
-                            class="c23"
+                            class="c25"
                           >
                             <span
-                              class="c8 c24"
+                              class="c8 c26"
                             >
                               Collection Type
                             </span>
                           </div>
                           <div
-                            class="c25"
+                            class="c27"
                           >
                             <svg
                               aria-hidden="true"
@@ -36620,10 +36634,11 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           </div>
                         </button>
                         <div
-                          class="c26 c27 c28"
+                          class="c28 c29"
+                          transform="translateY(-50%)"
                         >
                           <span
-                            class="c8 c24"
+                            class="c8 c26"
                           >
                             4
                           </span>
@@ -36635,14 +36650,14 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                     >
                       <li>
                         <a
-                          class="c29 c30"
+                          class="c30 c31"
                           href="/address"
                         >
                           <div
                             class="c3"
                           >
                             <svg
-                              class="c31"
+                              class="c32"
                               fill="none"
                               height="1em"
                               viewBox="0 0 4 4"
@@ -36657,10 +36672,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                               />
                             </svg>
                             <div
-                              class="c32"
+                              class="c33"
                             >
                               <span
-                                class="c8 c33"
+                                class="c8 c34"
                               >
                                 Addresses
                               </span>
@@ -36670,14 +36685,14 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       </li>
                       <li>
                         <a
-                          class="c29 c30"
+                          class="c30 c31"
                           href="/category"
                         >
                           <div
                             class="c3"
                           >
                             <svg
-                              class="c31"
+                              class="c32"
                               fill="none"
                               height="1em"
                               viewBox="0 0 4 4"
@@ -36692,10 +36707,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                               />
                             </svg>
                             <div
-                              class="c32"
+                              class="c33"
                             >
                               <span
-                                class="c8 c33"
+                                class="c8 c34"
                               >
                                 Categories
                               </span>
@@ -36705,14 +36720,14 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       </li>
                       <li>
                         <a
-                          class="c29 c30"
+                          class="c30 c31"
                           href="/city"
                         >
                           <div
                             class="c3"
                           >
                             <svg
-                              class="c31"
+                              class="c32"
                               fill="none"
                               height="1em"
                               viewBox="0 0 4 4"
@@ -36727,10 +36742,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                               />
                             </svg>
                             <div
-                              class="c32"
+                              class="c33"
                             >
                               <span
-                                class="c8 c33"
+                                class="c8 c34"
                               >
                                 Cities
                               </span>
@@ -36740,14 +36755,14 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       </li>
                       <li>
                         <a
-                          class="c29 c30"
+                          class="c30 c31"
                           href="/country"
                         >
                           <div
                             class="c3"
                           >
                             <svg
-                              class="c31"
+                              class="c32"
                               fill="none"
                               height="1em"
                               viewBox="0 0 4 4"
@@ -36762,10 +36777,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                               />
                             </svg>
                             <div
-                              class="c32"
+                              class="c33"
                             >
                               <span
-                                class="c8 c33"
+                                class="c8 c34"
                               >
                                 Countries
                               </span>
@@ -36778,16 +36793,16 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                 </li>
                 <li>
                   <div
-                    class="c34"
+                    class="c35"
                   >
                     <button
                       aria-disabled="false"
-                      class="c3 c35"
+                      class="c3 c36"
                       type="button"
                     >
                       <span
                         aria-hidden="true"
-                        class="c36"
+                        class="c37"
                       >
                         <svg
                           fill="none"
@@ -36803,7 +36818,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                         </svg>
                       </span>
                       <span
-                        class="c8 c37"
+                        class="c8 c38"
                       >
                         Click on me
                       </span>
@@ -36812,30 +36827,31 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                 </li>
                 <li>
                   <div
-                    class=""
+                    class="c17 c19"
+                    spacing="1"
                   >
                     <div
-                      class="c19 c20"
+                      class="c20 c21"
                     >
                       <div
-                        class="c21"
+                        class="c22"
                       >
                         <button
                           aria-controls="subnav-list-140"
                           aria-expanded="true"
-                          class="c3 c22"
+                          class="c23 c3 c24"
                         >
                           <div
-                            class="c23"
+                            class="c25"
                           >
                             <span
-                              class="c8 c24"
+                              class="c8 c26"
                             >
                               Single Type
                             </span>
                           </div>
                           <div
-                            class="c25"
+                            class="c27"
                           >
                             <svg
                               aria-hidden="true"
@@ -36855,10 +36871,11 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           </div>
                         </button>
                         <div
-                          class="c26 c27 c28"
+                          class="c28 c29"
+                          transform="translateY(-50%)"
                         >
                           <span
-                            class="c8 c24"
+                            class="c8 c26"
                           >
                             4
                           </span>
@@ -36873,18 +36890,18 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           class=""
                         >
                           <div
-                            class="c38 c39"
+                            class="c39 c40"
                           >
                             <div
-                              class="c40"
+                              class="c41"
                             >
                               <button
                                 aria-controls="subnav-list-141"
                                 aria-expanded="true"
-                                class="c41"
+                                class="c42"
                               >
                                 <div
-                                  class="c42"
+                                  class="c43"
                                 >
                                   <svg
                                     aria-hidden="true"
@@ -36903,10 +36920,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                                   </svg>
                                 </div>
                                 <div
-                                  class="c32"
+                                  class="c33"
                                 >
                                   <span
-                                    class="c8 c43"
+                                    class="c8 c44"
                                   >
                                     Default
                                   </span>
@@ -36919,14 +36936,14 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           >
                             <li>
                               <a
-                                class="c44 c30"
+                                class="c45 c31"
                                 href="/address"
                               >
                                 <div
                                   class="c3"
                                 >
                                   <svg
-                                    class="c31"
+                                    class="c32"
                                     fill="none"
                                     height="1em"
                                     viewBox="0 0 4 4"
@@ -36941,10 +36958,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                                     />
                                   </svg>
                                   <div
-                                    class="c32"
+                                    class="c33"
                                   >
                                     <span
-                                      class="c8 c33"
+                                      class="c8 c34"
                                     >
                                       Addresses
                                     </span>
@@ -36954,14 +36971,14 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             </li>
                             <li>
                               <a
-                                class="c44 c30"
+                                class="c45 c31"
                                 href="/category"
                               >
                                 <div
                                   class="c3"
                                 >
                                   <svg
-                                    class="c31"
+                                    class="c32"
                                     fill="none"
                                     height="1em"
                                     viewBox="0 0 4 4"
@@ -36976,10 +36993,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                                     />
                                   </svg>
                                   <div
-                                    class="c32"
+                                    class="c33"
                                   >
                                     <span
-                                      class="c8 c33"
+                                      class="c8 c34"
                                     >
                                       Categories
                                     </span>
@@ -36989,14 +37006,14 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             </li>
                             <li>
                               <a
-                                class="c44 c30"
+                                class="c45 c31"
                                 href="/city"
                               >
                                 <div
                                   class="c3"
                                 >
                                   <svg
-                                    class="c31"
+                                    class="c32"
                                     fill="none"
                                     height="1em"
                                     viewBox="0 0 4 4"
@@ -37011,10 +37028,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                                     />
                                   </svg>
                                   <div
-                                    class="c32"
+                                    class="c33"
                                   >
                                     <span
-                                      class="c8 c33"
+                                      class="c8 c34"
                                     >
                                       Cities
                                     </span>
@@ -37024,14 +37041,14 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             </li>
                             <li>
                               <a
-                                class="c44 c30"
+                                class="c45 c31"
                                 href="/country"
                               >
                                 <div
                                   class="c3"
                                 >
                                   <svg
-                                    class="c31"
+                                    class="c32"
                                     fill="none"
                                     height="1em"
                                     viewBox="0 0 4 4"
@@ -37046,10 +37063,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                                     />
                                   </svg>
                                   <div
-                                    class="c32"
+                                    class="c33"
                                   >
                                     <span
-                                      class="c8 c33"
+                                      class="c8 c34"
                                     >
                                       Countries
                                     </span>
@@ -37065,16 +37082,16 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                 </li>
                 <li>
                   <div
-                    class="c45"
+                    class="c46"
                   >
                     <button
                       aria-disabled="false"
-                      class="c3 c35"
+                      class="c3 c36"
                       type="button"
                     >
                       <span
                         aria-hidden="true"
-                        class="c36"
+                        class="c37"
                       >
                         <svg
                           fill="none"
@@ -37090,14 +37107,14 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                         </svg>
                       </span>
                       <span
-                        class="c8 c37"
+                        class="c8 c38"
                       >
                         Click on me
                       </span>
                     </button>
                   </div>
                 </li>
-              </ul>
+              </ol>
             </div>
           </nav>
         </div>
@@ -37132,20 +37149,20 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
             <div
               class="c16"
             >
-              <ul
+              <ol
                 class="c17 c18"
-                spacing="3"
+                spacing="2"
               >
                 <li>
                   <a
-                    class="c29 c30 active"
+                    class="c30 c31 active"
                     href="/blabla"
                   >
                     <div
                       class="c3"
                     >
                       <div
-                        class="c46"
+                        class="c47"
                       >
                         <svg
                           fill="none"
@@ -37161,20 +37178,20 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                         </svg>
                       </div>
                       <div
-                        class="c32"
+                        class="c33"
                       >
                         <span
-                          class="c8 c33"
+                          class="c8 c34"
                         >
                           Application
                         </span>
                       </div>
                     </div>
                     <div
-                      class="c3 sc-gsDKAQ c47"
+                      class="c3 sc-gsDKAQ c48"
                     >
                       <svg
-                        class="c48"
+                        class="c49"
                         fill="none"
                         height="1em"
                         viewBox="0 0 4 4"
@@ -37193,22 +37210,23 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                 </li>
                 <li>
                   <div
-                    class=""
+                    class="c17 c19"
+                    spacing="1"
                   >
                     <div
-                      class="c19 c20"
+                      class="c20 c21"
                     >
                       <div
-                        class="c21"
+                        class="c50"
                       >
                         <div
-                          class="c3 c22"
+                          class="c3 c24"
                         >
                           <div
-                            class="c23"
+                            class="c25"
                           >
                             <span
-                              class="c8 c24"
+                              class="c8 c26"
                             >
                               Global Settings
                             </span>
@@ -37221,14 +37239,14 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                     >
                       <li>
                         <a
-                          class="c29 c30"
+                          class="c30 c31"
                           href="/address"
                         >
                           <div
                             class="c3"
                           >
                             <div
-                              class="c46"
+                              class="c47"
                             >
                               <svg
                                 fill="none"
@@ -37244,10 +37262,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c32"
+                              class="c33"
                             >
                               <span
-                                class="c8 c33"
+                                class="c8 c34"
                               >
                                 Addresses
                               </span>
@@ -37258,14 +37276,14 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       <li />
                       <li>
                         <a
-                          class="c29 c30"
+                          class="c30 c31"
                           href="/city"
                         >
                           <div
                             class="c3"
                           >
                             <div
-                              class="c46"
+                              class="c47"
                             >
                               <svg
                                 fill="none"
@@ -37281,10 +37299,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c32"
+                              class="c33"
                             >
                               <span
-                                class="c8 c33"
+                                class="c8 c34"
                               >
                                 Cities
                               </span>
@@ -37298,22 +37316,23 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                 </li>
                 <li>
                   <div
-                    class=""
+                    class="c17 c19"
+                    spacing="1"
                   >
                     <div
-                      class="c19 c20"
+                      class="c20 c21"
                     >
                       <div
-                        class="c21"
+                        class="c50"
                       >
                         <div
-                          class="c3 c22"
+                          class="c3 c24"
                         >
                           <div
-                            class="c23"
+                            class="c25"
                           >
                             <span
-                              class="c8 c24"
+                              class="c8 c26"
                             >
                               Permissions
                             </span>
@@ -37326,14 +37345,14 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                     >
                       <li>
                         <a
-                          class="c29 c30"
+                          class="c30 c31"
                           href="/address"
                         >
                           <div
                             class="c3"
                           >
                             <div
-                              class="c46"
+                              class="c47"
                             >
                               <svg
                                 fill="none"
@@ -37349,10 +37368,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c32"
+                              class="c33"
                             >
                               <span
-                                class="c8 c33"
+                                class="c8 c34"
                               >
                                 Addresses
                               </span>
@@ -37363,14 +37382,14 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       <li />
                       <li>
                         <a
-                          class="c29 c30"
+                          class="c30 c31"
                           href="/city"
                         >
                           <div
                             class="c3"
                           >
                             <div
-                              class="c46"
+                              class="c47"
                             >
                               <svg
                                 fill="none"
@@ -37386,10 +37405,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c32"
+                              class="c33"
                             >
                               <span
-                                class="c8 c33"
+                                class="c8 c34"
                               >
                                 Cities
                               </span>
@@ -37401,7 +37420,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                     </ol>
                   </div>
                 </li>
-              </ul>
+              </ol>
             </div>
           </nav>
         </div>
@@ -37436,20 +37455,20 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
             <div
               class="c16"
             >
-              <ul
+              <ol
                 class="c17 c18"
-                spacing="3"
+                spacing="2"
               >
                 <li>
                   <a
-                    class="c29 c30"
+                    class="c30 c31"
                     href="/blabla"
                   >
                     <div
                       class="c3"
                     >
                       <div
-                        class="c46"
+                        class="c47"
                       >
                         <svg
                           fill="none"
@@ -37465,20 +37484,20 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                         </svg>
                       </div>
                       <div
-                        class="c32"
+                        class="c33"
                       >
                         <span
-                          class="c8 c33"
+                          class="c8 c34"
                         >
                           Application
                         </span>
                       </div>
                     </div>
                     <div
-                      class="c3 sc-gsDKAQ c47"
+                      class="c3 sc-gsDKAQ c48"
                     >
                       <svg
-                        class="c48"
+                        class="c49"
                         fill="none"
                         height="1em"
                         viewBox="0 0 4 4"
@@ -37497,22 +37516,23 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                 </li>
                 <li>
                   <div
-                    class=""
+                    class="c17 c19"
+                    spacing="1"
                   >
                     <div
-                      class="c19 c20"
+                      class="c20 c21"
                     >
                       <div
-                        class="c21"
+                        class="c50"
                       >
                         <div
-                          class="c3 c22"
+                          class="c3 c24"
                         >
                           <div
-                            class="c23"
+                            class="c25"
                           >
                             <span
-                              class="c8 c24"
+                              class="c8 c26"
                             >
                               Global Settings
                             </span>
@@ -37528,18 +37548,18 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           class=""
                         >
                           <div
-                            class="c38 c39"
+                            class="c39 c40"
                           >
                             <div
-                              class="c40"
+                              class="c41"
                             >
                               <button
                                 aria-controls="subnav-list-147"
                                 aria-expanded="true"
-                                class="c41"
+                                class="c42"
                               >
                                 <div
-                                  class="c42"
+                                  class="c43"
                                 >
                                   <svg
                                     aria-hidden="true"
@@ -37558,10 +37578,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                                   </svg>
                                 </div>
                                 <div
-                                  class="c32"
+                                  class="c33"
                                 >
                                   <span
-                                    class="c8 c43"
+                                    class="c8 c44"
                                   >
                                     Sub section
                                   </span>
@@ -37574,14 +37594,14 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           >
                             <li>
                               <a
-                                class="c44 c30"
+                                class="c45 c31"
                                 href="/address"
                               >
                                 <div
                                   class="c3"
                                 >
                                   <div
-                                    class="c46"
+                                    class="c47"
                                   >
                                     <svg
                                       fill="none"
@@ -37597,10 +37617,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                                     </svg>
                                   </div>
                                   <div
-                                    class="c32"
+                                    class="c33"
                                   >
                                     <span
-                                      class="c8 c33"
+                                      class="c8 c34"
                                     >
                                       Addresses
                                     </span>
@@ -37610,14 +37630,14 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             </li>
                             <li>
                               <a
-                                class="c44 c30"
+                                class="c45 c31"
                                 href="/category"
                               >
                                 <div
                                   class="c3"
                                 >
                                   <svg
-                                    class="c31"
+                                    class="c32"
                                     fill="none"
                                     height="1em"
                                     viewBox="0 0 4 4"
@@ -37632,10 +37652,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                                     />
                                   </svg>
                                   <div
-                                    class="c32"
+                                    class="c33"
                                   >
                                     <span
-                                      class="c8 c33"
+                                      class="c8 c34"
                                     >
                                       Categories
                                     </span>
@@ -37645,14 +37665,14 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             </li>
                             <li>
                               <a
-                                class="c44 c30"
+                                class="c45 c31"
                                 href="/city"
                               >
                                 <div
                                   class="c3"
                                 >
                                   <div
-                                    class="c46"
+                                    class="c47"
                                   >
                                     <svg
                                       fill="none"
@@ -37668,10 +37688,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                                     </svg>
                                   </div>
                                   <div
-                                    class="c32"
+                                    class="c33"
                                   >
                                     <span
-                                      class="c8 c33"
+                                      class="c8 c34"
                                     >
                                       Cities
                                     </span>
@@ -37681,14 +37701,14 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             </li>
                             <li>
                               <a
-                                class="c44 c30"
+                                class="c45 c31"
                                 href="/country"
                               >
                                 <div
                                   class="c3"
                                 >
                                   <svg
-                                    class="c31"
+                                    class="c32"
                                     fill="none"
                                     height="1em"
                                     viewBox="0 0 4 4"
@@ -37703,10 +37723,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                                     />
                                   </svg>
                                   <div
-                                    class="c32"
+                                    class="c33"
                                   >
                                     <span
-                                      class="c8 c33"
+                                      class="c8 c34"
                                     >
                                       Countries
                                     </span>
@@ -37722,22 +37742,23 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                 </li>
                 <li>
                   <div
-                    class=""
+                    class="c17 c19"
+                    spacing="1"
                   >
                     <div
-                      class="c19 c20"
+                      class="c20 c21"
                     >
                       <div
-                        class="c21"
+                        class="c50"
                       >
                         <div
-                          class="c3 c22"
+                          class="c3 c24"
                         >
                           <div
-                            class="c23"
+                            class="c25"
                           >
                             <span
-                              class="c8 c24"
+                              class="c8 c26"
                             >
                               Permissions
                             </span>
@@ -37750,14 +37771,14 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                     >
                       <li>
                         <a
-                          class="c29 c30"
+                          class="c30 c31"
                           href="/address"
                         >
                           <div
                             class="c3"
                           >
                             <div
-                              class="c46"
+                              class="c47"
                             >
                               <svg
                                 fill="none"
@@ -37773,10 +37794,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c32"
+                              class="c33"
                             >
                               <span
-                                class="c8 c33"
+                                class="c8 c34"
                               >
                                 Addresses
                               </span>
@@ -37786,14 +37807,14 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       </li>
                       <li>
                         <a
-                          class="c29 c30"
+                          class="c30 c31"
                           href="/category"
                         >
                           <div
                             class="c3"
                           >
                             <svg
-                              class="c31"
+                              class="c32"
                               fill="none"
                               height="1em"
                               viewBox="0 0 4 4"
@@ -37808,10 +37829,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                               />
                             </svg>
                             <div
-                              class="c32"
+                              class="c33"
                             >
                               <span
-                                class="c8 c33"
+                                class="c8 c34"
                               >
                                 Categories
                               </span>
@@ -37821,14 +37842,14 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       </li>
                       <li>
                         <a
-                          class="c29 c30"
+                          class="c30 c31"
                           href="/city"
                         >
                           <div
                             class="c3"
                           >
                             <div
-                              class="c46"
+                              class="c47"
                             >
                               <svg
                                 fill="none"
@@ -37844,10 +37865,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                               </svg>
                             </div>
                             <div
-                              class="c32"
+                              class="c33"
                             >
                               <span
-                                class="c8 c33"
+                                class="c8 c34"
                               >
                                 Cities
                               </span>
@@ -37857,14 +37878,14 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       </li>
                       <li>
                         <a
-                          class="c29 c30"
+                          class="c30 c31"
                           href="/country"
                         >
                           <div
                             class="c3"
                           >
                             <svg
-                              class="c31"
+                              class="c32"
                               fill="none"
                               height="1em"
                               viewBox="0 0 4 4"
@@ -37879,10 +37900,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                               />
                             </svg>
                             <div
-                              class="c32"
+                              class="c33"
                             >
                               <span
-                                class="c8 c33"
+                                class="c8 c34"
                               >
                                 Countries
                               </span>
@@ -37893,7 +37914,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                     </ol>
                   </div>
                 </li>
-              </ul>
+              </ol>
             </div>
           </nav>
         </div>

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -20189,8 +20189,8 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
 
 .c31 {
   background: #f6f6f9;
-  padding-top: 8px;
-  padding-bottom: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
   padding-left: 32px;
 }
 
@@ -36002,8 +36002,8 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
 
 .c29 {
   background: #f6f6f9;
-  padding-top: 8px;
-  padding-bottom: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
   padding-left: 32px;
 }
 
@@ -36026,7 +36026,14 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   padding-left: 32px;
 }
 
-.c44 {
+.c43 {
+  background: #f6f6f9;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  padding-left: 48px;
+}
+
+.c45 {
   padding-right: 16px;
 }
 
@@ -36382,16 +36389,16 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
   fill: #666687;
 }
 
-.c45 {
+.c46 {
   width: 0.75rem;
   height: 0.25rem;
 }
 
-.c45 * {
+.c46 * {
   fill: #4945ff;
 }
 
-.c43 svg {
+.c44 svg {
   height: 0.75rem;
   width: 0.75rem;
 }
@@ -36901,7 +36908,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           >
                             <li>
                               <a
-                                class="c29 c30"
+                                class="c43 c30"
                                 href="/address"
                               >
                                 <div
@@ -36936,7 +36943,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             </li>
                             <li>
                               <a
-                                class="c29 c30"
+                                class="c43 c30"
                                 href="/category"
                               >
                                 <div
@@ -36971,7 +36978,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             </li>
                             <li>
                               <a
-                                class="c29 c30"
+                                class="c43 c30"
                                 href="/city"
                               >
                                 <div
@@ -37006,7 +37013,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             </li>
                             <li>
                               <a
-                                class="c29 c30"
+                                class="c43 c30"
                                 href="/country"
                               >
                                 <div
@@ -37127,7 +37134,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       class="c3"
                     >
                       <div
-                        class="c43"
+                        class="c44"
                       >
                         <svg
                           fill="none"
@@ -37153,10 +37160,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       </div>
                     </div>
                     <div
-                      class="c3 sc-gsDKAQ c44"
+                      class="c3 sc-gsDKAQ c45"
                     >
                       <svg
-                        class="c45"
+                        class="c46"
                         fill="none"
                         height="1em"
                         viewBox="0 0 4 4"
@@ -37210,7 +37217,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             class="c3"
                           >
                             <div
-                              class="c43"
+                              class="c44"
                             >
                               <svg
                                 fill="none"
@@ -37247,7 +37254,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             class="c3"
                           >
                             <div
-                              class="c43"
+                              class="c44"
                             >
                               <svg
                                 fill="none"
@@ -37315,7 +37322,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             class="c3"
                           >
                             <div
-                              class="c43"
+                              class="c44"
                             >
                               <svg
                                 fill="none"
@@ -37352,7 +37359,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             class="c3"
                           >
                             <div
-                              class="c43"
+                              class="c44"
                             >
                               <svg
                                 fill="none"
@@ -37431,7 +37438,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       class="c3"
                     >
                       <div
-                        class="c43"
+                        class="c44"
                       >
                         <svg
                           fill="none"
@@ -37457,10 +37464,10 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       </div>
                     </div>
                     <div
-                      class="c3 sc-gsDKAQ c44"
+                      class="c3 sc-gsDKAQ c45"
                     >
                       <svg
-                        class="c45"
+                        class="c46"
                         fill="none"
                         height="1em"
                         viewBox="0 0 4 4"
@@ -37556,14 +37563,14 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                           >
                             <li>
                               <a
-                                class="c29 c30"
+                                class="c43 c30"
                                 href="/address"
                               >
                                 <div
                                   class="c3"
                                 >
                                   <div
-                                    class="c43"
+                                    class="c44"
                                   >
                                     <svg
                                       fill="none"
@@ -37592,7 +37599,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             </li>
                             <li>
                               <a
-                                class="c29 c30"
+                                class="c43 c30"
                                 href="/category"
                               >
                                 <div
@@ -37627,14 +37634,14 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             </li>
                             <li>
                               <a
-                                class="c29 c30"
+                                class="c43 c30"
                                 href="/city"
                               >
                                 <div
                                   class="c3"
                                 >
                                   <div
-                                    class="c43"
+                                    class="c44"
                                   >
                                     <svg
                                       fill="none"
@@ -37663,7 +37670,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             </li>
                             <li>
                               <a
-                                class="c29 c30"
+                                class="c43 c30"
                                 href="/country"
                               >
                                 <div
@@ -37739,7 +37746,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             class="c3"
                           >
                             <div
-                              class="c43"
+                              class="c44"
                             >
                               <svg
                                 fill="none"
@@ -37810,7 +37817,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             class="c3"
                           >
                             <div
-                              class="c43"
+                              class="c44"
                             >
                               <svg
                                 fill="none"


### PR DESCRIPTION
### What does it do?

Improves visual hierarchy of sub nav panel by adjusting indentation of `<SubNavLinkSection>` child elements, and reducing overall `<SubNavLink>` top and bottom padding. 

WIP, but I believe it's complete, pending review.

### Related issue(s)/PR(s)

Related to https://github.com/strapi/design-system/issues/637

*Before*
<img width="239" alt="Screen Shot 2022-06-30 at 11 21 44 AM" src="https://user-images.githubusercontent.com/4982035/176739288-d0e0fe12-e170-410a-ad93-183e43303808.png">

*After*
<img width="240" alt="Screen Shot 2022-06-30 at 11 20 41 AM" src="https://user-images.githubusercontent.com/4982035/176739342-b34f05ae-446f-4a86-896f-e220f5c5abfb.png">

