### PR TITLE
[Breadcrumbs update] HeaderLayout subtitle node support

### DIFF
--- a/packages/strapi-design-system/src/Layout/HeaderLayout.js
+++ b/packages/strapi-design-system/src/Layout/HeaderLayout.js
@@ -63,6 +63,8 @@ const StickyBox = styled(Box)`
 
 export const BaseHeaderLayout = React.forwardRef(
   ({ navigationAction, primaryAction, secondaryAction, subtitle, title, sticky, width, ...props }, ref) => {
+    const isSubtitleString = typeof subtitle === 'string';
+
     if (sticky) {
       return (
         <StickyBox
@@ -81,9 +83,13 @@ export const BaseHeaderLayout = React.forwardRef(
                 <Typography variant="beta" as="h1" {...props}>
                   {title}
                 </Typography>
-                <Typography variant="pi" textColor="neutral600">
-                  {subtitle}
-                </Typography>
+                {isSubtitleString ? (
+                  <Typography variant="pi" textColor="neutral600">
+                    {subtitle}
+                  </Typography>
+                ) : (
+                  subtitle
+                )}
               </Box>
               {secondaryAction ? <Box paddingLeft={4}>{secondaryAction}</Box> : null}
             </Flex>
@@ -113,9 +119,13 @@ export const BaseHeaderLayout = React.forwardRef(
           </Flex>
           {primaryAction}
         </Flex>
-        <Typography variant="epsilon" textColor="neutral600" as="p">
-          {subtitle}
-        </Typography>
+        {isSubtitleString ? (
+          <Typography variant="epsilon" textColor="neutral600" as="p">
+            {subtitle}
+          </Typography>
+        ) : (
+          subtitle
+        )}
       </Box>
     );
   },
@@ -137,7 +147,7 @@ BaseHeaderLayout.propTypes = {
   primaryAction: PropTypes.node,
   secondaryAction: PropTypes.node,
   sticky: PropTypes.bool,
-  subtitle: PropTypes.string,
+  subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   title: PropTypes.string.isRequired,
   width: PropTypes.number,
 };
@@ -153,6 +163,6 @@ HeaderLayout.propTypes = {
   navigationAction: PropTypes.node,
   primaryAction: PropTypes.node,
   secondaryAction: PropTypes.node,
-  subtitle: PropTypes.string,
+  subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   title: PropTypes.string.isRequired,
 };

--- a/packages/strapi-design-system/src/Layout/HeaderLayout.js
+++ b/packages/strapi-design-system/src/Layout/HeaderLayout.js
@@ -147,6 +147,7 @@ BaseHeaderLayout.propTypes = {
   primaryAction: PropTypes.node,
   secondaryAction: PropTypes.node,
   sticky: PropTypes.bool,
+  // TODO V2: Remove the string fallback
   subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   title: PropTypes.string.isRequired,
   width: PropTypes.number,
@@ -163,6 +164,7 @@ HeaderLayout.propTypes = {
   navigationAction: PropTypes.node,
   primaryAction: PropTypes.node,
   secondaryAction: PropTypes.node,
+  // TODO V2: Remove the string fallback
   subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   title: PropTypes.string.isRequired,
 };

--- a/packages/strapi-design-system/src/Layout/HeaderLayout.stories.mdx
+++ b/packages/strapi-design-system/src/Layout/HeaderLayout.stories.mdx
@@ -9,6 +9,7 @@ import Plus from '@strapi/icons/Plus';
 import { BaseHeaderLayout, HeaderLayout } from './HeaderLayout';
 import { ModalLayout } from '../ModalLayout';
 import { Link } from '../Link';
+import { Breadcrumbs, Crumb } from '../Breadcrumbs';
 import { Button } from '../Button';
 import { Box } from '../Box';
 import { VisuallyHidden } from '../VisuallyHidden';
@@ -62,7 +63,7 @@ Headers are placed at the very top of each page. Descriptions and buttons are op
   </Story>
 </Canvas>
 
-### BaseHeaderLayout without nav action
+### HeaderLayout without nav action
 
 <Canvas>
   <Story name="base without nav action">
@@ -82,7 +83,26 @@ Headers are placed at the very top of each page. Descriptions and buttons are op
   </Story>
 </Canvas>
 
-### BaseHeaderLayout sticky
+### HeaderLayout with custom subtitle
+
+<Canvas>
+  <Story name="base with custom subtitle">
+    <Box background="neutral100">
+      <BaseHeaderLayout
+        title="Media Library"
+        subtitle={
+          <Breadcrumbs label="folders">
+            <Crumb>Animals</Crumb>
+            <Crumb>Cats</Crumb>
+          </Breadcrumbs>
+        }
+        as="h2"
+      />
+    </Box>
+  </Story>
+</Canvas>
+
+### HeaderLayout sticky
 
 <Canvas>
   <Story name="sticky">

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -17309,6 +17309,226 @@ exports[`Storyshots Design System/Components/HeaderLayout base 1`] = `
 </div>
 `;
 
+exports[`Storyshots Design System/Components/HeaderLayout base with custom subtitle 1`] = `
+.c2 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c1 {
+  background: #ffffff;
+  padding: 8px;
+}
+
+.c3 {
+  padding: 8px;
+  height: 100%;
+}
+
+.c4 {
+  background: #f6f6f9;
+}
+
+.c5 {
+  background: #f6f6f9;
+  padding-top: 40px;
+  padding-right: 56px;
+  padding-bottom: 40px;
+  padding-left: 56px;
+}
+
+.c12 {
+  padding-right: 12px;
+  padding-left: 12px;
+}
+
+.c8 {
+  color: #32324d;
+  font-weight: 600;
+  font-size: 2rem;
+  line-height: 1.25;
+}
+
+.c11 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
+.c6 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c9 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c10 svg {
+  height: 10px;
+  width: 10px;
+}
+
+.c10 svg path {
+  fill: #c0c0cf;
+}
+
+.c10:last-of-type .c0 {
+  display: none;
+}
+
+<div
+  class="c0 c1"
+>
+  <main>
+    <div
+      class="c2"
+    >
+      <h1>
+        Storybook story
+      </h1>
+    </div>
+    <div
+      class="c0 c3"
+      height="100%"
+    >
+      <div
+        class="c0 c4"
+      >
+        <div
+          class="c0 c5"
+          data-strapi-header="true"
+        >
+          <div
+            class="c0 c6"
+          >
+            <div
+              class="c0 c7"
+            >
+              <h2
+                class="c8"
+              >
+                Media Library
+              </h2>
+            </div>
+          </div>
+          <div
+            class="c0 c7"
+          >
+            <div
+              class="c2"
+            >
+              folders
+            </div>
+            <ol
+              aria-hidden="true"
+            >
+              <li
+                class="c0 c9 c10"
+              >
+                <span
+                  class="c11"
+                  color="neutral800"
+                >
+                  Animals
+                </span>
+                <div
+                  class="c0 c12"
+                >
+                  <svg
+                    fill="none"
+                    height="1em"
+                    viewBox="0 0 10 16"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M0 1.88L6.107 8 0 14.12 1.88 16l8-8-8-8L0 1.88z"
+                      fill="#32324D"
+                    />
+                  </svg>
+                </div>
+              </li>
+              <li
+                class="c0 c9 c10"
+              >
+                <span
+                  class="c11"
+                  color="neutral800"
+                >
+                  Cats
+                </span>
+                <div
+                  class="c0 c12"
+                >
+                  <svg
+                    fill="none"
+                    height="1em"
+                    viewBox="0 0 10 16"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M0 1.88L6.107 8 0 14.12 1.88 16l8-8-8-8L0 1.88z"
+                      fill="#32324D"
+                    />
+                  </svg>
+                </div>
+              </li>
+            </ol>
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+</div>
+`;
+
 exports[`Storyshots Design System/Components/HeaderLayout base without nav action 1`] = `
 .c2 {
   border: 0;


### PR DESCRIPTION
## What

- Extending HeaderLayout subtitle type support needed for ML folders

## Snapshot

<img width="957" alt="image" src="https://user-images.githubusercontent.com/71838159/177968588-019469fa-6b97-4b90-b961-5c26a24bdfc5.png">
