### PR TITLE
Breadcrumbs: Implement v2 version

### DIFF
--- a/packages/strapi-design-system/src/Breadcrumbs/Breadcrumbs.js
+++ b/packages/strapi-design-system/src/Breadcrumbs/Breadcrumbs.js
@@ -9,24 +9,28 @@ import { VisuallyHidden } from '../VisuallyHidden';
 
 const CrumbWrapper = styled(Flex)`
   svg {
-    height: 10px;
-    width: 10px;
-  }
-  svg path {
-    fill: ${({ theme }) => theme.colors.neutral300};
+    height: ${10 / 16}rem;
+    width: ${10 / 16}rem;
+    path {
+      fill: ${({ theme }) => theme.colors.neutral500};
+    }
   }
   :last-of-type ${Box} {
     display: none;
+  }
+  :last-of-type ${Typography} {
+    color: ${({ theme }) => theme.colors.neutral800};
+    font-weight: ${({ theme }) => theme.fontWeights.bold};
   }
 `;
 
 export const Crumb = ({ children }) => {
   return (
     <CrumbWrapper inline as="li">
-      <Typography fontWeight="bold" color="neutral800">
+      <Typography variant="pi" textColor="neutral600">
         {children}
       </Typography>
-      <Box paddingLeft={3} paddingRight={3}>
+      <Box aria-hidden paddingLeft={3} paddingRight={3}>
         <ChevronRight />
       </Box>
     </CrumbWrapper>

--- a/packages/strapi-design-system/src/Layout/HeaderLayout.js
+++ b/packages/strapi-design-system/src/Layout/HeaderLayout.js
@@ -63,6 +63,8 @@ const StickyBox = styled(Box)`
 
 export const BaseHeaderLayout = React.forwardRef(
   ({ navigationAction, primaryAction, secondaryAction, subtitle, title, sticky, width, ...props }, ref) => {
+    const isSubtitleString = typeof subtitle === 'string';
+
     if (sticky) {
       return (
         <StickyBox
@@ -81,9 +83,13 @@ export const BaseHeaderLayout = React.forwardRef(
                 <Typography variant="beta" as="h1" {...props}>
                   {title}
                 </Typography>
-                <Typography variant="pi" textColor="neutral600">
-                  {subtitle}
-                </Typography>
+                {isSubtitleString ? (
+                  <Typography variant="pi" textColor="neutral600">
+                    {subtitle}
+                  </Typography>
+                ) : (
+                  subtitle
+                )}
               </Box>
               {secondaryAction ? <Box paddingLeft={4}>{secondaryAction}</Box> : null}
             </Flex>
@@ -113,9 +119,13 @@ export const BaseHeaderLayout = React.forwardRef(
           </Flex>
           {primaryAction}
         </Flex>
-        <Typography variant="epsilon" textColor="neutral600" as="p">
-          {subtitle}
-        </Typography>
+        {isSubtitleString ? (
+          <Typography variant="epsilon" textColor="neutral600" as="p">
+            {subtitle}
+          </Typography>
+        ) : (
+          subtitle
+        )}
       </Box>
     );
   },
@@ -137,7 +147,8 @@ BaseHeaderLayout.propTypes = {
   primaryAction: PropTypes.node,
   secondaryAction: PropTypes.node,
   sticky: PropTypes.bool,
-  subtitle: PropTypes.string,
+  // TODO V2: Remove the string fallback
+  subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   title: PropTypes.string.isRequired,
   width: PropTypes.number,
 };
@@ -153,6 +164,7 @@ HeaderLayout.propTypes = {
   navigationAction: PropTypes.node,
   primaryAction: PropTypes.node,
   secondaryAction: PropTypes.node,
-  subtitle: PropTypes.string,
+  // TODO V2: Remove the string fallback
+  subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   title: PropTypes.string.isRequired,
 };

--- a/packages/strapi-design-system/src/Layout/HeaderLayout.stories.mdx
+++ b/packages/strapi-design-system/src/Layout/HeaderLayout.stories.mdx
@@ -9,6 +9,7 @@ import Plus from '@strapi/icons/Plus';
 import { BaseHeaderLayout, HeaderLayout } from './HeaderLayout';
 import { ModalLayout } from '../ModalLayout';
 import { Link } from '../Link';
+import { Breadcrumbs, Crumb } from '../Breadcrumbs';
 import { Button } from '../Button';
 import { Box } from '../Box';
 import { VisuallyHidden } from '../VisuallyHidden';
@@ -62,7 +63,7 @@ Headers are placed at the very top of each page. Descriptions and buttons are op
   </Story>
 </Canvas>
 
-### BaseHeaderLayout without nav action
+### HeaderLayout without nav action
 
 <Canvas>
   <Story name="base without nav action">
@@ -82,7 +83,26 @@ Headers are placed at the very top of each page. Descriptions and buttons are op
   </Story>
 </Canvas>
 
-### BaseHeaderLayout sticky
+### HeaderLayout with custom subtitle
+
+<Canvas>
+  <Story name="base with custom subtitle">
+    <Box background="neutral100">
+      <BaseHeaderLayout
+        title="Media Library"
+        subtitle={
+          <Breadcrumbs label="folders">
+            <Crumb>Animals</Crumb>
+            <Crumb>Cats</Crumb>
+          </Breadcrumbs>
+        }
+        as="h2"
+      />
+    </Box>
+  </Story>
+</Canvas>
+
+### HeaderLayout sticky
 
 <Canvas>
   <Story name="sticky">

--- a/packages/strapi-design-system/src/v2/Breadcrumbs/Breadcrumbs.js
+++ b/packages/strapi-design-system/src/v2/Breadcrumbs/Breadcrumbs.js
@@ -1,5 +1,6 @@
 import React, { Children } from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 
 import { Box } from '../../Box';
 import { Crumb } from './Crumb';
@@ -8,10 +9,20 @@ import { CrumbSimpleMenu } from './CrumbSimpleMenu';
 import { Divider } from './Divider';
 import { Flex } from '../../Flex';
 
+const AlignedList = styled(Flex)`
+  // CrumbLinks do have padding-x, because they need to have a
+  // interaction effect, which mis-aligns the breadcrumbs on the left.
+  // This normalizes the behavior by moving the first item to left by
+  // the same amount it has inner padding
+  :first-child {
+    margin-left: ${({ theme }) => `calc(-1*${theme.spaces[2]})`};
+  }
+`;
+
 export const Breadcrumbs = ({ label, children, ...props }) => {
   return (
     <Box aria-label={label} {...props}>
-      <Flex as="ol" horizontal>
+      <AlignedList as="ol" horizontal>
         {Children.map(children, (child, index) => {
           const isLast = index + 1 === children.length;
 
@@ -22,7 +33,7 @@ export const Breadcrumbs = ({ label, children, ...props }) => {
             </Flex>
           );
         })}
-      </Flex>
+      </AlignedList>
     </Box>
   );
 };

--- a/packages/strapi-design-system/src/v2/Breadcrumbs/Breadcrumbs.js
+++ b/packages/strapi-design-system/src/v2/Breadcrumbs/Breadcrumbs.js
@@ -1,0 +1,42 @@
+import React, { Children } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+import { Box } from '../../Box';
+import { Crumb } from './Crumb';
+import { CrumbLink } from './CrumbLink';
+import { CrumbSimpleMenu } from './CrumbSimpleMenu';
+import { Divider } from './Divider';
+import { Flex } from '../../Flex';
+
+const ListFlex = styled.ol`
+  display: flex;
+`;
+
+export const Breadcrumbs = ({ label, children, ...props }) => {
+  return (
+    <Box aria-label={label} {...props}>
+      <ListFlex aria-hidden={true}>
+        {Children.map(children, (child, index) => {
+          const isLast = index + 1 === children.length;
+
+          return (
+            <Flex inline as="li">
+              {child}
+              {!isLast && <Divider />}
+            </Flex>
+          );
+        })}
+      </ListFlex>
+    </Box>
+  );
+};
+
+const crumbType = PropTypes.shape({ type: PropTypes.oneOf([Crumb, CrumbLink, CrumbSimpleMenu]) });
+
+Breadcrumbs.displayName = 'Breadcrumbs';
+
+Breadcrumbs.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.arrayOf(crumbType), crumbType]).isRequired,
+  label: PropTypes.string.isRequired,
+};

--- a/packages/strapi-design-system/src/v2/Breadcrumbs/Breadcrumbs.js
+++ b/packages/strapi-design-system/src/v2/Breadcrumbs/Breadcrumbs.js
@@ -1,6 +1,5 @@
 import React, { Children } from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
 
 import { Box } from '../../Box';
 import { Crumb } from './Crumb';
@@ -9,14 +8,10 @@ import { CrumbSimpleMenu } from './CrumbSimpleMenu';
 import { Divider } from './Divider';
 import { Flex } from '../../Flex';
 
-const ListFlex = styled.ol`
-  display: flex;
-`;
-
 export const Breadcrumbs = ({ label, children, ...props }) => {
   return (
     <Box aria-label={label} {...props}>
-      <ListFlex aria-hidden={true}>
+      <Flex as="ol" horizontal>
         {Children.map(children, (child, index) => {
           const isLast = index + 1 === children.length;
 
@@ -27,7 +22,7 @@ export const Breadcrumbs = ({ label, children, ...props }) => {
             </Flex>
           );
         })}
-      </ListFlex>
+      </Flex>
     </Box>
   );
 };

--- a/packages/strapi-design-system/src/v2/Breadcrumbs/Breadcrumbs.stories.mdx
+++ b/packages/strapi-design-system/src/v2/Breadcrumbs/Breadcrumbs.stories.mdx
@@ -39,7 +39,7 @@ Breadcrumbs with CrumbLink are a list of link to help navigation.
     <Stack horizontal spacing={3}>
       <Breadcrumbs label="Folder navigatation" as="nav">
         <CrumbLink href="/">Media Library</CrumbLink>
-        <Crumb>
+        <Crumb isCurrent>
           Cats
         </Crumb>
       </Breadcrumbs>
@@ -60,7 +60,7 @@ Breadcrumbs with CrumbSimpleMenu displays a list of potential options or actions
           <MenuItem to="/">Home</MenuItem>
           <MenuItem to="/somewhere">Somewhere internal</MenuItem>
         </CrumbSimpleMenu>
-        <Crumb>
+        <Crumb isCurrent>
           Cats
         </Crumb>
       </Breadcrumbs>
@@ -78,7 +78,7 @@ Breadcrumbs with Crumb are visual information only and cannot be navigated. They
       <CollectionType />
       <Breadcrumbs label="Category model, name field">
         <Crumb>Category</Crumb>
-        <Crumb>Name</Crumb>
+        <Crumb isCurrent>Name</Crumb>
       </Breadcrumbs>
     </Stack>
   </Story>

--- a/packages/strapi-design-system/src/v2/Breadcrumbs/Breadcrumbs.stories.mdx
+++ b/packages/strapi-design-system/src/v2/Breadcrumbs/Breadcrumbs.stories.mdx
@@ -2,16 +2,13 @@
 
 import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
-import styled from 'styled-components';
 import { Breadcrumbs } from './Breadcrumbs';
 import { Crumb } from './Crumb';
 import { CrumbLink } from './CrumbLink';
 import { CrumbSimpleMenu } from './CrumbSimpleMenu';
-import { SimpleMenu, MenuItem } from '../SimpleMenu';
-import { IconButton } from '../../IconButton';
+import { MenuItem } from '../SimpleMenu';
 import { Stack } from '../../Stack';
 import CollectionType from '@strapi/icons/CollectionType';
-import CarretDown from '@strapi/icons/CarretDown';
 
 <Meta title="Design System/Components/v2/Breadcrumbs" component={Breadcrumbs} />
 
@@ -55,28 +52,19 @@ Breadcrumbs with CrumbLink are a list of link to help navigation.
 Breadcrumbs with CrumbSimpleMenu displays a list of potential options or actions via a Popover component.
 
 <Canvas>
-  <Story name="with-simple-menu">
-    {() => {
-      const IconButtonCustom = styled(IconButton)`
-        height: ${({ theme }) => theme.spaces[3]};
-      `;
-      return (
-        <Stack horizontal spacing={3}>
-          <Breadcrumbs label="Folder navigatation" as="nav">
-            <CrumbLink href="/">Media Library</CrumbLink>
-            <CrumbSimpleMenu>
-              <SimpleMenu noBorder label="Menu" as={IconButtonCustom} icon={<CarretDown />}>
-                <MenuItem to="/">Home</MenuItem>
-                <MenuItem to="/somewhere">Somewhere internal</MenuItem>
-              </SimpleMenu>
-            </CrumbSimpleMenu>
-            <Crumb>
-              Cats
-            </Crumb>
-          </Breadcrumbs>
-        </Stack>
-      );
-    }}
+  <Story name="with-menu">
+    <Stack horizontal spacing={3}>
+      <Breadcrumbs label="Folder navigatation" as="nav">
+        <CrumbLink href="/">Media Library</CrumbLink>
+        <CrumbSimpleMenu label="Menu">
+          <MenuItem to="/">Home</MenuItem>
+          <MenuItem to="/somewhere">Somewhere internal</MenuItem>
+        </CrumbSimpleMenu>
+        <Crumb>
+          Cats
+        </Crumb>
+      </Breadcrumbs>
+    </Stack>
   </Story>
 </Canvas>
 

--- a/packages/strapi-design-system/src/v2/Breadcrumbs/Breadcrumbs.stories.mdx
+++ b/packages/strapi-design-system/src/v2/Breadcrumbs/Breadcrumbs.stories.mdx
@@ -56,7 +56,7 @@ Breadcrumbs with CrumbSimpleMenu displays a list of potential options or actions
     <Stack horizontal spacing={3}>
       <Breadcrumbs label="Folder navigatation" as="nav">
         <CrumbLink href="/">Media Library</CrumbLink>
-        <CrumbSimpleMenu label="Menu">
+        <CrumbSimpleMenu label="..." aria-label="Some items are not displayed">
           <MenuItem to="/">Home</MenuItem>
           <MenuItem to="/somewhere">Somewhere internal</MenuItem>
         </CrumbSimpleMenu>

--- a/packages/strapi-design-system/src/v2/Breadcrumbs/Breadcrumbs.stories.mdx
+++ b/packages/strapi-design-system/src/v2/Breadcrumbs/Breadcrumbs.stories.mdx
@@ -1,0 +1,132 @@
+<!--- Breadcrumbs.stories.mdx --->
+
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
+import { ArgsTable } from '@storybook/addon-docs';
+import styled from 'styled-components';
+import { Breadcrumbs } from './Breadcrumbs';
+import { Crumb } from './Crumb';
+import { CrumbLink } from './CrumbLink';
+import { CrumbSimpleMenu } from './CrumbSimpleMenu';
+import { SimpleMenu, MenuItem } from '../SimpleMenu';
+import { IconButton } from '../../IconButton';
+import { Stack } from '../../Stack';
+import CollectionType from '@strapi/icons/CollectionType';
+import CarretDown from '@strapi/icons/CarretDown';
+
+<Meta title="Design System/Components/v2/Breadcrumbs" component={Breadcrumbs} />
+
+# Breadcrumbs
+
+Breadcrumbs are a list of hierarchical links that inform users about their possible navigation path upwards.
+
+**Best practices**
+
+- Use breadcrumbs whenever a long path to achieve an action is required.
+- Use breadcrumbs in modal's headers.
+- Using breadcrumbs in a page or a form is _not_ a consistent experience.
+
+[View source](https://github.com/strapi/design-system/tree/main/packages/strapi-design-system/src/Breadcrumbs)
+
+## Imports
+
+```js
+import { Breadcrumbs } from '@strapi/design-system/Breadcrumbs';
+```
+
+## Usage
+
+Breadcrumbs with CrumbLink are a list of link to help navigation.
+
+<Canvas>
+  <Story name="base">
+    <Stack horizontal spacing={3}>
+      <Breadcrumbs label="Folder navigatation" as="nav">
+        <CrumbLink href="/">Media Library</CrumbLink>
+        <Crumb>
+          Cats
+        </Crumb>
+      </Breadcrumbs>
+    </Stack>
+  </Story>
+</Canvas>
+
+## Usage
+
+Breadcrumbs with CrumbSimpleMenu displays a list of potential options or actions via a Popover component.
+
+<Canvas>
+  <Story name="with-simple-menu">
+    {() => {
+      const IconButtonCustom = styled(IconButton)`
+        height: ${({ theme }) => theme.spaces[3]};
+      `;
+      return (
+        <Stack horizontal spacing={3}>
+          <Breadcrumbs label="Folder navigatation" as="nav">
+            <CrumbLink href="/">Media Library</CrumbLink>
+            <CrumbSimpleMenu>
+              <SimpleMenu noBorder label="Menu" as={IconButtonCustom} icon={<CarretDown />}>
+                <MenuItem to="/">Home</MenuItem>
+                <MenuItem to="/somewhere">Somewhere internal</MenuItem>
+              </SimpleMenu>
+            </CrumbSimpleMenu>
+            <Crumb>
+              Cats
+            </Crumb>
+          </Breadcrumbs>
+        </Stack>
+      );
+    }}
+  </Story>
+</Canvas>
+
+## Without navigation
+
+Breadcrumbs with Crumb are visual information only and cannot be navigated. They are mostly part of modals' headers.
+
+<Canvas>
+  <Story name="without-nagivation">
+    <Stack horizontal spacing={3}>
+      <CollectionType />
+      <Breadcrumbs label="Category model, name field">
+        <Crumb>Category</Crumb>
+        <Crumb>Name</Crumb>
+      </Breadcrumbs>
+    </Stack>
+  </Story>
+</Canvas>
+
+### Usage with other routing libraries
+
+To use the Link component with a routing library (e.g. react-router-dom), you'll need to pass the `NavLink` component to the `as` prop in order to replace the default HTML anchor `<a />`.
+You'll now be able to pass all `NavLink` props.
+
+```jsx
+import { Breadcrumbs, CrumbLink } from '@strapi/design-system/Breadcrumbs';
+import { NavLink } from 'react-router-dom';
+
+<Breadcrumbs label="Folder navigatation" as="nav">
+  <CrumbLink as={NavLink} to="/">
+    Media Library
+  </CrumbLink>
+</Breadcrumbs>;
+```
+
+#### NextJS usage
+
+For NextJS, you'll need to wrap the `CrumbLink` with the `NextLink` component
+
+```jsx
+import { Breadcrumbs, CrumbLink } from '@strapi/design-system/Breadcrumbs';
+import NextLink from 'next/link';
+
+<Breadcrumbs label="Folder navigatation" as="nav">
+  <NextLink href="/home" passHref>
+    <CrumbLink>Media Library</CrumbLink>
+  </NextLink>
+</Breadcrumbs>;
+```
+
+## Props
+
+<ArgsTable of={Breadcrumbs} />

--- a/packages/strapi-design-system/src/v2/Breadcrumbs/Crumb.js
+++ b/packages/strapi-design-system/src/v2/Breadcrumbs/Crumb.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Typography } from '../../Typography';
+
+export const Crumb = ({ children, ...props }) => (
+  <Typography variant="pi" textColor="neutral800" fontWeight="bold" {...props}>
+    {children}
+  </Typography>
+);
+
+Crumb.displayName = 'Crumb';
+
+Crumb.propTypes = {
+  children: PropTypes.string.isRequired,
+};

--- a/packages/strapi-design-system/src/v2/Breadcrumbs/Crumb.js
+++ b/packages/strapi-design-system/src/v2/Breadcrumbs/Crumb.js
@@ -3,14 +3,25 @@ import PropTypes from 'prop-types';
 
 import { Typography } from '../../Typography';
 
-export const Crumb = ({ children, ...props }) => (
-  <Typography variant="pi" textColor="neutral800" fontWeight="bold" {...props}>
+export const Crumb = ({ children, isCurrent, ...props }) => (
+  <Typography
+    variant="pi"
+    textColor="neutral800"
+    fontWeight={isCurrent ? 'bold' : 'normal'}
+    aria-current={isCurrent}
+    {...props}
+  >
     {children}
   </Typography>
 );
 
 Crumb.displayName = 'Crumb';
 
+Crumb.defaultProps = {
+  isCurrent: false,
+};
+
 Crumb.propTypes = {
   children: PropTypes.string.isRequired,
+  isCurrent: PropTypes.bool,
 };

--- a/packages/strapi-design-system/src/v2/Breadcrumbs/Crumb.js
+++ b/packages/strapi-design-system/src/v2/Breadcrumbs/Crumb.js
@@ -1,18 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { Box } from '../../Box';
 import { Typography } from '../../Typography';
 
 export const Crumb = ({ children, isCurrent, ...props }) => (
-  <Typography
-    variant="pi"
-    textColor="neutral800"
-    fontWeight={isCurrent ? 'bold' : 'normal'}
-    aria-current={isCurrent}
-    {...props}
-  >
-    {children}
-  </Typography>
+  <Box paddingLeft={1} paddingRight={1}>
+    <Typography
+      variant="pi"
+      textColor="neutral800"
+      fontWeight={isCurrent ? 'bold' : 'normal'}
+      aria-current={isCurrent}
+      {...props}
+    >
+      {children}
+    </Typography>
+  </Box>
 );
 
 Crumb.displayName = 'Crumb';

--- a/packages/strapi-design-system/src/v2/Breadcrumbs/CrumbLink.js
+++ b/packages/strapi-design-system/src/v2/Breadcrumbs/CrumbLink.js
@@ -8,12 +8,13 @@ const StyledLink = styled(BaseLink)`
   border-radius: ${({ theme }) => theme.borderRadius};
   color: ${({ theme }) => theme.colors.neutral600};
   font-size: ${({ theme }) => theme.fontSizes[1]};
-  line-height: ${({ theme }) => theme.lineHeights[3]};
-  padding: ${({ theme }) => theme.spaces[1]};
+  line-height: ${({ theme }) => theme.lineHeights[4]};
+  padding: ${({ theme }) => `${theme.spaces[1]} ${theme.spaces[2]}`};
   text-decoration: none;
 
   :hover,
   :focus {
+    background-color: ${({ theme }) => theme.colors.neutral100};
     color: ${({ theme }) => theme.colors.neutral700};
   }
 `;

--- a/packages/strapi-design-system/src/v2/Breadcrumbs/CrumbLink.js
+++ b/packages/strapi-design-system/src/v2/Breadcrumbs/CrumbLink.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+import { BaseLink } from '../../BaseLink';
+
+const StyledLink = styled(BaseLink)`
+  border-radius: ${({ theme }) => theme.borderRadius};
+  color: ${({ theme }) => theme.colors.neutral600};
+  font-size: ${({ theme }) => theme.fontSizes[1]};
+  line-height: ${({ theme }) => theme.lineHeights[3]};
+  padding: ${({ theme }) => theme.spaces[1]};
+  text-decoration: none;
+
+  :hover,
+  :focus {
+    color: ${({ theme }) => theme.colors.neutral700};
+  }
+`;
+
+export const CrumbLink = ({ children, ...props }) => <StyledLink {...props}>{children}</StyledLink>;
+
+CrumbLink.displayName = 'CrumbLink';
+
+CrumbLink.propTypes = {
+  children: PropTypes.string.isRequired,
+  href: PropTypes.string.isRequired,
+};

--- a/packages/strapi-design-system/src/v2/Breadcrumbs/CrumbSimpleMenu.js
+++ b/packages/strapi-design-system/src/v2/Breadcrumbs/CrumbSimpleMenu.js
@@ -14,5 +14,6 @@ export const CrumbSimpleMenu = ({ children, ...props }) => (
 CrumbSimpleMenu.displayName = 'CrumbSimpleMenu';
 
 CrumbSimpleMenu.propTypes = {
+  'aria-label': PropTypes.string.isRequired,
   children: PropTypes.shape({ type: PropTypes.oneOf([SimpleMenu]) }),
 };

--- a/packages/strapi-design-system/src/v2/Breadcrumbs/CrumbSimpleMenu.js
+++ b/packages/strapi-design-system/src/v2/Breadcrumbs/CrumbSimpleMenu.js
@@ -15,5 +15,5 @@ CrumbSimpleMenu.displayName = 'CrumbSimpleMenu';
 
 CrumbSimpleMenu.propTypes = {
   'aria-label': PropTypes.string.isRequired,
-  children: PropTypes.shape({ type: PropTypes.oneOf([SimpleMenu]) }),
+  children: PropTypes.arrayOf(SimpleMenu),
 };

--- a/packages/strapi-design-system/src/v2/Breadcrumbs/CrumbSimpleMenu.js
+++ b/packages/strapi-design-system/src/v2/Breadcrumbs/CrumbSimpleMenu.js
@@ -1,0 +1,11 @@
+import PropTypes from 'prop-types';
+
+import { SimpleMenu } from '../SimpleMenu';
+
+export const CrumbSimpleMenu = ({ children }) => children;
+
+CrumbSimpleMenu.displayName = 'CrumbSimpleMenu';
+
+CrumbSimpleMenu.propTypes = {
+  children: PropTypes.shape({ type: PropTypes.oneOf([SimpleMenu]) }),
+};

--- a/packages/strapi-design-system/src/v2/Breadcrumbs/CrumbSimpleMenu.js
+++ b/packages/strapi-design-system/src/v2/Breadcrumbs/CrumbSimpleMenu.js
@@ -1,8 +1,21 @@
 import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'styled-components';
 
+import { IconButton } from '../../IconButton';
 import { SimpleMenu } from '../SimpleMenu';
 
-export const CrumbSimpleMenu = ({ children }) => children;
+import CarretDown from '@strapi/icons/CarretDown';
+
+const IconButtonCustom = styled(IconButton)`
+  height: ${({ theme }) => theme.spaces[3]};
+`;
+
+export const CrumbSimpleMenu = ({ children, ...props }) => (
+  <SimpleMenu noBorder as={IconButtonCustom} icon={<CarretDown />} {...props}>
+    {children}
+  </SimpleMenu>
+);
 
 CrumbSimpleMenu.displayName = 'CrumbSimpleMenu';
 

--- a/packages/strapi-design-system/src/v2/Breadcrumbs/CrumbSimpleMenu.js
+++ b/packages/strapi-design-system/src/v2/Breadcrumbs/CrumbSimpleMenu.js
@@ -1,18 +1,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import styled from 'styled-components';
 
-import { IconButton } from '../../IconButton';
 import { SimpleMenu } from '../SimpleMenu';
 
 import CarretDown from '@strapi/icons/CarretDown';
 
-const IconButtonCustom = styled(IconButton)`
-  height: ${({ theme }) => theme.spaces[3]};
-`;
-
 export const CrumbSimpleMenu = ({ children, ...props }) => (
-  <SimpleMenu noBorder as={IconButtonCustom} icon={<CarretDown />} {...props}>
+  <SimpleMenu noBorder icon={<CarretDown />} size="S" {...props}>
     {children}
   </SimpleMenu>
 );

--- a/packages/strapi-design-system/src/v2/Breadcrumbs/Divider.js
+++ b/packages/strapi-design-system/src/v2/Breadcrumbs/Divider.js
@@ -1,25 +1,15 @@
 import React from 'react';
-import styled from 'styled-components';
-import ChevronRight from '@strapi/icons/ChevronRight';
 
 import { Box } from '../../Box';
-
-const Wrapper = styled(Box)`
-  svg {
-    height: ${10 / 16}rem;
-    width: ${10 / 16}rem;
-
-    path {
-      fill: ${({ theme }) => theme.colors.neutral500};
-    }
-  }
-`;
+import { Typography } from '../../Typography';
 
 export const Divider = () => {
   return (
-    <Wrapper aria-hidden paddingLeft={2} paddingRight={2}>
-      <ChevronRight />
-    </Wrapper>
+    <Box aria-hidden paddingLeft={1} paddingRight={1}>
+      <Typography variant="pi" textColor="neutral500">
+        /
+      </Typography>
+    </Box>
   );
 };
 

--- a/packages/strapi-design-system/src/v2/Breadcrumbs/Divider.js
+++ b/packages/strapi-design-system/src/v2/Breadcrumbs/Divider.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import styled from 'styled-components';
+import ChevronRight from '@strapi/icons/ChevronRight';
+
+import { Box } from '../../Box';
+
+const Wrapper = styled(Box)`
+  svg {
+    height: ${10 / 16}rem;
+    width: ${10 / 16}rem;
+
+    path {
+      fill: ${({ theme }) => theme.colors.neutral500};
+    }
+  }
+`;
+
+export const Divider = () => {
+  return (
+    <Wrapper aria-hidden paddingLeft={2} paddingRight={2}>
+      <ChevronRight />
+    </Wrapper>
+  );
+};
+
+Divider.displayName = 'Divider';

--- a/packages/strapi-design-system/src/v2/Breadcrumbs/__tests__/Breadcrumbs.e2e.js
+++ b/packages/strapi-design-system/src/v2/Breadcrumbs/__tests__/Breadcrumbs.e2e.js
@@ -1,0 +1,47 @@
+const { injectAxe, checkA11y } = require('axe-playwright');
+
+const { test } = require('@playwright/test');
+
+test.describe.parallel('Breadcrumbs', () => {
+  test.describe('with CrumbLink', () => {
+    test.describe('light mode', () => {
+      test('triggers axe on the document', async ({ page }) => {
+        // This is the URL of the Storybook Iframe
+        await page.goto('/iframe.html?id=design-system-components-v2-breadcrumbs--base&viewMode=story');
+        await injectAxe(page);
+        await checkA11y(page);
+      });
+    });
+
+    test.describe('dark mode', () => {
+      test('triggers axe on the document', async ({ page }) => {
+        // This is the URL of the Storybook Iframe
+        await page.goto('/iframe.html?id=design-system-components-v2-breadcrumbs--base&viewMode=story&theme=dark');
+        await injectAxe(page);
+        await checkA11y(page);
+      });
+    });
+  });
+
+  test.describe('with Crumb', () => {
+    test.describe('light mode', () => {
+      test('triggers axe on the document', async ({ page }) => {
+        // This is the URL of the Storybook Iframe
+        await page.goto('/iframe.html?id=design-system-components-v2-breadcrumbs--without-nagivation&viewMode=story');
+        await injectAxe(page);
+        await checkA11y(page);
+      });
+    });
+
+    test.describe('dark mode', () => {
+      test('triggers axe on the document', async ({ page }) => {
+        // This is the URL of the Storybook Iframe
+        await page.goto(
+          '/iframe.html?id=design-system-components-v2-breadcrumbs--without-nagivation&viewMode=story&theme=dark',
+        );
+        await injectAxe(page);
+        await checkA11y(page);
+      });
+    });
+  });
+});

--- a/packages/strapi-design-system/src/v2/Breadcrumbs/index.js
+++ b/packages/strapi-design-system/src/v2/Breadcrumbs/index.js
@@ -1,0 +1,4 @@
+export * from './Breadcrumbs';
+export * from './Crumb';
+export * from './CrumbLink';
+export * from './CrumbSimpleMenu';

--- a/packages/strapi-design-system/src/v2/index.js
+++ b/packages/strapi-design-system/src/v2/index.js
@@ -1,3 +1,4 @@
+export * from './Breadcrumbs';
 export * from './Link';
 export * from './LinkButton';
 export * from './MainNav';

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -50803,7 +50803,7 @@ exports[`Storyshots Design System/Components/TwoColsLayout base 1`] = `
 `;
 
 exports[`Storyshots Design System/Components/v2/Breadcrumbs base 1`] = `
-.c2 {
+.c1 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -50815,22 +50815,35 @@ exports[`Storyshots Design System/Components/v2/Breadcrumbs base 1`] = `
   width: 1px;
 }
 
-.c1 {
+.c0 {
   background: #ffffff;
   padding: 8px;
 }
 
-.c3 {
+.c2 {
   padding: 8px;
   height: 100%;
 }
 
-.c10 {
-  padding-right: 8px;
-  padding-left: 8px;
+.c9 {
+  padding-right: 4px;
+  padding-left: 4px;
 }
 
-.c4 {
+.c10 {
+  color: #8e8ea9;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c11 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c3 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -50844,7 +50857,7 @@ exports[`Storyshots Design System/Components/v2/Breadcrumbs base 1`] = `
   flex-direction: row;
 }
 
-.c7 {
+.c6 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -50858,120 +50871,70 @@ exports[`Storyshots Design System/Components/v2/Breadcrumbs base 1`] = `
   flex-direction: row;
 }
 
-.c5 > * {
+.c4 > * {
   margin-left: 0;
   margin-right: 0;
 }
 
-.c5 > * + * {
+.c4 > * + * {
   margin-left: 12px;
 }
 
-.c9 {
+.c7 {
   cursor: pointer;
 }
 
-.c8 a {
-  -webkit-text-decoration: none;
-  text-decoration: none;
+.c8 {
+  border-radius: 4px;
   color: #666687;
   font-size: 0.75rem;
-  line-height: 1.33;
-  padding: 4px;
-  border-radius: 4px;
+  line-height: 1.43;
+  padding: 4px 8px;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
-.c8 a:hover,
-.c8 a:focus {
+.c8:hover,
+.c8:focus {
+  background-color: #f6f6f9;
   color: #4a4a6a;
 }
 
-.c8 svg {
-  height: 0.625rem;
-  width: 0.625rem;
-}
-
-.c8 svg path {
-  fill: #8e8ea9;
-}
-
-.c8 a {
-  color: #666687;
-  font-weight: 400;
-}
-
-.c11 a {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  color: #666687;
-  font-size: 0.75rem;
-  line-height: 1.33;
-  padding: 4px;
-  border-radius: 4px;
-}
-
-.c11 a:hover,
-.c11 a:focus {
-  color: #4a4a6a;
-}
-
-.c11 svg {
-  height: 0.625rem;
-  width: 0.625rem;
-}
-
-.c11 svg path {
-  fill: #8e8ea9;
-}
-
-.c11 .c0 {
-  display: none;
-}
-
-.c11 a {
-  color: #32324d;
-  font-weight: 600;
-}
-
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+.c5:first-child {
+  margin-left: calc(-1*8px);
 }
 
 <div
-  class="c0 c1"
+  class="c0"
 >
   <main>
     <div
-      class="c2"
+      class="c1"
     >
       <h1>
         Storybook story
       </h1>
     </div>
     <div
-      class="c0 c3"
+      class="c2"
       height="100%"
     >
       <div
-        class="c0 c4 c5"
+        class="c3 c4"
         spacing="3"
       >
         <nav
           aria-label="Folder navigatation"
-          class="c0 "
+          class=""
         >
           <ol
-            aria-hidden="true"
-            class="c6"
+            class="c3 c5"
           >
             <li
-              class="c0 c7 c8"
+              class="c6"
             >
               <a
-                class="c9"
+                class="c7 c8"
                 href="/"
                 target="_self"
               >
@@ -50979,48 +50942,27 @@ exports[`Storyshots Design System/Components/v2/Breadcrumbs base 1`] = `
               </a>
               <div
                 aria-hidden="true"
-                class="c0 c10"
+                class="c9"
               >
-                <svg
-                  fill="none"
-                  height="1em"
-                  viewBox="0 0 10 16"
-                  width="1em"
-                  xmlns="http://www.w3.org/2000/svg"
+                <span
+                  class="c10"
                 >
-                  <path
-                    d="M0 1.88L6.107 8 0 14.12 1.88 16l8-8-8-8L0 1.88z"
-                    fill="#32324D"
-                  />
-                </svg>
+                  /
+                </span>
               </div>
             </li>
             <li
-              class="c0 c7 c11"
+              class="c6"
             >
-              <a
-                class="c9"
-                href="/cats"
-                target="_self"
-              >
-                Cats
-              </a>
               <div
-                aria-hidden="true"
-                class="c0 c10"
+                class="c9"
               >
-                <svg
-                  fill="none"
-                  height="1em"
-                  viewBox="0 0 10 16"
-                  width="1em"
-                  xmlns="http://www.w3.org/2000/svg"
+                <span
+                  aria-current="true"
+                  class="c11"
                 >
-                  <path
-                    d="M0 1.88L6.107 8 0 14.12 1.88 16l8-8-8-8L0 1.88z"
-                    fill="#32324D"
-                  />
-                </svg>
+                  Cats
+                </span>
               </div>
             </li>
           </ol>
@@ -51031,7 +50973,7 @@ exports[`Storyshots Design System/Components/v2/Breadcrumbs base 1`] = `
 </div>
 `;
 
-exports[`Storyshots Design System/Components/v2/Breadcrumbs with-simple-menu 1`] = `
+exports[`Storyshots Design System/Components/v2/Breadcrumbs with-menu 1`] = `
 .c2 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
@@ -51055,13 +50997,25 @@ exports[`Storyshots Design System/Components/v2/Breadcrumbs with-simple-menu 1`]
 }
 
 .c10 {
-  padding-right: 8px;
+  padding-right: 4px;
+  padding-left: 4px;
+}
+
+.c17 {
   padding-left: 8px;
 }
 
-.c15 {
-  padding-right: 12px;
-  padding-left: 12px;
+.c12 {
+  color: #8e8ea9;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c16 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
 }
 
 .c4 {
@@ -51101,7 +51055,7 @@ exports[`Storyshots Design System/Components/v2/Breadcrumbs with-simple-menu 1`]
   margin-left: 12px;
 }
 
-.c12 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -51115,21 +51069,21 @@ exports[`Storyshots Design System/Components/v2/Breadcrumbs with-simple-menu 1`]
   outline: none;
 }
 
-.c12 svg {
+.c13 svg {
   height: 12px;
   width: 12px;
 }
 
-.c12 svg > g,
-.c12 svg path {
+.c13 svg > g,
+.c13 svg path {
   fill: #ffffff;
 }
 
-.c12[aria-disabled='true'] {
+.c13[aria-disabled='true'] {
   pointer-events: none;
 }
 
-.c12:after {
+.c13:after {
   -webkit-transition-property: all;
   transition-property: all;
   -webkit-transition-duration: 0.2s;
@@ -51144,11 +51098,11 @@ exports[`Storyshots Design System/Components/v2/Breadcrumbs with-simple-menu 1`]
   border: 2px solid transparent;
 }
 
-.c12:focus-visible {
+.c13:focus-visible {
   outline: none;
 }
 
-.c12:focus-visible:after {
+.c13:focus-visible:after {
   border-radius: 8px;
   content: '';
   position: absolute;
@@ -51159,7 +51113,23 @@ exports[`Storyshots Design System/Components/v2/Breadcrumbs with-simple-menu 1`]
   border: 2px solid #4945ff;
 }
 
-.c13 {
+.c8 {
+  cursor: pointer;
+}
+
+.c14 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 8px 16px;
+  background: #4945ff;
+  border: 1px solid #4945ff;
+  border: 1px solid transparent;
+  background: transparent;
+}
+
+.c14 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -51168,122 +51138,96 @@ exports[`Storyshots Design System/Components/v2/Breadcrumbs with-simple-menu 1`]
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  height: 2rem;
-  width: 2rem;
-  border: none;
 }
 
-.c13 svg > g,
-.c13 svg path {
+.c14 .c11 {
+  color: #ffffff;
+}
+
+.c14[aria-disabled='true'] {
+  border: 1px solid #dcdce4;
+  background: #eaeaef;
+}
+
+.c14[aria-disabled='true'] .c11 {
+  color: #666687;
+}
+
+.c14[aria-disabled='true'] svg > g,
+.c14[aria-disabled='true'] svg path {
+  fill: #666687;
+}
+
+.c14[aria-disabled='true']:active {
+  border: 1px solid #dcdce4;
+  background: #eaeaef;
+}
+
+.c14[aria-disabled='true']:active .c11 {
+  color: #666687;
+}
+
+.c14[aria-disabled='true']:active svg > g,
+.c14[aria-disabled='true']:active svg path {
+  fill: #666687;
+}
+
+.c14:hover {
+  background-color: #f6f6f9;
+}
+
+.c14:active {
+  border: 1px solid undefined;
+  background: undefined;
+}
+
+.c14 .c11 {
+  color: #32324d;
+}
+
+.c14 svg > g,
+.c14 svg path {
   fill: #8e8ea9;
-}
-
-.c13:hover svg > g,
-.c13:hover svg path {
-  fill: #666687;
-}
-
-.c13:active svg > g,
-.c13:active svg path {
-  fill: #a5a5ba;
-}
-
-.c13[aria-disabled='true'] {
-  background-color: #eaeaef;
-}
-
-.c13[aria-disabled='true'] svg path {
-  fill: #666687;
 }
 
 .c9 {
-  cursor: pointer;
-}
-
-.c8 a {
-  -webkit-text-decoration: none;
-  text-decoration: none;
+  border-radius: 4px;
   color: #666687;
   font-size: 0.75rem;
-  line-height: 1.33;
-  padding: 4px;
-  border-radius: 4px;
+  line-height: 1.43;
+  padding: 4px 8px;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
-.c8 a:hover,
-.c8 a:focus {
+.c9:hover,
+.c9:focus {
+  background-color: #f6f6f9;
   color: #4a4a6a;
 }
 
-.c8 svg {
-  height: 0.625rem;
-  width: 0.625rem;
-}
-
-.c8 svg path {
-  fill: #8e8ea9;
-}
-
-.c8 a {
-  color: #666687;
-  font-weight: 400;
-}
-
-.c16 a {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  color: #666687;
-  font-size: 0.75rem;
-  line-height: 1.33;
-  padding: 4px;
-  border-radius: 4px;
-}
-
-.c16 a:hover,
-.c16 a:focus {
-  color: #4a4a6a;
-}
-
-.c16 svg {
-  height: 0.625rem;
-  width: 0.625rem;
-}
-
-.c16 svg path {
-  fill: #8e8ea9;
-}
-
-.c16 .c0 {
-  display: none;
-}
-
-.c16 a {
-  color: #32324d;
-  font-weight: 600;
-}
-
-.c11 div[aria-hidden='true'] svg {
-  height: 0.625rem;
-  width: 0.625rem;
-}
-
-.c11 div[aria-hidden='true'] svg path {
-  fill: #8e8ea9;
-}
-
-.c6 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
-.c14 {
-  height: 12px;
+.c18 svg {
+  height: 4px;
+  width: 6px;
+}
+
+.c15 {
+  padding: 4px 12px;
+}
+
+.c6:first-child {
+  margin-left: calc(-1*8px);
 }
 
 <div
@@ -51310,14 +51254,13 @@ exports[`Storyshots Design System/Components/v2/Breadcrumbs with-simple-menu 1`]
           class="c0 "
         >
           <ol
-            aria-hidden="true"
-            class="c6"
+            class="c0 c4 c6"
           >
             <li
-              class="c0 c7 c8"
+              class="c0 c7"
             >
               <a
-                class="c9"
+                class="c8 c9"
                 href="/"
                 target="_self"
               >
@@ -51327,96 +51270,81 @@ exports[`Storyshots Design System/Components/v2/Breadcrumbs with-simple-menu 1`]
                 aria-hidden="true"
                 class="c0 c10"
               >
-                <svg
-                  fill="none"
-                  height="1em"
-                  viewBox="0 0 10 16"
-                  width="1em"
-                  xmlns="http://www.w3.org/2000/svg"
+                <span
+                  class="c11 c12"
                 >
-                  <path
-                    d="M0 1.88L6.107 8 0 14.12 1.88 16l8-8-8-8L0 1.88z"
-                    fill="#32324D"
-                  />
-                </svg>
-              </div>
-            </li>
-            <div
-              class="c0 c4 c11"
-            >
-              <div>
-                <span>
-                  <button
-                    aria-controls="simplemenu-250"
-                    aria-disabled="false"
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    aria-labelledby="tooltip-251"
-                    class="c12 c13 c14"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <svg
-                      fill="none"
-                      height="1em"
-                      viewBox="0 0 14 8"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        clip-rule="evenodd"
-                        d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
-                        fill="#32324D"
-                        fill-rule="evenodd"
-                      />
-                    </svg>
-                  </button>
+                  /
                 </span>
               </div>
-              <div
-                aria-hidden="true"
-                class="c0 c15"
-              >
-                <svg
-                  fill="none"
-                  height="1em"
-                  viewBox="0 0 10 16"
-                  width="1em"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M0 1.88L6.107 8 0 14.12 1.88 16l8-8-8-8L0 1.88z"
-                    fill="#32324D"
-                  />
-                </svg>
-              </div>
-            </div>
+            </li>
             <li
-              class="c0 c7 c16"
+              class="c0 c7"
             >
-              <a
-                class="c9"
-                href="/cats"
-                target="_self"
-              >
-                Cats
-              </a>
+              <div>
+                <button
+                  aria-controls="simplemenu-252"
+                  aria-disabled="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Some items are not displayed"
+                  class="c13 c14 c15"
+                  label="..."
+                  type="button"
+                >
+                  <span
+                    class="c11 c16"
+                  >
+                    ...
+                  </span>
+                  <div
+                    aria-hidden="true"
+                    class="c0 c17"
+                  >
+                    <span
+                      class="c18"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        fill="none"
+                        height="1em"
+                        viewBox="0 0 14 8"
+                        width="1em"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          clip-rule="evenodd"
+                          d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
+                          fill="#32324D"
+                          fill-rule="evenodd"
+                        />
+                      </svg>
+                    </span>
+                  </div>
+                </button>
+              </div>
               <div
                 aria-hidden="true"
                 class="c0 c10"
               >
-                <svg
-                  fill="none"
-                  height="1em"
-                  viewBox="0 0 10 16"
-                  width="1em"
-                  xmlns="http://www.w3.org/2000/svg"
+                <span
+                  class="c11 c12"
                 >
-                  <path
-                    d="M0 1.88L6.107 8 0 14.12 1.88 16l8-8-8-8L0 1.88z"
-                    fill="#32324D"
-                  />
-                </svg>
+                  /
+                </span>
+              </div>
+            </li>
+            <li
+              class="c0 c7"
+            >
+              <div
+                class="c0 c10"
+              >
+                <span
+                  aria-current="true"
+                  class="c11 c16"
+                >
+                  Cats
+                </span>
               </div>
             </li>
           </ol>
@@ -51428,7 +51356,7 @@ exports[`Storyshots Design System/Components/v2/Breadcrumbs with-simple-menu 1`]
 `;
 
 exports[`Storyshots Design System/Components/v2/Breadcrumbs without-nagivation 1`] = `
-.c2 {
+.c1 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -51440,28 +51368,41 @@ exports[`Storyshots Design System/Components/v2/Breadcrumbs without-nagivation 1
   width: 1px;
 }
 
-.c1 {
+.c0 {
   background: #ffffff;
   padding: 8px;
 }
 
-.c3 {
+.c2 {
   padding: 8px;
   height: 100%;
 }
 
-.c11 {
-  padding-right: 12px;
-  padding-left: 12px;
+.c7 {
+  padding-right: 4px;
+  padding-left: 4px;
 }
 
-.c10 {
-  color: #666687;
+.c8 {
+  color: #32324d;
   font-size: 0.75rem;
   line-height: 1.33;
 }
 
-.c4 {
+.c9 {
+  color: #8e8ea9;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c10 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c3 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -51475,7 +51416,7 @@ exports[`Storyshots Design System/Components/v2/Breadcrumbs without-nagivation 1
   flex-direction: row;
 }
 
-.c7 {
+.c6 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -51489,71 +51430,36 @@ exports[`Storyshots Design System/Components/v2/Breadcrumbs without-nagivation 1
   flex-direction: row;
 }
 
-.c5 > * {
+.c4 > * {
   margin-left: 0;
   margin-right: 0;
 }
 
-.c5 > * + * {
+.c4 > * + * {
   margin-left: 12px;
 }
 
-.c8 svg {
-  height: 0.625rem;
-  width: 0.625rem;
-}
-
-.c8 svg path {
-  fill: #8e8ea9;
-}
-
-.c8 .c9 {
-  color: #666687;
-  font-weight: 400;
-}
-
-.c12 svg {
-  height: 0.625rem;
-  width: 0.625rem;
-}
-
-.c12 svg path {
-  fill: #8e8ea9;
-}
-
-.c12 .c0 {
-  display: none;
-}
-
-.c12 .c9 {
-  color: #32324d;
-  font-weight: 600;
-}
-
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+.c5:first-child {
+  margin-left: calc(-1*8px);
 }
 
 <div
-  class="c0 c1"
+  class="c0"
 >
   <main>
     <div
-      class="c2"
+      class="c1"
     >
       <h1>
         Storybook story
       </h1>
     </div>
     <div
-      class="c0 c3"
+      class="c2"
       height="100%"
     >
       <div
-        class="c0 c4 c5"
+        class="c3 c4"
         spacing="3"
       >
         <svg
@@ -51579,62 +51485,47 @@ exports[`Storyshots Design System/Components/v2/Breadcrumbs without-nagivation 1
         </svg>
         <div
           aria-label="Category model, name field"
-          class="c0 "
+          class=""
         >
           <ol
-            aria-hidden="true"
-            class="c6"
+            class="c3 c5"
           >
             <li
-              class="c0 c7 c8"
+              class="c6"
             >
-              <span
-                class="c9 c10"
+              <div
+                class="c7"
               >
-                Category
-              </span>
+                <span
+                  aria-current="false"
+                  class="c8"
+                >
+                  Category
+                </span>
+              </div>
               <div
                 aria-hidden="true"
-                class="c0 c11"
+                class="c7"
               >
-                <svg
-                  fill="none"
-                  height="1em"
-                  viewBox="0 0 10 16"
-                  width="1em"
-                  xmlns="http://www.w3.org/2000/svg"
+                <span
+                  class="c9"
                 >
-                  <path
-                    d="M0 1.88L6.107 8 0 14.12 1.88 16l8-8-8-8L0 1.88z"
-                    fill="#32324D"
-                  />
-                </svg>
+                  /
+                </span>
               </div>
             </li>
             <li
-              class="c0 c7 c12"
+              class="c6"
             >
-              <span
-                class="c9 c10"
-              >
-                Name
-              </span>
               <div
-                aria-hidden="true"
-                class="c0 c11"
+                class="c7"
               >
-                <svg
-                  fill="none"
-                  height="1em"
-                  viewBox="0 0 10 16"
-                  width="1em"
-                  xmlns="http://www.w3.org/2000/svg"
+                <span
+                  aria-current="true"
+                  class="c10"
                 >
-                  <path
-                    d="M0 1.88L6.107 8 0 14.12 1.88 16l8-8-8-8L0 1.88z"
-                    fill="#32324D"
-                  />
-                </svg>
+                  Name
+                </span>
               </div>
             </li>
           </ol>

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -51282,7 +51282,7 @@ exports[`Storyshots Design System/Components/v2/Breadcrumbs with-menu 1`] = `
             >
               <div>
                 <button
-                  aria-controls="simplemenu-252"
+                  aria-controls="simplemenu-255"
                   aria-disabled="false"
                   aria-expanded="false"
                   aria-haspopup="true"
@@ -56520,7 +56520,7 @@ exports[`Storyshots Design System/Components/v2/SimpleMenu sizes 1`] = `
       >
         <div>
           <button
-            aria-controls="simplemenu-253"
+            aria-controls="simplemenu-256"
             aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="true"
@@ -56561,7 +56561,7 @@ exports[`Storyshots Design System/Components/v2/SimpleMenu sizes 1`] = `
         </div>
         <div>
           <button
-            aria-controls="simplemenu-254"
+            aria-controls="simplemenu-257"
             aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="true"
@@ -56804,7 +56804,7 @@ exports[`Storyshots Design System/Components/v2/SimpleMenu with-custom-label 1`]
     >
       <div>
         <button
-          aria-controls="simplemenu-255"
+          aria-controls="simplemenu-258"
           aria-disabled="false"
           aria-expanded="false"
           aria-haspopup="true"
@@ -56989,11 +56989,11 @@ exports[`Storyshots Design System/Components/v2/SimpleMenu with-iconbutton 1`] =
       <div>
         <span>
           <button
-            aria-controls="simplemenu-256"
+            aria-controls="simplemenu-259"
             aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="true"
-            aria-labelledby="tooltip-257"
+            aria-labelledby="tooltip-260"
             class="c3 c4"
             tabindex="0"
             type="button"
@@ -57218,7 +57218,7 @@ exports[`Storyshots Design System/Components/v2/SimpleMenu with-links 1`] = `
     >
       <div>
         <button
-          aria-controls="simplemenu-259"
+          aria-controls="simplemenu-262"
           aria-disabled="false"
           aria-expanded="false"
           aria-haspopup="true"
@@ -57852,7 +57852,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                 <span>
                   <button
                     aria-disabled="false"
-                    aria-labelledby="tooltip-261"
+                    aria-labelledby="tooltip-264"
                     class="c10 c11"
                     tabindex="0"
                     type="button"
@@ -57900,7 +57900,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                         class="c21"
                       >
                         <button
-                          aria-controls="subnav-list-263"
+                          aria-controls="subnav-list-266"
                           aria-expanded="true"
                           class="c3 c22"
                         >
@@ -57945,7 +57945,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                       </div>
                     </div>
                     <ul
-                      id="subnav-list-263"
+                      id="subnav-list-266"
                     >
                       <li>
                         <a
@@ -58139,7 +58139,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                         class="c21"
                       >
                         <button
-                          aria-controls="subnav-list-264"
+                          aria-controls="subnav-list-267"
                           aria-expanded="true"
                           class="c3 c22"
                         >
@@ -58184,7 +58184,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                       </div>
                     </div>
                     <ul
-                      id="subnav-list-264"
+                      id="subnav-list-267"
                     >
                       <li>
                         <div
@@ -58197,7 +58197,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                               class="c21"
                             >
                               <button
-                                aria-controls="subnav-list-265"
+                                aria-controls="subnav-list-268"
                                 aria-expanded="true"
                                 class="c41"
                               >
@@ -58233,7 +58233,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                             </div>
                           </div>
                           <ul
-                            id="subnav-list-265"
+                            id="subnav-list-268"
                           >
                             <li>
                               <a
@@ -58540,7 +58540,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                       </div>
                     </div>
                     <ul
-                      id="subnav-list-267"
+                      id="subnav-list-270"
                     >
                       <li>
                         <a
@@ -58647,7 +58647,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                       </div>
                     </div>
                     <ul
-                      id="subnav-list-268"
+                      id="subnav-list-271"
                     >
                       <li>
                         <a
@@ -58849,7 +58849,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                       </div>
                     </div>
                     <ul
-                      id="subnav-list-270"
+                      id="subnav-list-273"
                     >
                       <li>
                         <div
@@ -58862,7 +58862,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                               class="c21"
                             >
                               <button
-                                aria-controls="subnav-list-271"
+                                aria-controls="subnav-list-274"
                                 aria-expanded="true"
                                 class="c41"
                               >
@@ -58898,7 +58898,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                             </div>
                           </div>
                           <ul
-                            id="subnav-list-271"
+                            id="subnav-list-274"
                           >
                             <li>
                               <a
@@ -59078,7 +59078,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                       </div>
                     </div>
                     <ul
-                      id="subnav-list-272"
+                      id="subnav-list-275"
                     >
                       <li>
                         <a

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -4304,16 +4304,15 @@ exports[`Storyshots Design System/Components/Breadcrumbs base 1`] = `
   height: 100%;
 }
 
-.c9 {
+.c10 {
   padding-right: 12px;
   padding-left: 12px;
 }
 
-.c8 {
-  font-weight: 600;
-  color: #32324d;
-  font-size: 0.875rem;
-  line-height: 1.43;
+.c9 {
+  color: #666687;
+  font-size: 0.75rem;
+  line-height: 1.33;
 }
 
 .c4 {
@@ -4354,16 +4353,21 @@ exports[`Storyshots Design System/Components/Breadcrumbs base 1`] = `
 }
 
 .c7 svg {
-  height: 10px;
-  width: 10px;
+  height: 0.625rem;
+  width: 0.625rem;
 }
 
 .c7 svg path {
-  fill: #c0c0cf;
+  fill: #8e8ea9;
 }
 
 .c7:last-of-type .c0 {
   display: none;
+}
+
+.c7:last-of-type .c8 {
+  color: #32324d;
+  font-weight: 600;
 }
 
 <div
@@ -4421,13 +4425,13 @@ exports[`Storyshots Design System/Components/Breadcrumbs base 1`] = `
               class="c0 c6 c7"
             >
               <span
-                class="c8"
-                color="neutral800"
+                class="c8 c9"
               >
                 Category
               </span>
               <div
-                class="c0 c9"
+                aria-hidden="true"
+                class="c0 c10"
               >
                 <svg
                   fill="none"
@@ -4447,13 +4451,13 @@ exports[`Storyshots Design System/Components/Breadcrumbs base 1`] = `
               class="c0 c6 c7"
             >
               <span
-                class="c8"
-                color="neutral800"
+                class="c8 c9"
               >
                 Name
               </span>
               <div
-                class="c0 c9"
+                aria-hidden="true"
+                class="c0 c10"
               >
                 <svg
                   fill="none"
@@ -17452,6 +17456,230 @@ exports[`Storyshots Design System/Components/HeaderLayout base 1`] = `
           >
             36 entries found
           </p>
+        </div>
+      </div>
+    </div>
+  </main>
+</div>
+`;
+
+exports[`Storyshots Design System/Components/HeaderLayout base with custom subtitle 1`] = `
+.c2 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c1 {
+  background: #ffffff;
+  padding: 8px;
+}
+
+.c3 {
+  padding: 8px;
+  height: 100%;
+}
+
+.c4 {
+  background: #f6f6f9;
+}
+
+.c5 {
+  background: #f6f6f9;
+  padding-top: 40px;
+  padding-right: 56px;
+  padding-bottom: 40px;
+  padding-left: 56px;
+}
+
+.c13 {
+  padding-right: 12px;
+  padding-left: 12px;
+}
+
+.c9 {
+  color: #32324d;
+  font-weight: 600;
+  font-size: 2rem;
+  line-height: 1.25;
+}
+
+.c12 {
+  color: #666687;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c6 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c10 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c11 svg {
+  height: 0.625rem;
+  width: 0.625rem;
+}
+
+.c11 svg path {
+  fill: #8e8ea9;
+}
+
+.c11:last-of-type .c0 {
+  display: none;
+}
+
+.c11:last-of-type .c8 {
+  color: #32324d;
+  font-weight: 600;
+}
+
+<div
+  class="c0 c1"
+>
+  <main>
+    <div
+      class="c2"
+    >
+      <h1>
+        Storybook story
+      </h1>
+    </div>
+    <div
+      class="c0 c3"
+      height="100%"
+    >
+      <div
+        class="c0 c4"
+      >
+        <div
+          class="c0 c5"
+          data-strapi-header="true"
+        >
+          <div
+            class="c0 c6"
+          >
+            <div
+              class="c0 c7"
+            >
+              <h2
+                class="c8 c9"
+              >
+                Media Library
+              </h2>
+            </div>
+          </div>
+          <div
+            class="c0 c7"
+          >
+            <div
+              class="c2"
+            >
+              folders
+            </div>
+            <ol
+              aria-hidden="true"
+            >
+              <li
+                class="c0 c10 c11"
+              >
+                <span
+                  class="c8 c12"
+                >
+                  Animals
+                </span>
+                <div
+                  aria-hidden="true"
+                  class="c0 c13"
+                >
+                  <svg
+                    fill="none"
+                    height="1em"
+                    viewBox="0 0 10 16"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M0 1.88L6.107 8 0 14.12 1.88 16l8-8-8-8L0 1.88z"
+                      fill="#32324D"
+                    />
+                  </svg>
+                </div>
+              </li>
+              <li
+                class="c0 c10 c11"
+              >
+                <span
+                  class="c8 c12"
+                >
+                  Cats
+                </span>
+                <div
+                  aria-hidden="true"
+                  class="c0 c13"
+                >
+                  <svg
+                    fill="none"
+                    height="1em"
+                    viewBox="0 0 10 16"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M0 1.88L6.107 8 0 14.12 1.88 16l8-8-8-8L0 1.88z"
+                      fill="#32324D"
+                    />
+                  </svg>
+                </div>
+              </li>
+            </ol>
+          </div>
         </div>
       </div>
     </div>
@@ -50567,6 +50795,849 @@ exports[`Storyshots Design System/Components/TwoColsLayout base 1`] = `
               </div>
             </div>
           </div>
+        </div>
+      </div>
+    </div>
+  </main>
+</div>
+`;
+
+exports[`Storyshots Design System/Components/v2/Breadcrumbs base 1`] = `
+.c2 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c1 {
+  background: #ffffff;
+  padding: 8px;
+}
+
+.c3 {
+  padding: 8px;
+  height: 100%;
+}
+
+.c10 {
+  padding-right: 8px;
+  padding-left: 8px;
+}
+
+.c4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c5 > * {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.c5 > * + * {
+  margin-left: 12px;
+}
+
+.c9 {
+  cursor: pointer;
+}
+
+.c8 a {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #666687;
+  font-size: 0.75rem;
+  line-height: 1.33;
+  padding: 4px;
+  border-radius: 4px;
+}
+
+.c8 a:hover,
+.c8 a:focus {
+  color: #4a4a6a;
+}
+
+.c8 svg {
+  height: 0.625rem;
+  width: 0.625rem;
+}
+
+.c8 svg path {
+  fill: #8e8ea9;
+}
+
+.c8 a {
+  color: #666687;
+  font-weight: 400;
+}
+
+.c11 a {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #666687;
+  font-size: 0.75rem;
+  line-height: 1.33;
+  padding: 4px;
+  border-radius: 4px;
+}
+
+.c11 a:hover,
+.c11 a:focus {
+  color: #4a4a6a;
+}
+
+.c11 svg {
+  height: 0.625rem;
+  width: 0.625rem;
+}
+
+.c11 svg path {
+  fill: #8e8ea9;
+}
+
+.c11 .c0 {
+  display: none;
+}
+
+.c11 a {
+  color: #32324d;
+  font-weight: 600;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+<div
+  class="c0 c1"
+>
+  <main>
+    <div
+      class="c2"
+    >
+      <h1>
+        Storybook story
+      </h1>
+    </div>
+    <div
+      class="c0 c3"
+      height="100%"
+    >
+      <div
+        class="c0 c4 c5"
+        spacing="3"
+      >
+        <nav
+          aria-label="Folder navigatation"
+          class="c0 "
+        >
+          <ol
+            aria-hidden="true"
+            class="c6"
+          >
+            <li
+              class="c0 c7 c8"
+            >
+              <a
+                class="c9"
+                href="/"
+                target="_self"
+              >
+                Media Library
+              </a>
+              <div
+                aria-hidden="true"
+                class="c0 c10"
+              >
+                <svg
+                  fill="none"
+                  height="1em"
+                  viewBox="0 0 10 16"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 1.88L6.107 8 0 14.12 1.88 16l8-8-8-8L0 1.88z"
+                    fill="#32324D"
+                  />
+                </svg>
+              </div>
+            </li>
+            <li
+              class="c0 c7 c11"
+            >
+              <a
+                class="c9"
+                href="/cats"
+                target="_self"
+              >
+                Cats
+              </a>
+              <div
+                aria-hidden="true"
+                class="c0 c10"
+              >
+                <svg
+                  fill="none"
+                  height="1em"
+                  viewBox="0 0 10 16"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 1.88L6.107 8 0 14.12 1.88 16l8-8-8-8L0 1.88z"
+                    fill="#32324D"
+                  />
+                </svg>
+              </div>
+            </li>
+          </ol>
+        </nav>
+      </div>
+    </div>
+  </main>
+</div>
+`;
+
+exports[`Storyshots Design System/Components/v2/Breadcrumbs with-simple-menu 1`] = `
+.c2 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c1 {
+  background: #ffffff;
+  padding: 8px;
+}
+
+.c3 {
+  padding: 8px;
+  height: 100%;
+}
+
+.c10 {
+  padding-right: 8px;
+  padding-left: 8px;
+}
+
+.c15 {
+  padding-right: 12px;
+  padding-left: 12px;
+}
+
+.c4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c5 > * {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.c5 > * + * {
+  margin-left: 12px;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 4px;
+  background: #ffffff;
+  border: 1px solid #dcdce4;
+  position: relative;
+  outline: none;
+}
+
+.c12 svg {
+  height: 12px;
+  width: 12px;
+}
+
+.c12 svg > g,
+.c12 svg path {
+  fill: #ffffff;
+}
+
+.c12[aria-disabled='true'] {
+  pointer-events: none;
+}
+
+.c12:after {
+  -webkit-transition-property: all;
+  transition-property: all;
+  -webkit-transition-duration: 0.2s;
+  transition-duration: 0.2s;
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  left: -4px;
+  right: -4px;
+  border: 2px solid transparent;
+}
+
+.c12:focus-visible {
+  outline: none;
+}
+
+.c12:focus-visible:after {
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -5px;
+  bottom: -5px;
+  left: -5px;
+  right: -5px;
+  border: 2px solid #4945ff;
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  height: 2rem;
+  width: 2rem;
+  border: none;
+}
+
+.c13 svg > g,
+.c13 svg path {
+  fill: #8e8ea9;
+}
+
+.c13:hover svg > g,
+.c13:hover svg path {
+  fill: #666687;
+}
+
+.c13:active svg > g,
+.c13:active svg path {
+  fill: #a5a5ba;
+}
+
+.c13[aria-disabled='true'] {
+  background-color: #eaeaef;
+}
+
+.c13[aria-disabled='true'] svg path {
+  fill: #666687;
+}
+
+.c9 {
+  cursor: pointer;
+}
+
+.c8 a {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #666687;
+  font-size: 0.75rem;
+  line-height: 1.33;
+  padding: 4px;
+  border-radius: 4px;
+}
+
+.c8 a:hover,
+.c8 a:focus {
+  color: #4a4a6a;
+}
+
+.c8 svg {
+  height: 0.625rem;
+  width: 0.625rem;
+}
+
+.c8 svg path {
+  fill: #8e8ea9;
+}
+
+.c8 a {
+  color: #666687;
+  font-weight: 400;
+}
+
+.c16 a {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #666687;
+  font-size: 0.75rem;
+  line-height: 1.33;
+  padding: 4px;
+  border-radius: 4px;
+}
+
+.c16 a:hover,
+.c16 a:focus {
+  color: #4a4a6a;
+}
+
+.c16 svg {
+  height: 0.625rem;
+  width: 0.625rem;
+}
+
+.c16 svg path {
+  fill: #8e8ea9;
+}
+
+.c16 .c0 {
+  display: none;
+}
+
+.c16 a {
+  color: #32324d;
+  font-weight: 600;
+}
+
+.c11 div[aria-hidden='true'] svg {
+  height: 0.625rem;
+  width: 0.625rem;
+}
+
+.c11 div[aria-hidden='true'] svg path {
+  fill: #8e8ea9;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c14 {
+  height: 12px;
+}
+
+<div
+  class="c0 c1"
+>
+  <main>
+    <div
+      class="c2"
+    >
+      <h1>
+        Storybook story
+      </h1>
+    </div>
+    <div
+      class="c0 c3"
+      height="100%"
+    >
+      <div
+        class="c0 c4 c5"
+        spacing="3"
+      >
+        <nav
+          aria-label="Folder navigatation"
+          class="c0 "
+        >
+          <ol
+            aria-hidden="true"
+            class="c6"
+          >
+            <li
+              class="c0 c7 c8"
+            >
+              <a
+                class="c9"
+                href="/"
+                target="_self"
+              >
+                Media Library
+              </a>
+              <div
+                aria-hidden="true"
+                class="c0 c10"
+              >
+                <svg
+                  fill="none"
+                  height="1em"
+                  viewBox="0 0 10 16"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 1.88L6.107 8 0 14.12 1.88 16l8-8-8-8L0 1.88z"
+                    fill="#32324D"
+                  />
+                </svg>
+              </div>
+            </li>
+            <div
+              class="c0 c4 c11"
+            >
+              <div>
+                <span>
+                  <button
+                    aria-controls="simplemenu-250"
+                    aria-disabled="false"
+                    aria-expanded="false"
+                    aria-haspopup="true"
+                    aria-labelledby="tooltip-251"
+                    class="c12 c13 c14"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <svg
+                      fill="none"
+                      height="1em"
+                      viewBox="0 0 14 8"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
+                        fill="#32324D"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </button>
+                </span>
+              </div>
+              <div
+                aria-hidden="true"
+                class="c0 c15"
+              >
+                <svg
+                  fill="none"
+                  height="1em"
+                  viewBox="0 0 10 16"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 1.88L6.107 8 0 14.12 1.88 16l8-8-8-8L0 1.88z"
+                    fill="#32324D"
+                  />
+                </svg>
+              </div>
+            </div>
+            <li
+              class="c0 c7 c16"
+            >
+              <a
+                class="c9"
+                href="/cats"
+                target="_self"
+              >
+                Cats
+              </a>
+              <div
+                aria-hidden="true"
+                class="c0 c10"
+              >
+                <svg
+                  fill="none"
+                  height="1em"
+                  viewBox="0 0 10 16"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 1.88L6.107 8 0 14.12 1.88 16l8-8-8-8L0 1.88z"
+                    fill="#32324D"
+                  />
+                </svg>
+              </div>
+            </li>
+          </ol>
+        </nav>
+      </div>
+    </div>
+  </main>
+</div>
+`;
+
+exports[`Storyshots Design System/Components/v2/Breadcrumbs without-nagivation 1`] = `
+.c2 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c1 {
+  background: #ffffff;
+  padding: 8px;
+}
+
+.c3 {
+  padding: 8px;
+  height: 100%;
+}
+
+.c11 {
+  padding-right: 12px;
+  padding-left: 12px;
+}
+
+.c10 {
+  color: #666687;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c5 > * {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.c5 > * + * {
+  margin-left: 12px;
+}
+
+.c8 svg {
+  height: 0.625rem;
+  width: 0.625rem;
+}
+
+.c8 svg path {
+  fill: #8e8ea9;
+}
+
+.c8 .c9 {
+  color: #666687;
+  font-weight: 400;
+}
+
+.c12 svg {
+  height: 0.625rem;
+  width: 0.625rem;
+}
+
+.c12 svg path {
+  fill: #8e8ea9;
+}
+
+.c12 .c0 {
+  display: none;
+}
+
+.c12 .c9 {
+  color: #32324d;
+  font-weight: 600;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+<div
+  class="c0 c1"
+>
+  <main>
+    <div
+      class="c2"
+    >
+      <h1>
+        Storybook story
+      </h1>
+    </div>
+    <div
+      class="c0 c3"
+      height="100%"
+    >
+      <div
+        class="c0 c4 c5"
+        spacing="3"
+      >
+        <svg
+          fill="none"
+          height="1em"
+          viewBox="0 0 32 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <rect
+            fill="#4945FF"
+            height="23"
+            rx="2.5"
+            stroke="#4945FF"
+            width="31"
+            x="0.5"
+            y="0.5"
+          />
+          <path
+            d="M15.328 10.54h1.723c.012-.089.012-.165.012-.253 0-1.676-1.471-2.959-3.41-2.959-2.696 0-4.647 2.22-4.647 5.344 0 2.15 1.383 3.545 3.504 3.545 2.045 0 3.597-1.154 3.967-2.936h-1.752c-.276.826-1.102 1.371-2.063 1.371-1.137 0-1.846-.802-1.846-2.103 0-2.08 1.19-3.65 2.725-3.65 1.037 0 1.746.62 1.787 1.558v.082zM21.053 16l1.488-6.943h2.531l.31-1.512H18.54l-.31 1.512h2.53L19.272 16h1.782z"
+            fill="#fff"
+          />
+        </svg>
+        <div
+          aria-label="Category model, name field"
+          class="c0 "
+        >
+          <ol
+            aria-hidden="true"
+            class="c6"
+          >
+            <li
+              class="c0 c7 c8"
+            >
+              <span
+                class="c9 c10"
+              >
+                Category
+              </span>
+              <div
+                aria-hidden="true"
+                class="c0 c11"
+              >
+                <svg
+                  fill="none"
+                  height="1em"
+                  viewBox="0 0 10 16"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 1.88L6.107 8 0 14.12 1.88 16l8-8-8-8L0 1.88z"
+                    fill="#32324D"
+                  />
+                </svg>
+              </div>
+            </li>
+            <li
+              class="c0 c7 c12"
+            >
+              <span
+                class="c9 c10"
+              >
+                Name
+              </span>
+              <div
+                aria-hidden="true"
+                class="c0 c11"
+              >
+                <svg
+                  fill="none"
+                  height="1em"
+                  viewBox="0 0 10 16"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 1.88L6.107 8 0 14.12 1.88 16l8-8-8-8L0 1.88z"
+                    fill="#32324D"
+                  />
+                </svg>
+              </div>
+            </li>
+          </ol>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### What does it do?

This is an alternative solution & implementation of https://github.com/strapi/design-system/pull/646 and https://github.com/strapi/design-system/pull/651 with a few advantages:

- the single `Crumb*` components are much simpler, because
- the `Divider` logic was abstracted at the `Breadcrumbs` level
- it works with much less style overwrites

I didn't fully understand the API for the other PR - this one follows the idea of:

- `CrumbLink`: is used to render a link
- `Crumb`: is used to render a non-link and can receive an `aria-current` prop, if it is the last one
- `CrumbSimpleMenu`: acts as an alias for `SimpleMenu` with meaningful defaults

[Preview](https://design-system-git-enhancement-breadcrumbs-simplified-strapijs.vercel.app/?path=/story/design-system-components-v2-breadcrumbs--with-menu)

### Why is it needed?

It is just a different implementation.
