### PR TITLE
NumberInput: Fix maximum significant digits which are displayed

### DIFF
--- a/packages/strapi-design-system/package.json
+++ b/packages/strapi-design-system/package.json
@@ -48,7 +48,7 @@
     "styled-components": "^5.2.1"
   },
   "dependencies": {
-    "@internationalized/number": "^3.0.2",
+    "@internationalized/number": "^3.1.1",
     "compute-scroll-into-view": "^1.0.17",
     "prop-types": "^15.7.2"
   },

--- a/packages/strapi-design-system/src/NumberInput/NumberInput.js
+++ b/packages/strapi-design-system/src/NumberInput/NumberInput.js
@@ -70,7 +70,7 @@ export const NumberInput = React.forwardRef(
     };
 
     const increment = (fromKeyBoard) => {
-      if (inputValue === '') {
+      if (inputValue === undefined) {
         onValueChange(step);
         setInputValue(String(step));
         return;
@@ -96,7 +96,7 @@ export const NumberInput = React.forwardRef(
     };
 
     const decrement = (fromKeyBoard) => {
-      if (inputValue === '') {
+      if (inputValue === undefined) {
         onValueChange(-step);
         setInputValue(String(-step));
         return;

--- a/packages/strapi-design-system/src/NumberInput/NumberInput.js
+++ b/packages/strapi-design-system/src/NumberInput/NumberInput.js
@@ -50,11 +50,7 @@ export const NumberInput = React.forwardRef(
     const [inputValue, setInputValue] = useState(value === undefined || value === null ? INITIAL_VALUE : String(value));
     const generatedId = useId('numberinput', id);
     const numberParserRef = useRef(new NumberParser(getDefaultLocale()));
-    const numberFormaterRef = useRef(new NumberFormatter(getDefaultLocale()));
-
-    if (!label && !props['aria-label']) {
-      throw new Error('The NumberInput component needs a "label" or an "aria-label" props');
-    }
+    const numberFormaterRef = useRef(new NumberFormatter(getDefaultLocale(), { maximumSignificantDigits: 21 }));
 
     const handleChange = (e) => {
       const nextValue = e.target.value;
@@ -62,10 +58,8 @@ export const NumberInput = React.forwardRef(
       if (numberParserRef.current.isValidPartialNumber(nextValue)) {
         const parsedValue = nextValue === '' ? undefined : numberParserRef.current.parse(nextValue);
 
-        if (parsedValue === undefined) {
-          onValueChange(undefined);
-        } else if (isNaN(parsedValue)) {
-          // checking NaN case when only typing a "-" (minus) sign inside the field
+        // checking NaN case when only typing a "-" (minus) sign inside the field
+        if (parsedValue === undefined || isNaN(parsedValue)) {
           onValueChange(undefined);
         } else {
           onValueChange(parsedValue);

--- a/packages/strapi-design-system/src/NumberInput/NumberInput.js
+++ b/packages/strapi-design-system/src/NumberInput/NumberInput.js
@@ -144,7 +144,7 @@ export const NumberInput = React.forwardRef(
 
     const handleFocus = () => {
       if (value !== undefined) {
-        setInputValue(String(numberParserRef.current.parse(inputValue)));
+        setInputValue(String(numberParserRef.current.parse(inputValue) || ''));
       }
     };
 

--- a/packages/strapi-design-system/src/NumberInput/NumberInput.js
+++ b/packages/strapi-design-system/src/NumberInput/NumberInput.js
@@ -144,7 +144,7 @@ export const NumberInput = React.forwardRef(
 
     const handleFocus = () => {
       if (value !== undefined) {
-        setInputValue(String(numberParserRef.current.parse(inputValue) || ''));
+        setInputValue(String(numberParserRef.current.parse(inputValue) ?? INITIAL_VALUE));
       }
     };
 

--- a/packages/strapi-design-system/src/NumberInput/NumberInput.stories.mdx
+++ b/packages/strapi-design-system/src/NumberInput/NumberInput.stories.mdx
@@ -250,6 +250,45 @@ NumberInputs are always found in forms. They give users the possibility to add o
   </Story>
 </Canvas>
 
+## With initial empty value
+
+<Canvas>
+  <Story name="with initial empty">
+    {() => {
+      const [content, setContent] = useState('');
+      return (
+        <Box padding={10}>
+          <NumberInput
+            placeholder="This is a content placeholder"
+            label="Content"
+            name="content"
+            hint="Description line"
+            error={undefined}
+            onValueChange={(value) => setContent(value)}
+            value={content}
+            labelAction={
+              <Tooltip description="Content of the tooltip">
+                <button
+                  aria-label="Information about the email"
+                  style={{ border: 'none', padding: 0, background: 'transparent' }}
+                >
+                  <Information aria-hidden={true} />
+                </button>
+              </Tooltip>
+            }
+          />
+          <Box as="p" padding={4} background="neutral100">
+            <Typography>{`The value is ${content}`}</Typography>
+          </Box>
+          <button>
+            <Typography>Escape</Typography>
+          </button>
+        </Box>
+      );
+    }}
+  </Story>
+</Canvas>
+
 ## Props
 
 <ArgsTable of={NumberInput} />

--- a/packages/strapi-design-system/src/NumberInput/NumberInput.stories.mdx
+++ b/packages/strapi-design-system/src/NumberInput/NumberInput.stories.mdx
@@ -40,7 +40,7 @@ NumberInputs are always found in forms. They give users the possibility to add o
 <Canvas>
   <Story name="base">
     {() => {
-      const [content, setContent] = useState();
+      const [content, setContent] = useState(3.14159265359);
       return (
         <Box padding={10}>
           <NumberInput

--- a/packages/strapi-design-system/src/NumberInput/__tests__/NumberInput.e2e.js
+++ b/packages/strapi-design-system/src/NumberInput/__tests__/NumberInput.e2e.js
@@ -21,8 +21,16 @@ test.describe.parallel('NumberInput', () => {
 
         const value = await page.$eval('input', (el) => el.value);
         expect(value).toBe('123.123');
-        //TODO
-        // expect(await page.$('text="The value is 123123"')).toBeTruthy();
+      });
+
+      test('fills the input when typing valid float numbers with more than 3 significant digits after the seperator', async ({
+        page,
+      }) => {
+        await page.fill('input', '1.23456789');
+        await page.keyboard.press('Tab');
+
+        const value = await page.$eval('input', (el) => el.value);
+        expect(value).toBe('1.23456789');
       });
 
       test('fills the input when typing a valid numeric and a trailing comma', async ({ page }) => {
@@ -46,12 +54,13 @@ test.describe.parallel('NumberInput', () => {
 
       test('puts the step value in the input when pressing ArrowUp and that the input is empty', async ({ page }) => {
         await page.focus('input');
+        await page.fill('input', '1,');
         await page.keyboard.press('ArrowUp');
         await page.keyboard.press('Tab');
 
         const value = await page.$eval('input', (el) => el.value);
-        expect(value).toBe('1');
-        expect(await page.$('text="The value is 1"')).toBeTruthy();
+        expect(value).toBe('2');
+        expect(await page.$('text="The value is 2"')).toBeTruthy();
       });
 
       test('puts the step value in the input when pressing ArrowDown and that the input contains only the minus sign', async ({
@@ -68,6 +77,7 @@ test.describe.parallel('NumberInput', () => {
 
       test('puts the step value in the input when pressing ArrowDown and that the input is empty', async ({ page }) => {
         await page.focus('input');
+        await page.fill('input', '-');
         await page.keyboard.press('ArrowDown');
         await page.keyboard.press('Tab');
 
@@ -89,6 +99,7 @@ test.describe.parallel('NumberInput', () => {
       });
 
       test('increments the value when clicking on ArrowUp without blur needed', async ({ page }) => {
+        await page.fill('input', '0');
         await page.click('[data-testid="ArrowUp"]');
 
         const value = await page.$eval('input', (el) => el.value);
@@ -97,6 +108,7 @@ test.describe.parallel('NumberInput', () => {
       });
 
       test('decrements the value when clicking on ArrowUp without blur needed', async ({ page }) => {
+        await page.fill('input', '0');
         await page.click('[data-testid="ArrowDown"]');
 
         const value = await page.$eval('input', (el) => el.value);

--- a/packages/strapi-design-system/src/NumberInput/__tests__/NumberInput.e2e.js
+++ b/packages/strapi-design-system/src/NumberInput/__tests__/NumberInput.e2e.js
@@ -63,6 +63,16 @@ test.describe.parallel('NumberInput', () => {
         expect(await page.$('text="The value is 2"')).toBeTruthy();
       });
 
+      test('keeps zero/ a falsy value on blur/ focus', async ({ page }) => {
+        await page.focus('input');
+        await page.fill('input', '0,');
+        await page.keyboard.press('Tab');
+        await page.focus('input');
+
+        const value = await page.$eval('input', (el) => el.value);
+        expect(value).toBe('0');
+      });
+
       test('puts the step value in the input when pressing ArrowDown and that the input contains only the minus sign', async ({
         page,
       }) => {

--- a/packages/strapi-design-system/src/NumberInput/__tests__/NumberInput.e2e.js
+++ b/packages/strapi-design-system/src/NumberInput/__tests__/NumberInput.e2e.js
@@ -125,6 +125,22 @@ test.describe.parallel('NumberInput', () => {
         expect(value).toBe('-1');
         expect(await page.$('text="The value is -1"')).toBeTruthy();
       });
+
+      test('increments the value eventhough the field is empty', async ({ page }) => {
+        await page.fill('input', '');
+        await page.click('[data-testid="ArrowUp"]');
+
+        const value = await page.$eval('input', (el) => el.value);
+        expect(value).toBe('1');
+      });
+
+      test('decrements the value eventhough the field is empty', async ({ page }) => {
+        await page.fill('input', '');
+        await page.click('[data-testid="ArrowDown"]');
+
+        const value = await page.$eval('input', (el) => el.value);
+        expect(value).toBe('-1');
+      });
     });
 
     test.describe('with initial value', () => {

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -28197,7 +28197,7 @@ exports[`Storyshots Design System/Components/NumberInput base 1`] = `
                 name="content"
                 placeholder="This is a content placeholder"
                 type="text"
-                value=""
+                value="3.14159265359"
               />
               <div
                 class="c13"
@@ -28264,7 +28264,7 @@ exports[`Storyshots Design System/Components/NumberInput base 1`] = `
           <span
             class="c20"
           >
-            The value is undefined
+            The value is 3.14159265359
           </span>
         </p>
         <button>

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -29730,6 +29730,395 @@ exports[`Storyshots Design System/Components/NumberInput with initial 0 1`] = `
 </div>
 `;
 
+exports[`Storyshots Design System/Components/NumberInput with initial empty 1`] = `
+.c1 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c0 {
+  background: #ffffff;
+  padding: 8px;
+}
+
+.c2 {
+  padding: 8px;
+  height: 100%;
+}
+
+.c3 {
+  padding: 56px;
+}
+
+.c8 {
+  margin-left: 4px;
+}
+
+.c13 {
+  padding-right: 12px;
+  padding-left: 8px;
+}
+
+.c15 {
+  color: #8e8ea9;
+}
+
+.c19 {
+  background: #f6f6f9;
+  padding: 16px;
+}
+
+.c6 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c18 {
+  color: #666687;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c20 {
+  color: #32324d;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
+.c4 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c10 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c5 > * {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.c5 > * + * {
+  margin-top: 4px;
+}
+
+.c16 path {
+  fill: #8e8ea9;
+}
+
+.c9 {
+  line-height: 0;
+}
+
+.c9 svg path {
+  fill: #8e8ea9;
+}
+
+.c12 {
+  border: none;
+  border-radius: 4px;
+  padding-bottom: 0.65625rem;
+  padding-left: 16px;
+  padding-right: 0;
+  padding-top: 0.65625rem;
+  color: #32324d;
+  font-weight: 400;
+  font-size: 0.875rem;
+  display: block;
+  width: 100%;
+  background: inherit;
+}
+
+.c12::-webkit-input-placeholder {
+  color: #8e8ea9;
+  opacity: 1;
+}
+
+.c12::-moz-placeholder {
+  color: #8e8ea9;
+  opacity: 1;
+}
+
+.c12:-ms-input-placeholder {
+  color: #8e8ea9;
+  opacity: 1;
+}
+
+.c12::placeholder {
+  color: #8e8ea9;
+  opacity: 1;
+}
+
+.c12[aria-disabled='true'] {
+  color: inherit;
+}
+
+.c12:focus {
+  outline: none;
+  box-shadow: none;
+}
+
+.c11 {
+  border: 1px solid #dcdce4;
+  border-radius: 4px;
+  background: #ffffff;
+  outline: none;
+  box-shadow: 0;
+  -webkit-transition-property: border-color,box-shadow,fill;
+  transition-property: border-color,box-shadow,fill;
+  -webkit-transition-duration: 0.2s;
+  transition-duration: 0.2s;
+}
+
+.c11:focus-within {
+  border: 1px solid #4945ff;
+  box-shadow: #4945ff 0px 0px 0px 2px;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 1rem;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  -webkit-transform: translateY(-2px);
+  -ms-transform: translateY(-2px);
+  transform: translateY(-2px);
+}
+
+.c14 svg {
+  display: block;
+  height: 0.25rem;
+  -webkit-transform: rotateX(180deg);
+  -ms-transform: rotateX(180deg);
+  transform: rotateX(180deg);
+}
+
+.c17 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 1rem;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-transform: translateY(2px);
+  -ms-transform: translateY(2px);
+  transform: translateY(2px);
+}
+
+.c17 svg {
+  display: block;
+  height: 0.25rem;
+}
+
+<div
+  class="c0"
+>
+  <main>
+    <div
+      class="c1"
+    >
+      <h1>
+        Storybook story
+      </h1>
+    </div>
+    <div
+      class="c2"
+      height="100%"
+    >
+      <div
+        class="c3"
+      >
+        <div>
+          <div
+            class="c4 c5"
+            spacing="1"
+          >
+            <label
+              class="c6"
+              for="numberinput-122"
+            >
+              <div
+                class="c7"
+              >
+                Content
+                <div
+                  class="c8 c7 c9"
+                >
+                  <span>
+                    <button
+                      aria-describedby="tooltip-123"
+                      aria-label="Information about the email"
+                      style="padding: 0px; background: transparent;"
+                      tabindex="0"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        fill="none"
+                        height="1em"
+                        viewBox="0 0 24 24"
+                        width="1em"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 0C5.383 0 0 5.383 0 12s5.383 12 12 12 12-5.383 12-12S18.617 0 12 0zm0 4.92a1.56 1.56 0 110 3.12 1.56 1.56 0 010-3.12zm3.84 13.06a.5.5 0 01-.5.5h-6.2a.5.5 0 01-.5-.5v-.92a.5.5 0 01.5-.5h2.14v-5.28H9.86a.5.5 0 01-.5-.5v-.92a.5.5 0 01.5-.5h2.84a.5.5 0 01.5.5v6.7h2.14a.5.5 0 01.5.5v.92z"
+                          fill="#212134"
+                        />
+                      </svg>
+                    </button>
+                  </span>
+                </div>
+              </div>
+            </label>
+            <div
+              class="c10 c11"
+            >
+              <input
+                aria-describedby="numberinput-122-hint"
+                aria-disabled="false"
+                aria-invalid="false"
+                class="c12"
+                id="numberinput-122"
+                name="content"
+                placeholder="This is a content placeholder"
+                type="text"
+                value=""
+              />
+              <div
+                class="c13"
+              >
+                <button
+                  aria-hidden="true"
+                  class="c14"
+                  data-testid="ArrowUp"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    class="c15 c16"
+                    fill="none"
+                    height="1em"
+                    viewBox="0 0 14 8"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
+                      fill="#32324D"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-hidden="true"
+                  class="c17"
+                  data-testid="ArrowDown"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    class="c15 c16"
+                    fill="none"
+                    height="1em"
+                    viewBox="0 0 14 8"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
+                      fill="#32324D"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <p
+              class="c18"
+              id="numberinput-122-hint"
+            >
+              Description line
+            </p>
+          </div>
+        </div>
+        <p
+          class="c19"
+        >
+          <span
+            class="c20"
+          >
+            The value is 
+          </span>
+        </p>
+        <button>
+          <span
+            class="c20"
+          >
+            Escape
+          </span>
+        </button>
+      </div>
+    </div>
+  </main>
+</div>
+`;
+
 exports[`Storyshots Design System/Components/NumberInput withoutLabel 1`] = `
 .c1 {
   border: 0;
@@ -29959,12 +30348,12 @@ exports[`Storyshots Design System/Components/NumberInput withoutLabel 1`] = `
               class="c6 c7"
             >
               <input
-                aria-describedby="numberinput-122-hint"
+                aria-describedby="numberinput-125-hint"
                 aria-disabled="false"
                 aria-invalid="false"
                 aria-label="Content"
                 class="c8"
-                id="numberinput-122"
+                id="numberinput-125"
                 name="content"
                 placeholder="This is a content placeholder"
                 type="text"
@@ -30023,7 +30412,7 @@ exports[`Storyshots Design System/Components/NumberInput withoutLabel 1`] = `
             </div>
             <p
               class="c14"
-              id="numberinput-122-hint"
+              id="numberinput-125-hint"
             >
               Description line
             </p>
@@ -31154,7 +31543,7 @@ exports[`Storyshots Design System/Components/Searchbar base 1`] = `
             >
               <label
                 class="c4"
-                for="field-123"
+                for="field-126"
               >
                 <div
                   class="c5"
@@ -31193,7 +31582,7 @@ exports[`Storyshots Design System/Components/Searchbar base 1`] = `
                 aria-disabled="false"
                 aria-invalid="false"
                 class="c12"
-                id="field-123"
+                id="field-126"
                 name="searchbar"
                 placeholder="e.g: strapi-plugin-abcd"
                 value=""
@@ -31394,7 +31783,7 @@ exports[`Storyshots Design System/Components/Searchbar disabled 1`] = `
           >
             <label
               class="c4"
-              for="field-124"
+              for="field-127"
             >
               <div
                 class="c5"
@@ -31434,7 +31823,7 @@ exports[`Storyshots Design System/Components/Searchbar disabled 1`] = `
               aria-disabled="true"
               aria-invalid="false"
               class="c12"
-              id="field-124"
+              id="field-127"
               name="searchbar"
               placeholder="e.g: strapi-plugin-abcd"
               value=""
@@ -31634,7 +32023,7 @@ exports[`Storyshots Design System/Components/Searchbar size S 1`] = `
             >
               <label
                 class="c4"
-                for="field-125"
+                for="field-128"
               >
                 <div
                   class="c5"
@@ -31673,7 +32062,7 @@ exports[`Storyshots Design System/Components/Searchbar size S 1`] = `
                 aria-disabled="false"
                 aria-invalid="false"
                 class="c12"
-                id="field-125"
+                id="field-128"
                 name="searchbar"
                 placeholder="e.g: strapi-plugin-abcd"
                 value=""
@@ -34239,7 +34628,7 @@ exports[`Storyshots Design System/Components/SimpleMenu sizes 1`] = `
       >
         <div>
           <button
-            aria-controls="simplemenu-126"
+            aria-controls="simplemenu-129"
             aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="true"
@@ -34280,7 +34669,7 @@ exports[`Storyshots Design System/Components/SimpleMenu sizes 1`] = `
         </div>
         <div>
           <button
-            aria-controls="simplemenu-127"
+            aria-controls="simplemenu-130"
             aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="true"
@@ -34523,7 +34912,7 @@ exports[`Storyshots Design System/Components/SimpleMenu with-custom-label 1`] = 
     >
       <div>
         <button
-          aria-controls="simplemenu-128"
+          aria-controls="simplemenu-131"
           aria-disabled="false"
           aria-expanded="false"
           aria-haspopup="true"
@@ -34708,11 +35097,11 @@ exports[`Storyshots Design System/Components/SimpleMenu with-iconbutton 1`] = `
       <div>
         <span>
           <button
-            aria-controls="simplemenu-129"
+            aria-controls="simplemenu-132"
             aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="true"
-            aria-labelledby="tooltip-130"
+            aria-labelledby="tooltip-133"
             class="c3 c4"
             tabindex="0"
             type="button"
@@ -34937,7 +35326,7 @@ exports[`Storyshots Design System/Components/SimpleMenu with-links 1`] = `
     >
       <div>
         <button
-          aria-controls="simplemenu-132"
+          aria-controls="simplemenu-135"
           aria-disabled="false"
           aria-expanded="false"
           aria-haspopup="true"
@@ -35753,7 +36142,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                 <span>
                   <button
                     aria-disabled="false"
-                    aria-labelledby="tooltip-134"
+                    aria-labelledby="tooltip-137"
                     class="c10 c11"
                     tabindex="0"
                     type="button"
@@ -35801,7 +36190,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                         class="c21"
                       >
                         <button
-                          aria-controls="subnav-list-136"
+                          aria-controls="subnav-list-139"
                           aria-expanded="true"
                           class="c3 c22"
                         >
@@ -35846,7 +36235,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       </div>
                     </div>
                     <ul
-                      id="subnav-list-136"
+                      id="subnav-list-139"
                     >
                       <li>
                         <a
@@ -36036,7 +36425,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                         class="c21"
                       >
                         <button
-                          aria-controls="subnav-list-137"
+                          aria-controls="subnav-list-140"
                           aria-expanded="true"
                           class="c3 c22"
                         >
@@ -36081,7 +36470,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       </div>
                     </div>
                     <ul
-                      id="subnav-list-137"
+                      id="subnav-list-140"
                     >
                       <li>
                         <div
@@ -36094,7 +36483,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                               class="c21"
                             >
                               <button
-                                aria-controls="subnav-list-138"
+                                aria-controls="subnav-list-141"
                                 aria-expanded="true"
                                 class="c40"
                               >
@@ -36130,7 +36519,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             </div>
                           </div>
                           <ul
-                            id="subnav-list-138"
+                            id="subnav-list-141"
                           >
                             <li>
                               <a
@@ -36432,7 +36821,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       </div>
                     </div>
                     <ul
-                      id="subnav-list-140"
+                      id="subnav-list-143"
                     >
                       <li>
                         <a
@@ -36537,7 +36926,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       </div>
                     </div>
                     <ul
-                      id="subnav-list-141"
+                      id="subnav-list-144"
                     >
                       <li>
                         <a
@@ -36736,7 +37125,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       </div>
                     </div>
                     <ul
-                      id="subnav-list-143"
+                      id="subnav-list-146"
                     >
                       <li>
                         <div
@@ -36749,7 +37138,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                               class="c21"
                             >
                               <button
-                                aria-controls="subnav-list-144"
+                                aria-controls="subnav-list-147"
                                 aria-expanded="true"
                                 class="c40"
                               >
@@ -36785,7 +37174,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             </div>
                           </div>
                           <ul
-                            id="subnav-list-144"
+                            id="subnav-list-147"
                           >
                             <li>
                               <a
@@ -36961,7 +37350,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       </div>
                     </div>
                     <ul
-                      id="subnav-list-145"
+                      id="subnav-list-148"
                     >
                       <li>
                         <a
@@ -38050,7 +38439,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-146"
+                            aria-labelledby="tooltip-149"
                             class="c21 c22"
                             tabindex="-1"
                             type="button"
@@ -38077,7 +38466,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-148"
+                              aria-labelledby="tooltip-151"
                               class="c21 c22"
                               tabindex="-1"
                               type="button"
@@ -38188,7 +38577,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-150"
+                            aria-labelledby="tooltip-153"
                             class="c21 c22"
                             tabindex="-1"
                             type="button"
@@ -38215,7 +38604,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-152"
+                              aria-labelledby="tooltip-155"
                               class="c21 c22"
                               tabindex="-1"
                               type="button"
@@ -38326,7 +38715,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-154"
+                            aria-labelledby="tooltip-157"
                             class="c21 c22"
                             tabindex="-1"
                             type="button"
@@ -38353,7 +38742,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-156"
+                              aria-labelledby="tooltip-159"
                               class="c21 c22"
                               tabindex="-1"
                               type="button"
@@ -38464,7 +38853,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-158"
+                            aria-labelledby="tooltip-161"
                             class="c21 c22"
                             tabindex="-1"
                             type="button"
@@ -38491,7 +38880,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-160"
+                              aria-labelledby="tooltip-163"
                               class="c21 c22"
                               tabindex="-1"
                               type="button"
@@ -38602,7 +38991,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-162"
+                            aria-labelledby="tooltip-165"
                             class="c21 c22"
                             tabindex="-1"
                             type="button"
@@ -38629,7 +39018,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-164"
+                              aria-labelledby="tooltip-167"
                               class="c21 c22"
                               tabindex="-1"
                               type="button"
@@ -39292,7 +39681,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-166"
+                            aria-labelledby="tooltip-169"
                             class="c21 c22"
                             tabindex="-1"
                             type="button"
@@ -39319,7 +39708,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-168"
+                              aria-labelledby="tooltip-171"
                               class="c21 c22"
                               tabindex="-1"
                               type="button"
@@ -39430,7 +39819,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-170"
+                            aria-labelledby="tooltip-173"
                             class="c21 c22"
                             tabindex="-1"
                             type="button"
@@ -39457,7 +39846,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-172"
+                              aria-labelledby="tooltip-175"
                               class="c21 c22"
                               tabindex="-1"
                               type="button"
@@ -39568,7 +39957,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-174"
+                            aria-labelledby="tooltip-177"
                             class="c21 c22"
                             tabindex="-1"
                             type="button"
@@ -39595,7 +39984,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-176"
+                              aria-labelledby="tooltip-179"
                               class="c21 c22"
                               tabindex="-1"
                               type="button"
@@ -39706,7 +40095,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-178"
+                            aria-labelledby="tooltip-181"
                             class="c21 c22"
                             tabindex="-1"
                             type="button"
@@ -39733,7 +40122,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-180"
+                              aria-labelledby="tooltip-183"
                               class="c21 c22"
                               tabindex="-1"
                               type="button"
@@ -39844,7 +40233,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-182"
+                            aria-labelledby="tooltip-185"
                             class="c21 c22"
                             tabindex="-1"
                             type="button"
@@ -39871,7 +40260,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-184"
+                              aria-labelledby="tooltip-187"
                               class="c21 c22"
                               tabindex="-1"
                               type="button"
@@ -40376,7 +40765,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-186"
+                              aria-labelledby="tooltip-189"
                               class="c17 c18"
                               tabindex="-1"
                               type="button"
@@ -40583,7 +40972,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-188"
+                            aria-labelledby="tooltip-191"
                             class="c17 c18"
                             tabindex="-1"
                             type="button"
@@ -40610,7 +40999,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-190"
+                              aria-labelledby="tooltip-193"
                               class="c17 c18"
                               tabindex="-1"
                               type="button"
@@ -40721,7 +41110,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-192"
+                            aria-labelledby="tooltip-195"
                             class="c17 c18"
                             tabindex="-1"
                             type="button"
@@ -40748,7 +41137,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-194"
+                              aria-labelledby="tooltip-197"
                               class="c17 c18"
                               tabindex="-1"
                               type="button"
@@ -40859,7 +41248,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-196"
+                            aria-labelledby="tooltip-199"
                             class="c17 c18"
                             tabindex="-1"
                             type="button"
@@ -40886,7 +41275,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-198"
+                              aria-labelledby="tooltip-201"
                               class="c17 c18"
                               tabindex="-1"
                               type="button"
@@ -40997,7 +41386,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-200"
+                            aria-labelledby="tooltip-203"
                             class="c17 c18"
                             tabindex="-1"
                             type="button"
@@ -41024,7 +41413,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-202"
+                              aria-labelledby="tooltip-205"
                               class="c17 c18"
                               tabindex="-1"
                               type="button"
@@ -41135,7 +41524,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-204"
+                            aria-labelledby="tooltip-207"
                             class="c17 c18"
                             tabindex="-1"
                             type="button"
@@ -41162,7 +41551,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-206"
+                              aria-labelledby="tooltip-209"
                               class="c17 c18"
                               tabindex="-1"
                               type="button"
@@ -42734,7 +43123,7 @@ exports[`Storyshots Design System/Components/TextInput base 1`] = `
             >
               <label
                 class="c6"
-                for="textinput-208"
+                for="textinput-211"
               >
                 <div
                   class="c7"
@@ -42745,7 +43134,7 @@ exports[`Storyshots Design System/Components/TextInput base 1`] = `
                   >
                     <span>
                       <button
-                        aria-describedby="tooltip-209"
+                        aria-describedby="tooltip-212"
                         aria-label="Information about the email"
                         style="padding: 0px; background: transparent;"
                         tabindex="0"
@@ -42772,11 +43161,11 @@ exports[`Storyshots Design System/Components/TextInput base 1`] = `
                 class="c10 c11"
               >
                 <input
-                  aria-describedby="textinput-208-hint"
+                  aria-describedby="textinput-211-hint"
                   aria-disabled="false"
                   aria-invalid="false"
                   class="c12"
-                  id="textinput-208"
+                  id="textinput-211"
                   name="content"
                   placeholder="This is a content placeholder"
                   value=""
@@ -42784,7 +43173,7 @@ exports[`Storyshots Design System/Components/TextInput base 1`] = `
               </div>
               <p
                 class="c13"
-                id="textinput-208-hint"
+                id="textinput-211-hint"
               >
                 Description line
               </p>
@@ -42994,7 +43383,7 @@ exports[`Storyshots Design System/Components/TextInput disabled 1`] = `
             >
               <label
                 class="c6"
-                for="textinput-211"
+                for="textinput-214"
               >
                 <div
                   class="c7"
@@ -43005,7 +43394,7 @@ exports[`Storyshots Design System/Components/TextInput disabled 1`] = `
                   >
                     <span>
                       <button
-                        aria-describedby="tooltip-212"
+                        aria-describedby="tooltip-215"
                         aria-label="Information about the email"
                         style="padding: 0px; background: transparent;"
                         tabindex="0"
@@ -43033,11 +43422,11 @@ exports[`Storyshots Design System/Components/TextInput disabled 1`] = `
                 disabled=""
               >
                 <input
-                  aria-describedby="textinput-211-hint"
+                  aria-describedby="textinput-214-hint"
                   aria-disabled="true"
                   aria-invalid="false"
                   class="c12"
-                  id="textinput-211"
+                  id="textinput-214"
                   name="content"
                   placeholder="This is a content placeholder"
                   value="Disabled ontent"
@@ -43045,7 +43434,7 @@ exports[`Storyshots Design System/Components/TextInput disabled 1`] = `
               </div>
               <p
                 class="c13"
-                id="textinput-211-hint"
+                id="textinput-214-hint"
               >
                 Description line
               </p>
@@ -43252,7 +43641,7 @@ exports[`Storyshots Design System/Components/TextInput password 1`] = `
             >
               <label
                 class="c6"
-                for="textinput-214"
+                for="textinput-217"
               >
                 <div
                   class="c7"
@@ -43263,7 +43652,7 @@ exports[`Storyshots Design System/Components/TextInput password 1`] = `
                   >
                     <span>
                       <button
-                        aria-describedby="tooltip-215"
+                        aria-describedby="tooltip-218"
                         aria-label="Information about the email"
                         style="padding: 0px; background: transparent;"
                         tabindex="0"
@@ -43290,11 +43679,11 @@ exports[`Storyshots Design System/Components/TextInput password 1`] = `
                 class="c10 c11"
               >
                 <input
-                  aria-describedby="textinput-214-hint"
+                  aria-describedby="textinput-217-hint"
                   aria-disabled="false"
                   aria-invalid="false"
                   class="c12"
-                  id="textinput-214"
+                  id="textinput-217"
                   name="password"
                   placeholder="This is a password placeholder"
                   type="password"
@@ -43303,7 +43692,7 @@ exports[`Storyshots Design System/Components/TextInput password 1`] = `
               </div>
               <p
                 class="c13"
-                id="textinput-214-hint"
+                id="textinput-217-hint"
               >
                 Description line
               </p>
@@ -43510,7 +43899,7 @@ exports[`Storyshots Design System/Components/TextInput size S 1`] = `
             >
               <label
                 class="c6"
-                for="textinput-217"
+                for="textinput-220"
               >
                 <div
                   class="c7"
@@ -43521,7 +43910,7 @@ exports[`Storyshots Design System/Components/TextInput size S 1`] = `
                   >
                     <span>
                       <button
-                        aria-describedby="tooltip-218"
+                        aria-describedby="tooltip-221"
                         aria-label="Information about the email"
                         style="padding: 0px; background: transparent;"
                         tabindex="0"
@@ -43548,11 +43937,11 @@ exports[`Storyshots Design System/Components/TextInput size S 1`] = `
                 class="c10 c11"
               >
                 <input
-                  aria-describedby="textinput-217-hint"
+                  aria-describedby="textinput-220-hint"
                   aria-disabled="false"
                   aria-invalid="false"
                   class="c12"
-                  id="textinput-217"
+                  id="textinput-220"
                   name="content"
                   placeholder="This is a content placeholder"
                   value="size S input"
@@ -43560,7 +43949,7 @@ exports[`Storyshots Design System/Components/TextInput size S 1`] = `
               </div>
               <p
                 class="c13"
-                id="textinput-217-hint"
+                id="textinput-220-hint"
               >
                 Description line
               </p>
@@ -43767,7 +44156,7 @@ exports[`Storyshots Design System/Components/TextInput with error 1`] = `
             >
               <label
                 class="c6"
-                for="textinput-220"
+                for="textinput-223"
               >
                 <div
                   class="c7"
@@ -43778,7 +44167,7 @@ exports[`Storyshots Design System/Components/TextInput with error 1`] = `
                   >
                     <span>
                       <button
-                        aria-describedby="tooltip-221"
+                        aria-describedby="tooltip-224"
                         aria-label="Information about the email"
                         style="padding: 0px; background: transparent;"
                         tabindex="0"
@@ -43805,11 +44194,11 @@ exports[`Storyshots Design System/Components/TextInput with error 1`] = `
                 class="c10 c11"
               >
                 <input
-                  aria-describedby="textinput-220-error"
+                  aria-describedby="textinput-223-error"
                   aria-disabled="false"
                   aria-invalid="true"
                   class="c12"
-                  id="textinput-220"
+                  id="textinput-223"
                   name="content"
                   placeholder="This is a content placeholder"
                   value="content"
@@ -43818,7 +44207,7 @@ exports[`Storyshots Design System/Components/TextInput with error 1`] = `
               <p
                 class="c13"
                 data-strapi-field-error="true"
-                id="textinput-220-error"
+                id="textinput-223-error"
               >
                 Content is too long
               </p>
@@ -43994,12 +44383,12 @@ exports[`Storyshots Design System/Components/TextInput withoutLabel 1`] = `
                 class="c6 c7"
               >
                 <input
-                  aria-describedby="textinput-223-hint"
+                  aria-describedby="textinput-226-hint"
                   aria-disabled="false"
                   aria-invalid="false"
                   aria-label="Password"
                   class="c8"
-                  id="textinput-223"
+                  id="textinput-226"
                   name="password"
                   placeholder="This is a password placeholder"
                   type="password"
@@ -44008,7 +44397,7 @@ exports[`Storyshots Design System/Components/TextInput withoutLabel 1`] = `
               </div>
               <p
                 class="c9"
-                id="textinput-223-hint"
+                id="textinput-226-hint"
               >
                 Description line
               </p>
@@ -44234,7 +44623,7 @@ exports[`Storyshots Design System/Components/Textarea base 1`] = `
               >
                 <label
                   class="c8"
-                  for="textarea-224"
+                  for="textarea-227"
                 >
                   <div
                     class="c7"
@@ -44245,7 +44634,7 @@ exports[`Storyshots Design System/Components/Textarea base 1`] = `
                     >
                       <span>
                         <button
-                          aria-describedby="tooltip-225"
+                          aria-describedby="tooltip-228"
                           aria-label="Information about the email"
                           style="padding: 0px; background: transparent;"
                           tabindex="0"
@@ -44273,10 +44662,10 @@ exports[`Storyshots Design System/Components/Textarea base 1`] = `
                 class="c11"
               >
                 <textarea
-                  aria-describedby="textarea-224-error"
+                  aria-describedby="textarea-227-error"
                   aria-invalid="true"
                   class="c12"
-                  id="textarea-224"
+                  id="textarea-227"
                   name="content"
                   placeholder="This is a content placeholder"
                 />
@@ -44284,7 +44673,7 @@ exports[`Storyshots Design System/Components/Textarea base 1`] = `
               <p
                 class="c13"
                 data-strapi-field-error="true"
-                id="textarea-224-error"
+                id="textarea-227-error"
               >
                 Content is too short
               </p>
@@ -44510,7 +44899,7 @@ exports[`Storyshots Design System/Components/Textarea disabled 1`] = `
               >
                 <label
                   class="c8"
-                  for="textarea-227"
+                  for="textarea-230"
                 >
                   <div
                     class="c7"
@@ -44521,7 +44910,7 @@ exports[`Storyshots Design System/Components/Textarea disabled 1`] = `
                     >
                       <span>
                         <button
-                          aria-describedby="tooltip-228"
+                          aria-describedby="tooltip-231"
                           aria-label="Information about the email"
                           style="padding: 0px; background: transparent;"
                           tabindex="0"
@@ -44550,18 +44939,18 @@ exports[`Storyshots Design System/Components/Textarea disabled 1`] = `
                 disabled=""
               >
                 <textarea
-                  aria-describedby="textarea-227-hint"
+                  aria-describedby="textarea-230-hint"
                   aria-invalid="false"
                   class="c12"
                   disabled=""
-                  id="textarea-227"
+                  id="textarea-230"
                   name="content"
                   placeholder="This is a content placeholder"
                 />
               </div>
               <p
                 class="c13"
-                id="textarea-227-hint"
+                id="textarea-230-hint"
               >
                 Description line
               </p>
@@ -48733,7 +49122,7 @@ exports[`Storyshots Design System/Components/ToggleInput base 1`] = `
           >
             <label
               class="c7"
-              for="toggleinput-230"
+              for="toggleinput-233"
             >
               <div
                 class="c6"
@@ -48744,7 +49133,7 @@ exports[`Storyshots Design System/Components/ToggleInput base 1`] = `
                 >
                   <span>
                     <button
-                      aria-describedby="tooltip-231"
+                      aria-describedby="tooltip-234"
                       aria-label="Information about the email"
                       style="padding: 0px; background: transparent;"
                       tabindex="0"
@@ -48804,7 +49193,7 @@ exports[`Storyshots Design System/Components/ToggleInput base 1`] = `
                 aria-disabled="false"
                 checked=""
                 class="c18"
-                id="toggleinput-230"
+                id="toggleinput-233"
                 name="enable-provider"
                 type="checkbox"
               />
@@ -48812,7 +49201,7 @@ exports[`Storyshots Design System/Components/ToggleInput base 1`] = `
           </label>
           <p
             class="c19"
-            id="toggleinput-230-hint"
+            id="toggleinput-233-hint"
           >
             Enable provider
           </p>
@@ -49017,7 +49406,7 @@ exports[`Storyshots Design System/Components/ToggleInput error 1`] = `
           >
             <label
               class="c7"
-              for="toggleinput-233"
+              for="toggleinput-236"
             >
               <div
                 class="c6"
@@ -49061,7 +49450,7 @@ exports[`Storyshots Design System/Components/ToggleInput error 1`] = `
               <input
                 aria-disabled="false"
                 class="c16"
-                id="toggleinput-233"
+                id="toggleinput-236"
                 name="enable-provider"
                 type="checkbox"
               />
@@ -49070,7 +49459,7 @@ exports[`Storyshots Design System/Components/ToggleInput error 1`] = `
           <p
             class="c17"
             data-strapi-field-error="true"
-            id="toggleinput-233-error"
+            id="toggleinput-236-error"
           >
             this field is required
           </p>
@@ -49256,7 +49645,7 @@ exports[`Storyshots Design System/Components/ToggleInput null-value 1`] = `
           >
             <label
               class="c7"
-              for="toggleinput-234"
+              for="toggleinput-237"
             >
               <div
                 class="c6"
@@ -49300,7 +49689,7 @@ exports[`Storyshots Design System/Components/ToggleInput null-value 1`] = `
               <input
                 aria-disabled="false"
                 class="c14"
-                id="toggleinput-234"
+                id="toggleinput-237"
                 name="enable-provider"
                 type="checkbox"
               />
@@ -49308,7 +49697,7 @@ exports[`Storyshots Design System/Components/ToggleInput null-value 1`] = `
           </label>
           <p
             class="c15"
-            id="toggleinput-234-hint"
+            id="toggleinput-237-hint"
           >
             Enable provider
           </p>
@@ -49513,7 +49902,7 @@ exports[`Storyshots Design System/Components/ToggleInput size S 1`] = `
           >
             <label
               class="c7"
-              for="toggleinput-235"
+              for="toggleinput-238"
             >
               <div
                 class="c6"
@@ -49557,7 +49946,7 @@ exports[`Storyshots Design System/Components/ToggleInput size S 1`] = `
               <input
                 aria-disabled="false"
                 class="c16"
-                id="toggleinput-235"
+                id="toggleinput-238"
                 name="enable-provider"
                 type="checkbox"
               />
@@ -49566,7 +49955,7 @@ exports[`Storyshots Design System/Components/ToggleInput size S 1`] = `
           <p
             class="c17"
             data-strapi-field-error="true"
-            id="toggleinput-235-error"
+            id="toggleinput-238-error"
           >
             this field is required
           </p>
@@ -49629,7 +50018,7 @@ exports[`Storyshots Design System/Components/Tooltip base 1`] = `
         </span>
         <span>
           <span
-            aria-describedby="tooltip-236"
+            aria-describedby="tooltip-239"
             class="c3"
             tabindex="0"
           >
@@ -49729,7 +50118,7 @@ exports[`Storyshots Design System/Components/Tooltip grid 1`] = `
           >
             <span>
               <button
-                aria-describedby="tooltip-238"
+                aria-describedby="tooltip-241"
                 tabindex="0"
               >
                 <span
@@ -49749,7 +50138,7 @@ exports[`Storyshots Design System/Components/Tooltip grid 1`] = `
           >
             <span>
               <button
-                aria-describedby="tooltip-240"
+                aria-describedby="tooltip-243"
                 tabindex="0"
               >
                 <span
@@ -49769,7 +50158,7 @@ exports[`Storyshots Design System/Components/Tooltip grid 1`] = `
           >
             <span>
               <button
-                aria-describedby="tooltip-242"
+                aria-describedby="tooltip-245"
                 tabindex="0"
               >
                 <span
@@ -49789,7 +50178,7 @@ exports[`Storyshots Design System/Components/Tooltip grid 1`] = `
           >
             <span>
               <button
-                aria-describedby="tooltip-244"
+                aria-describedby="tooltip-247"
                 tabindex="0"
               >
                 <span
@@ -49854,7 +50243,7 @@ exports[`Storyshots Design System/Components/Tooltip with text inside 1`] = `
       <div>
         <span>
           <span
-            aria-describedby="tooltip-246"
+            aria-describedby="tooltip-249"
             class="c3"
             tabindex="0"
           >
@@ -49865,7 +50254,7 @@ exports[`Storyshots Design System/Components/Tooltip with text inside 1`] = `
       <div>
         <span>
           <button
-            aria-describedby="tooltip-248"
+            aria-describedby="tooltip-251"
             tabindex="0"
           >
             <span
@@ -55019,7 +55408,7 @@ exports[`Storyshots Design System/Components/v2/SimpleMenu sizes 1`] = `
       >
         <div>
           <button
-            aria-controls="simplemenu-250"
+            aria-controls="simplemenu-253"
             aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="true"
@@ -55060,7 +55449,7 @@ exports[`Storyshots Design System/Components/v2/SimpleMenu sizes 1`] = `
         </div>
         <div>
           <button
-            aria-controls="simplemenu-251"
+            aria-controls="simplemenu-254"
             aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="true"
@@ -55303,7 +55692,7 @@ exports[`Storyshots Design System/Components/v2/SimpleMenu with-custom-label 1`]
     >
       <div>
         <button
-          aria-controls="simplemenu-252"
+          aria-controls="simplemenu-255"
           aria-disabled="false"
           aria-expanded="false"
           aria-haspopup="true"
@@ -55488,11 +55877,11 @@ exports[`Storyshots Design System/Components/v2/SimpleMenu with-iconbutton 1`] =
       <div>
         <span>
           <button
-            aria-controls="simplemenu-253"
+            aria-controls="simplemenu-256"
             aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="true"
-            aria-labelledby="tooltip-254"
+            aria-labelledby="tooltip-257"
             class="c3 c4"
             tabindex="0"
             type="button"
@@ -55717,7 +56106,7 @@ exports[`Storyshots Design System/Components/v2/SimpleMenu with-links 1`] = `
     >
       <div>
         <button
-          aria-controls="simplemenu-256"
+          aria-controls="simplemenu-259"
           aria-disabled="false"
           aria-expanded="false"
           aria-haspopup="true"
@@ -56351,7 +56740,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                 <span>
                   <button
                     aria-disabled="false"
-                    aria-labelledby="tooltip-258"
+                    aria-labelledby="tooltip-261"
                     class="c10 c11"
                     tabindex="0"
                     type="button"
@@ -56399,7 +56788,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                         class="c21"
                       >
                         <button
-                          aria-controls="subnav-list-260"
+                          aria-controls="subnav-list-263"
                           aria-expanded="true"
                           class="c3 c22"
                         >
@@ -56444,7 +56833,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                       </div>
                     </div>
                     <ul
-                      id="subnav-list-260"
+                      id="subnav-list-263"
                     >
                       <li>
                         <a
@@ -56638,7 +57027,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                         class="c21"
                       >
                         <button
-                          aria-controls="subnav-list-261"
+                          aria-controls="subnav-list-264"
                           aria-expanded="true"
                           class="c3 c22"
                         >
@@ -56683,7 +57072,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                       </div>
                     </div>
                     <ul
-                      id="subnav-list-261"
+                      id="subnav-list-264"
                     >
                       <li>
                         <div
@@ -56696,7 +57085,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                               class="c21"
                             >
                               <button
-                                aria-controls="subnav-list-262"
+                                aria-controls="subnav-list-265"
                                 aria-expanded="true"
                                 class="c41"
                               >
@@ -56732,7 +57121,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                             </div>
                           </div>
                           <ul
-                            id="subnav-list-262"
+                            id="subnav-list-265"
                           >
                             <li>
                               <a
@@ -57039,7 +57428,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                       </div>
                     </div>
                     <ul
-                      id="subnav-list-264"
+                      id="subnav-list-267"
                     >
                       <li>
                         <a
@@ -57146,7 +57535,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                       </div>
                     </div>
                     <ul
-                      id="subnav-list-265"
+                      id="subnav-list-268"
                     >
                       <li>
                         <a
@@ -57348,7 +57737,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                       </div>
                     </div>
                     <ul
-                      id="subnav-list-267"
+                      id="subnav-list-270"
                     >
                       <li>
                         <div
@@ -57361,7 +57750,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                               class="c21"
                             >
                               <button
-                                aria-controls="subnav-list-268"
+                                aria-controls="subnav-list-271"
                                 aria-expanded="true"
                                 class="c41"
                               >
@@ -57397,7 +57786,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                             </div>
                           </div>
                           <ul
-                            id="subnav-list-268"
+                            id="subnav-list-271"
                           >
                             <li>
                               <a
@@ -57577,7 +57966,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                       </div>
                     </div>
                     <ul
-                      id="subnav-list-269"
+                      id="subnav-list-272"
                     >
                       <li>
                         <a


### PR DESCRIPTION
### What does it do?

Fixes issue https://github.com/strapi/strapi/issues/11821: currently we don't display the appropriate number of digits after the comma for float values. This PR ensures, we display up to 21 digits after the comma instead of 3 by default.

### Why is it needed?

To properly display float values across the UI.

### How to test it?

#### Currently

1. Navigate to https://design-system-git-main-strapijs.vercel.app/?path=/story/design-system-components-numberinput--base
2. Enter `3.14159265359`
3. Blur the field

#### This PR

1. Navigate to https://design-system-git-fix-number-significant-digits-strapijs.vercel.app/?path=/story/design-system-components-numberinput--base
2. Blur the field

### Related issue(s)/PR(s)

- Refs https://github.com/strapi/strapi/issues/11821
- Fixes https://github.com/strapi/design-system/issues/581
- Fixes https://strapi-inc.atlassian.net/browse/DS-69
- Fixes https://github.com/strapi/design-system/issues/654
