### PR TITLE
DatePicker: remove default placeholder value

### DIFF
--- a/packages/strapi-design-system/src/DatePicker/DatePicker.js
+++ b/packages/strapi-design-system/src/DatePicker/DatePicker.js
@@ -13,16 +13,12 @@ export const DatePicker = ({
   ariaLabel,
   initialDate,
   selectedDate,
-  size,
   onChange,
   label,
   selectedDateLabel,
   onClear,
   clearLabel,
   disabled,
-  minDate,
-  maxDate,
-  placeholder,
   id,
   ...props
 }) => {
@@ -61,8 +57,6 @@ export const DatePicker = ({
         // Prevent input from changing for now
         onChange={() => {}}
         value={formattedDate}
-        placeholder={placeholder || formatDate(new Date(1970, 0, 1))}
-        size={size}
         startAction={
           <DatePickerButton
             ref={datePickerButtonRef}
@@ -97,8 +91,6 @@ export const DatePicker = ({
           onEscape={handleEscape}
           popoverSource={inputRef.current.inputWrapperRef}
           label={label || ariaLabel}
-          minDate={minDate}
-          maxDate={maxDate}
         />
       )}
     </DatePickerWrapper>

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -12780,7 +12780,6 @@ exports[`Storyshots Design System/Components/DatePicker base 1`] = `
                     class="c11"
                     id="datepicker-45"
                     name="datepicker"
-                    placeholder="1/1/1970"
                     value=""
                   />
                 </div>
@@ -13048,7 +13047,6 @@ exports[`Storyshots Design System/Components/DatePicker disabled 1`] = `
                     class="c11"
                     id="datepicker-46"
                     name="datepicker"
-                    placeholder="1/1/1970"
                     value=""
                   />
                 </div>
@@ -13555,7 +13553,6 @@ exports[`Storyshots Design System/Components/DatePicker size S 1`] = `
                     class="c11"
                     id="datepicker-48"
                     name="datepicker"
-                    placeholder="1/1/1970"
                     value=""
                   />
                 </div>


### PR DESCRIPTION
### What does it do?

This removes the default `placeholder` attribute value for the `DatePicker` component. As has been discussed with @maevalienard and suggested in #663. It also removes some explicit props and passes them through `props` instead.

### Why is it needed?

1. we don't have it on other input fields (consistency)
2. editors can not type into the field (yet) and therefore can not make a mistake
3. the format would need to be localized to be clear in every timezone

### How to test it?

Validate the default placeholder is gone in [the component preview](https://design-system-git-fix-datepicker-placeholder-strapijs.vercel.app/?path=/story/design-system-components-datepicker--base)

### Related issue(s)/PR(s)

- Fixes #663
