### PR TITLE
[Fix] Avatar img resizing

### DIFF
--- a/packages/strapi-design-system/src/Avatar/Avatar.js
+++ b/packages/strapi-design-system/src/Avatar/Avatar.js
@@ -7,6 +7,7 @@ import { Flex } from '../Flex';
 
 const AvatarImg = styled.img`
   border-radius: 50%;
+  object-fit: cover;
   display: block;
   position: relative;
 `;
@@ -20,6 +21,7 @@ const AvatarImgWrapper = styled.div`
 
 const PreviewContainer = styled.img`
   border-radius: 50%;
+  object-fit: cover;
   position: absolute;
   transform: translate(-${(previewSize - avatarSize) / 2}px, -100%);
   margin-top: -${({ theme }) => theme.spaces[1]};

--- a/packages/strapi-design-system/src/Avatar/__tests__/Avatar.spec.js
+++ b/packages/strapi-design-system/src/Avatar/__tests__/Avatar.spec.js
@@ -17,6 +17,7 @@ describe('Avatar', () => {
     expect(container.firstChild).toMatchInlineSnapshot(`
       .c3 {
         border-radius: 50%;
+        object-fit: cover;
         display: block;
         position: relative;
       }
@@ -30,6 +31,7 @@ describe('Avatar', () => {
 
       .c0 {
         border-radius: 50%;
+        object-fit: cover;
         position: absolute;
         -webkit-transform: translate(-19px,-100%);
         -ms-transform: translate(-19px,-100%);
@@ -90,6 +92,7 @@ describe('Avatar', () => {
     expect(container.firstChild).toMatchInlineSnapshot(`
       .c3 {
         border-radius: 50%;
+        object-fit: cover;
         display: block;
         position: relative;
       }
@@ -103,6 +106,7 @@ describe('Avatar', () => {
 
       .c0 {
         border-radius: 50%;
+        object-fit: cover;
         position: absolute;
         -webkit-transform: translate(-19px,-100%);
         -ms-transform: translate(-19px,-100%);

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -3836,6 +3836,7 @@ exports[`Storyshots Design System/Components/Avatar base 1`] = `
 
 .c5 {
   border-radius: 50%;
+  object-fit: cover;
   display: block;
   position: relative;
 }
@@ -3926,6 +3927,7 @@ exports[`Storyshots Design System/Components/Avatar group 1`] = `
 
 .c7 {
   border-radius: 50%;
+  object-fit: cover;
   display: block;
   position: relative;
 }
@@ -20577,6 +20579,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
 
 .c80 {
   border-radius: 50%;
+  object-fit: cover;
   display: block;
   position: relative;
 }
@@ -26639,6 +26642,7 @@ exports[`Storyshots Design System/Components/MainNav base 1`] = `
 
 .c30 {
   border-radius: 50%;
+  object-fit: cover;
   display: block;
   position: relative;
 }
@@ -38395,6 +38399,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
 
 .c20 {
   border-radius: 50%;
+  object-fit: cover;
   display: block;
   position: relative;
 }
@@ -39677,6 +39682,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
 
 .c20 {
   border-radius: 50%;
+  object-fit: cover;
   display: block;
   position: relative;
 }
@@ -40904,6 +40910,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
 
 .c22 {
   border-radius: 50%;
+  object-fit: cover;
   display: block;
   position: relative;
 }
@@ -54588,6 +54595,7 @@ exports[`Storyshots Design System/Components/v2/MainNav base 1`] = `
 
 .c31 {
   border-radius: 50%;
+  object-fit: cover;
   display: block;
   position: relative;
 }


### PR DESCRIPTION
## What

Fixed image in Avatar component being stretched

## Before

<img width="398" alt="Screenshot 2022-07-28 at 10 18 30" src="https://user-images.githubusercontent.com/71838159/181457893-6dfad549-e3b4-4cdf-8e49-349244d100b4.png">


## After 

<img width="511" alt="Screenshot 2022-07-28 at 10 18 46" src="https://user-images.githubusercontent.com/71838159/181457913-3508873d-fecb-408f-88a0-8dff2f94ce80.png">

