### PR TITLE
chore: Update many children prop-types from string to node

### DIFF
--- a/packages/strapi-design-system/src/Alert/Alert.js
+++ b/packages/strapi-design-system/src/Alert/Alert.js
@@ -116,7 +116,7 @@ Alert.propTypes = {
   /**
    * The body of the `Alert` (Will be rendered under the `Alert` title).
    */
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
   /**
    * Accessible label for the close icon button.
    */

--- a/packages/strapi-design-system/src/Avatar/Avatar.js
+++ b/packages/strapi-design-system/src/Avatar/Avatar.js
@@ -87,7 +87,7 @@ export const Initials = ({ children }) => {
 };
 
 Initials.propTypes = {
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
 };
 
 Avatar.defaultProps = {

--- a/packages/strapi-design-system/src/Breadcrumbs/Breadcrumbs.js
+++ b/packages/strapi-design-system/src/Breadcrumbs/Breadcrumbs.js
@@ -39,7 +39,7 @@ export const Crumb = ({ children }) => {
 
 Crumb.displayName = 'Crumb';
 Crumb.propTypes = {
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
 };
 const crumbType = PropTypes.shape({ type: PropTypes.oneOf([Crumb]) });
 

--- a/packages/strapi-design-system/src/Card/CardTimer.js
+++ b/packages/strapi-design-system/src/Card/CardTimer.js
@@ -19,5 +19,5 @@ export const CardTimer = ({ children, ...props }) => (
 );
 
 CardTimer.propTypes = {
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
 };

--- a/packages/strapi-design-system/src/Checkbox/Checkbox.js
+++ b/packages/strapi-design-system/src/Checkbox/Checkbox.js
@@ -55,7 +55,7 @@ Checkbox.defaultProps = {
   hint: undefined,
 };
 Checkbox.propTypes = {
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
   disabled: PropTypes.bool,
   error: PropTypes.string,
   hint: PropTypes.string,

--- a/packages/strapi-design-system/src/LinkButton/LinkButton.js
+++ b/packages/strapi-design-system/src/LinkButton/LinkButton.js
@@ -93,7 +93,7 @@ LinkButton.defaultProps = {
   to: undefined,
 };
 LinkButton.propTypes = {
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
   disabled: PropTypes.bool,
   endIcon: PropTypes.element,
   href: (props) => {

--- a/packages/strapi-design-system/src/Loader/Loader.js
+++ b/packages/strapi-design-system/src/Loader/Loader.js
@@ -34,6 +34,6 @@ Loader.defaultProps = {
 };
 
 Loader.propTypes = {
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
   small: PropTypes.bool,
 };

--- a/packages/strapi-design-system/src/MainNav/NavLink.js
+++ b/packages/strapi-design-system/src/MainNav/NavLink.js
@@ -138,6 +138,6 @@ NavLink.defaultProps = {
 NavLink.propTypes = {
   badgeAriaLabel: PropTypes.string,
   badgeContent: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
   icon: PropTypes.node.isRequired,
 };

--- a/packages/strapi-design-system/src/ProgressBar/ProgressBar.js
+++ b/packages/strapi-design-system/src/ProgressBar/ProgressBar.js
@@ -49,7 +49,7 @@ ProgressBar.defaultProps = {
 };
 
 ProgressBar.propTypes = {
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
   max: PropTypes.number,
   min: PropTypes.number,
   size: PropTypes.oneOf(['S', 'M']),

--- a/packages/strapi-design-system/src/Radio/Radio.js
+++ b/packages/strapi-design-system/src/Radio/Radio.js
@@ -20,6 +20,6 @@ export const Radio = ({ children, ...props }) => {
 };
 
 Radio.propTypes = {
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
   value: PropTypes.any.isRequired,
 };

--- a/packages/strapi-design-system/src/Searchbar/Searchbar.js
+++ b/packages/strapi-design-system/src/Searchbar/Searchbar.js
@@ -94,7 +94,7 @@ Searchbar.defaultProps = {
 };
 
 Searchbar.propTypes = {
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
   clearLabel: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   onClear: PropTypes.func.isRequired,

--- a/packages/strapi-design-system/src/Tag/Tag.js
+++ b/packages/strapi-design-system/src/Tag/Tag.js
@@ -65,7 +65,7 @@ Tag.defaultProps = {
 };
 
 Tag.propTypes = {
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
   disabled: PropTypes.bool,
   icon: PropTypes.element.isRequired,
   onClick: PropTypes.func,

--- a/packages/strapi-design-system/src/v2/Breadcrumbs/Crumb.js
+++ b/packages/strapi-design-system/src/v2/Breadcrumbs/Crumb.js
@@ -25,6 +25,6 @@ Crumb.defaultProps = {
 };
 
 Crumb.propTypes = {
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
   isCurrent: PropTypes.bool,
 };

--- a/packages/strapi-design-system/src/v2/Breadcrumbs/CrumbLink.js
+++ b/packages/strapi-design-system/src/v2/Breadcrumbs/CrumbLink.js
@@ -28,6 +28,6 @@ CrumbLink.defaultProps = {
 };
 
 CrumbLink.propTypes = {
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
   to: PropTypes.string,
 };

--- a/packages/strapi-design-system/src/v2/LinkButton/LinkButton.js
+++ b/packages/strapi-design-system/src/v2/LinkButton/LinkButton.js
@@ -85,7 +85,7 @@ LinkButton.defaultProps = {
 };
 LinkButton.propTypes = {
   as: PropTypes.elementType,
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
   disabled: PropTypes.bool,
   endIcon: PropTypes.element,
   href: (props) => {


### PR DESCRIPTION
### What does it do?

In the tests of the core repo we see a couple of prop-type errors, because some components can only render `string` for `children` props. This PR opens many of these to be able to receive `node` instead.

### Why is it needed?

While `string` might work, it sometimes might not, if `formatMessage()` renders sub-components as replacements. I think opening `children` doesn't do any harm, because using a node instead of pure text isn't harmful in most cases, such as:

```js
<Checkbox>
  <span>Label</span>
</Checkbox>
```

I think it avoids some frustration in the future and I think `string` is too strict in most cases.
