### PR TITLE
Combobox filtering behavior

### DIFF
--- a/packages/strapi-design-system/src/Combobox/__tests__/utils.spec.js
+++ b/packages/strapi-design-system/src/Combobox/__tests__/utils.spec.js
@@ -1,27 +1,94 @@
 import { filterOptions } from '../utils';
 
-describe('Combobox | utils', () => {
+describe('Combobox | utils', () => {
   describe('filterOptions', () => {
+    const options = [{ props: { children: 'Hamburger' } }, { props: { children: 'Bagel' } }];
+
     it('should filter the options correctly', () => {
-      const options = [{ props: { children: 'Hamburger' } }, { props: { children: 'Bagel' } }];
       const actual = filterOptions(options, 'ham');
-      const expected = [{ props: { children: 'Hamburger' } }];
+      const expected = [options[0]];
+
       expect(actual).toEqual(expected);
     });
 
-    it('should not filter the options if the search is empty or null', () => {
-      const options = [{ props: { children: 'Hamburger' } }, { props: { children: 'Bagel' } }];
-      const expected = [{ props: { children: 'Hamburger' } }, { props: { children: 'Bagel' } }];
+    it('empty array, without any param', () => {
+      const expected = [];
+      const result = filterOptions();
 
-      expect(filterOptions(options, '')).toEqual(expected);
-      expect(filterOptions(options, null)).toEqual(expected);
+      expect(result).toEqual(expected);
     });
 
-    it('should also filter the options if the search is a number', () => {
-      const options = [{ props: { children: 421 } }, { props: { children: 1285 } }];
-      const expected = [{ props: { children: 1285 } }];
+    it('all items, without filter param', () => {
+      const expected = options;
+      const result = filterOptions(options);
 
-      expect(filterOptions(options, 12)).toEqual(expected);
+      expect(result).toEqual(expected);
+    });
+
+    it('all items, with empty filter param', () => {
+      const expected = options;
+      const result = filterOptions(options, '');
+
+      expect(result).toEqual(expected);
+    });
+
+    it('all items, with null as filter param', () => {
+      const expected = options;
+      const result = filterOptions(options, null);
+
+      expect(result).toEqual(expected);
+    });
+
+    it('no items, with 0 as filter param', () => {
+      const expected = [];
+      const result = filterOptions(options, 0);
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should filter the options if the search is a number', () => {
+      const optionsNumeric = [{ props: { children: 421 } }, { props: { children: 1285 } }];
+      const expected = [optionsNumeric[1]];
+
+      expect(filterOptions(optionsNumeric, 12)).toEqual(expected);
+    });
+
+    describe('should filter the options correctly, with partial term', () => {
+      const optionsPartial = [
+        { props: { children: 'some-gh-user/project-super-cms' } },
+        { props: { children: 'other-gh-user/project-awesome-cms' } },
+        { props: { children: 'one-more-gh-user/cool-cms' } },
+        { props: { children: 'strapi/strapi' } },
+        { props: { children: 'strapi/design-system' } },
+      ];
+
+      it('3 of 5 items', () => {
+        const result = filterOptions(optionsPartial, 'cms');
+        const expected = [optionsPartial[0], optionsPartial[1], optionsPartial[2]];
+
+        expect(result).toEqual(expected);
+      });
+
+      it('2 of 5 items', () => {
+        const result = filterOptions(optionsPartial, 'project');
+        const expected = [optionsPartial[0], optionsPartial[1]];
+
+        expect(result).toEqual(expected);
+      });
+
+      it('2 last of 5 items', () => {
+        const result = filterOptions(optionsPartial, 'strapi');
+        const expected = [optionsPartial[3], optionsPartial[4]];
+
+        expect(result).toEqual(expected);
+      });
+
+      it('1 item', () => {
+        const result = filterOptions(optionsPartial, 'awesome');
+        const expected = [optionsPartial[1]];
+
+        expect(result).toEqual(expected);
+      });
     });
   });
 });

--- a/packages/strapi-design-system/src/Combobox/utils.js
+++ b/packages/strapi-design-system/src/Combobox/utils.js
@@ -28,12 +28,15 @@ export const TreeActions = {
 };
 
 // filter an array of options against an input string
-// returns an array of options that begin with the filter string, case-independent
+// returns an array of options that contains the filter string, case-independent
 export function filterOptions(options = [], filter, exclude = []) {
-  return filter
+  const equalizedTerm = String(filter ?? '').toLowerCase();
+
+  return equalizedTerm
     ? options.filter((option) => {
-        const optionChildren = option.props.children.toString();
-        const matches = optionChildren.toLowerCase().indexOf(filter.toString().toLowerCase()) === 0;
+        const equalizedOptionChildren = option.props.children.toString().toLowerCase();
+        const matches = equalizedOptionChildren.includes(equalizedTerm);
+
         return matches && exclude.indexOf(option) < 0;
       })
     : options;


### PR DESCRIPTION
### What does it do?
Updates the filtering rule for the `Combobox` component.

Before, just showing options which starts with the typed term.
Now, displays options containing any part of the typed term.

### Why is it needed?
Will help out to search for User Repositories at the Strapi Cloud Dashboard.

### How to test it?
Unit tests.
E2E existent tests.