### PR TITLE
[Fix] Link font

### DIFF
--- a/packages/strapi-design-system/src/Link/Link.js
+++ b/packages/strapi-design-system/src/Link/Link.js
@@ -47,9 +47,7 @@ export const Link = ({ href, to, children, disabled, startIcon, endIcon, ...prop
           {startIcon}
         </IconWrapper>
       )}
-      <Typography variant="pi" textColor={disabled ? 'neutral600' : 'primary600'}>
-        {children}
-      </Typography>
+      <Typography textColor={disabled ? 'neutral600' : 'primary600'}>{children}</Typography>
 
       {endIcon && !href && (
         <IconWrapper as="span" aria-hidden={true} paddingLeft={2}>

--- a/packages/strapi-design-system/src/v2/Link/Link.js
+++ b/packages/strapi-design-system/src/v2/Link/Link.js
@@ -42,9 +42,7 @@ export const Link = React.forwardRef(({ children, href, disabled, startIcon, end
         </IconWrapper>
       )}
 
-      <Typography variant="pi" textColor={disabled ? 'neutral600' : 'primary600'}>
-        {children}
-      </Typography>
+      <Typography textColor={disabled ? 'neutral600' : 'primary600'}>{children}</Typography>
 
       {endIcon && (
         <IconWrapper as="span" aria-hidden={true} paddingLeft={2}>

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -3546,8 +3546,8 @@ exports[`Storyshots Design System/Components/Alert with action 1`] = `
 
 .c16 {
   color: #4945ff;
-  font-size: 0.75rem;
-  line-height: 1.33;
+  font-size: 0.875rem;
+  line-height: 1.43;
 }
 
 .c5 {
@@ -15219,8 +15219,8 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
 
 .c14 {
   color: #4945ff;
-  font-size: 0.75rem;
-  line-height: 1.33;
+  font-size: 0.875rem;
+  line-height: 1.43;
 }
 
 .c22 {
@@ -15681,8 +15681,8 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
 
 .c14 {
   color: #4945ff;
-  font-size: 0.75rem;
-  line-height: 1.33;
+  font-size: 0.875rem;
+  line-height: 1.43;
 }
 
 .c22 {
@@ -17003,8 +17003,8 @@ exports[`Storyshots Design System/Components/HeaderLayout base 1`] = `
 
 .c11 {
   color: #4945ff;
-  font-size: 0.75rem;
-  line-height: 1.33;
+  font-size: 0.875rem;
+  line-height: 1.43;
 }
 
 .c14 {
@@ -18141,8 +18141,8 @@ exports[`Storyshots Design System/Components/HeaderLayout combined w/ scroll 1`]
 
 .c11 {
   color: #4945ff;
-  font-size: 0.75rem;
-  line-height: 1.33;
+  font-size: 0.875rem;
+  line-height: 1.43;
 }
 
 .c14 {
@@ -18658,8 +18658,8 @@ exports[`Storyshots Design System/Components/HeaderLayout sticky 1`] = `
 
 .c14 {
   color: #4945ff;
-  font-size: 0.75rem;
-  line-height: 1.33;
+  font-size: 0.875rem;
+  line-height: 1.43;
 }
 
 .c15 {
@@ -51986,8 +51986,8 @@ exports[`Storyshots Design System/Components/v2/Link base 1`] = `
 
 .c7 {
   color: #4945ff;
-  font-size: 0.75rem;
-  line-height: 1.33;
+  font-size: 0.875rem;
+  line-height: 1.43;
 }
 
 .c3 {
@@ -52160,8 +52160,8 @@ exports[`Storyshots Design System/Components/v2/Link disabled 1`] = `
 
 .c7 {
   color: #666687;
-  font-size: 0.75rem;
-  line-height: 1.33;
+  font-size: 0.875rem;
+  line-height: 1.43;
 }
 
 .c3 {
@@ -52340,8 +52340,8 @@ exports[`Storyshots Design System/Components/v2/Link icons 1`] = `
 
 .c9 {
   color: #4945ff;
-  font-size: 0.75rem;
-  line-height: 1.33;
+  font-size: 0.875rem;
+  line-height: 1.43;
 }
 
 .c3 {
@@ -64117,8 +64117,8 @@ exports[`Storyshots Design System/Technical Components/RawTable simple 1`] = `
 
 .c7 {
   color: #4945ff;
-  font-size: 0.75rem;
-  line-height: 1.33;
+  font-size: 0.875rem;
+  line-height: 1.43;
 }
 
 .c6 {


### PR DESCRIPTION
## What

Update Links font from `pi` to `omega` variant

## Snapshots

Before:
<img width="475" alt="image" src="https://user-images.githubusercontent.com/71838159/185899204-38c62aaa-bdb4-4048-bd62-8c13c64af185.png">

After:
<img width="493" alt="image" src="https://user-images.githubusercontent.com/71838159/185899246-c37f56eb-cdb3-413a-8daf-ee235ba338b0.png">
