### PR TITLE
Breadcrumbs: Update interaction colors

### DIFF
--- a/packages/strapi-design-system/src/v2/Breadcrumbs/CrumbLink.js
+++ b/packages/strapi-design-system/src/v2/Breadcrumbs/CrumbLink.js
@@ -14,7 +14,7 @@ const StyledLink = styled(BaseLink)`
 
   :hover,
   :focus {
-    background-color: ${({ theme }) => theme.colors.neutral100};
+    background-color: ${({ theme }) => theme.colors.neutral200};
     color: ${({ theme }) => theme.colors.neutral700};
   }
 `;

--- a/packages/strapi-design-system/src/v2/Breadcrumbs/CrumbSimpleMenu.js
+++ b/packages/strapi-design-system/src/v2/Breadcrumbs/CrumbSimpleMenu.js
@@ -1,12 +1,23 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import styled from 'styled-components';
 
+import { Button } from '../../Button';
 import { SimpleMenu } from '../SimpleMenu';
 
 import CarretDown from '@strapi/icons/CarretDown';
 
+const StyledButton = styled(Button)`
+  padding: ${({ theme }) => `${theme.spaces[1]} ${theme.spaces[3]}`};
+
+  :hover,
+  :focus {
+    background-color: ${({ theme }) => theme.colors.neutral200};
+  }
+`;
+
 export const CrumbSimpleMenu = ({ children, ...props }) => (
-  <SimpleMenu noBorder icon={<CarretDown />} size="S" {...props}>
+  <SimpleMenu noBorder icon={<CarretDown />} as={StyledButton} size="S" {...props}>
     {children}
   </SimpleMenu>
 );

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -50896,7 +50896,7 @@ exports[`Storyshots Design System/Components/v2/Breadcrumbs base 1`] = `
 
 .c8:hover,
 .c8:focus {
-  background-color: #f6f6f9;
+  background-color: #dcdce4;
   color: #4a4a6a;
 }
 
@@ -51202,7 +51202,7 @@ exports[`Storyshots Design System/Components/v2/Breadcrumbs with-menu 1`] = `
 
 .c9:hover,
 .c9:focus {
-  background-color: #f6f6f9;
+  background-color: #dcdce4;
   color: #4a4a6a;
 }
 
@@ -51224,6 +51224,11 @@ exports[`Storyshots Design System/Components/v2/Breadcrumbs with-menu 1`] = `
 
 .c15 {
   padding: 4px 12px;
+}
+
+.c15:hover,
+.c15:focus {
+  background-color: #dcdce4;
 }
 
 .c6:first-child {


### PR DESCRIPTION
### What does it do?

This PR updates the interaction colors for `CrumbLink`s and `CrumbSimpleMenu`s from `neutral100` to `neutral200`.

### Why is it needed?

These components are used on a background which is already `neutral100` and therefore the state won't be visible.

### How to test it?

Validate the `hover/ focus` background colors on https://design-system-git-fix-breadcrumbs-interaction-strapijs.vercel.app/?path=/story/design-system-components-v2-breadcrumbs--with-menu

### Related issue(s)/PR(s)

- https://github.com/strapi/strapi/pull/13788
- https://github.com/strapi/design-system/pull/653
