### PR TITLE
ToggleInput: Remove clear button, if the field is disabled

### DIFF
--- a/packages/strapi-design-system/src/ToggleInput/ToggleInput.js
+++ b/packages/strapi-design-system/src/ToggleInput/ToggleInput.js
@@ -19,6 +19,7 @@ const ClearButton = styled(TextButton)`
 `;
 
 export const ToggleInput = ({
+  disabled,
   size,
   error,
   hint,
@@ -41,9 +42,11 @@ export const ToggleInput = ({
           <FieldLabel required={required} action={labelAction}>
             {label}
           </FieldLabel>
-          {clearLabel && onClear && checked !== null && <ClearButton onClick={onClear}>{clearLabel}</ClearButton>}
+          {clearLabel && onClear && checked !== null && !disabled && (
+            <ClearButton onClick={onClear}>{clearLabel}</ClearButton>
+          )}
         </Flex>
-        <ToggleCheckbox id={generatedId} size={size} name={name} checked={checked} {...props}>
+        <ToggleCheckbox id={generatedId} size={size} name={name} checked={checked} disabled={disabled} {...props}>
           {label}
         </ToggleCheckbox>
         <FieldHint />
@@ -58,6 +61,7 @@ ToggleInput.displayName = 'ToggleInput';
 ToggleInput.defaultProps = {
   checked: false,
   clearLabel: undefined,
+  disabled: false,
   error: undefined,
   hint: undefined,
   id: undefined,
@@ -72,6 +76,7 @@ ToggleInput.defaultProps = {
 ToggleInput.propTypes = {
   checked: PropTypes.bool,
   clearLabel: PropTypes.string,
+  disabled: PropTypes.bool,
   error: PropTypes.string,
   hint: PropTypes.string,
   id: PropTypes.string,

--- a/packages/strapi-design-system/src/ToggleInput/ToggleInput.stories.mdx
+++ b/packages/strapi-design-system/src/ToggleInput/ToggleInput.stories.mdx
@@ -142,6 +142,30 @@ import { ToggleInput } from '@strapi/design-system/ToggleInput';
   </Story>
 </Canvas>
 
+### Disabled
+
+<Canvas>
+  <Story name="disabled">
+    {() => {
+      const [checked, setChecked] = useState(true);
+      return (
+        <ToggleInput
+          disabled
+          hint="Enable provider"
+          label="Label"
+          name="enable-provider"
+          onLabel="True"
+          offLabel="False"
+          checked={checked}
+          onChange={(e) => setChecked(e.target.checked)}
+          clearLabel="clear"
+          onClear={() => setChecked(null)}
+        />
+      );
+    }}
+  </Story>
+</Canvas>
+
 ## Props
 
 <ArgsTable of={ToggleInput} />

--- a/packages/strapi-design-system/src/ToggleInput/__tests__/ToggleInput.e2e.js
+++ b/packages/strapi-design-system/src/ToggleInput/__tests__/ToggleInput.e2e.js
@@ -94,6 +94,16 @@ test.describe.parallel('ToggleInput', () => {
         await page.click('label');
         expect(await page.isChecked('#toggleinput-1')).toBeTruthy();
       });
+
+      test('clear value is not present, if the field is disabled', async ({ page }) => {
+        await page.goto(
+          '/iframe.html?id=design-system-components-toggleinput--disabled&args=&viewMode=story&theme=dark',
+        );
+        await injectAxe(page);
+        await checkA11y(page);
+
+        expect(await page.$$('text=clear')).toHaveLength(0);
+      });
     });
   });
 });

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -49972,6 +49972,260 @@ exports[`Storyshots Design System/Components/ToggleInput clear-value 1`] = `
 </div>
 `;
 
+exports[`Storyshots Design System/Components/ToggleInput disabled 1`] = `
+.c1 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c0 {
+  background: #ffffff;
+  padding: 8px;
+}
+
+.c2 {
+  padding: 8px;
+  height: 100%;
+}
+
+.c9 {
+  background: #eaeaef;
+  padding: 4px;
+  border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  border-color: #dcdce4;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c11 {
+  padding-right: 32px;
+  padding-left: 32px;
+  border-radius: 4px;
+}
+
+.c7 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c13 {
+  font-weight: 600;
+  color: #4a4a6a;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c16 {
+  color: #666687;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c4 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c6 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c5 > * {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.c5 > * + * {
+  margin-top: 4px;
+}
+
+.c8 {
+  position: relative;
+  display: inline-block;
+}
+
+.c10 {
+  height: 2.5rem;
+  cursor: not-allowed;
+  overflow: hidden;
+  outline: none;
+  box-shadow: 0;
+  -webkit-transition-property: border-color,box-shadow,fill;
+  transition-property: border-color,box-shadow,fill;
+  -webkit-transition-duration: 0.2s;
+  transition-duration: 0.2s;
+}
+
+.c10:focus-within {
+  border: 1px solid #4945ff;
+  box-shadow: #4945ff 0px 0px 0px 2px;
+}
+
+.c12 {
+  background-color: transparent;
+  border: 1px solid #eaeaef;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  z-index: 2;
+}
+
+.c14 {
+  background-color: #dcdce4;
+  border: 1px solid #c0c0cf;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  z-index: 2;
+}
+
+.c15 {
+  height: 100%;
+  left: 0;
+  opacity: 0;
+  position: absolute;
+  top: 0;
+  z-index: 1;
+  width: 100%;
+}
+
+.c3 {
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+}
+
+<div
+  class="c0"
+>
+  <main>
+    <div
+      class="c1"
+    >
+      <h1>
+        Storybook story
+      </h1>
+    </div>
+    <div
+      class="c2"
+      height="100%"
+    >
+      <div
+        class="c3"
+      >
+        <div
+          class="c4 c5"
+          spacing="1"
+        >
+          <div
+            class="c6"
+          >
+            <label
+              class="c7"
+              for="toggleinput-237"
+            >
+              <div
+                class="c6"
+              >
+                Label
+              </div>
+            </label>
+          </div>
+          <label
+            class="c8"
+          >
+            <div
+              class="c1"
+            >
+              Label
+            </div>
+            <div
+              class="c9 c10"
+              disabled=""
+              display="inline-flex"
+            >
+              <div
+                aria-hidden="true"
+                class="c11 c6 c12"
+                disabled=""
+              >
+                <span
+                  class="c13"
+                >
+                  False
+                </span>
+              </div>
+              <div
+                aria-hidden="true"
+                class="c11 c6 c14"
+                disabled=""
+              >
+                <span
+                  class="c13"
+                >
+                  True
+                </span>
+              </div>
+              <input
+                aria-disabled="true"
+                checked=""
+                class="c15"
+                id="toggleinput-237"
+                name="enable-provider"
+                type="checkbox"
+              />
+            </div>
+          </label>
+          <p
+            class="c16"
+            id="toggleinput-237-hint"
+          >
+            Enable provider
+          </p>
+        </div>
+      </div>
+    </div>
+  </main>
+</div>
+`;
+
 exports[`Storyshots Design System/Components/ToggleInput error 1`] = `
 .c1 {
   border: 0;
@@ -50166,7 +50420,7 @@ exports[`Storyshots Design System/Components/ToggleInput error 1`] = `
           >
             <label
               class="c7"
-              for="toggleinput-237"
+              for="toggleinput-238"
             >
               <div
                 class="c6"
@@ -50210,7 +50464,7 @@ exports[`Storyshots Design System/Components/ToggleInput error 1`] = `
               <input
                 aria-disabled="false"
                 class="c16"
-                id="toggleinput-237"
+                id="toggleinput-238"
                 name="enable-provider"
                 type="checkbox"
               />
@@ -50219,7 +50473,7 @@ exports[`Storyshots Design System/Components/ToggleInput error 1`] = `
           <p
             class="c17"
             data-strapi-field-error="true"
-            id="toggleinput-237-error"
+            id="toggleinput-238-error"
           >
             this field is required
           </p>
@@ -50405,7 +50659,7 @@ exports[`Storyshots Design System/Components/ToggleInput null-value 1`] = `
           >
             <label
               class="c7"
-              for="toggleinput-238"
+              for="toggleinput-239"
             >
               <div
                 class="c6"
@@ -50449,7 +50703,7 @@ exports[`Storyshots Design System/Components/ToggleInput null-value 1`] = `
               <input
                 aria-disabled="false"
                 class="c14"
-                id="toggleinput-238"
+                id="toggleinput-239"
                 name="enable-provider"
                 type="checkbox"
               />
@@ -50457,7 +50711,7 @@ exports[`Storyshots Design System/Components/ToggleInput null-value 1`] = `
           </label>
           <p
             class="c15"
-            id="toggleinput-238-hint"
+            id="toggleinput-239-hint"
           >
             Enable provider
           </p>
@@ -50662,7 +50916,7 @@ exports[`Storyshots Design System/Components/ToggleInput size S 1`] = `
           >
             <label
               class="c7"
-              for="toggleinput-239"
+              for="toggleinput-240"
             >
               <div
                 class="c6"
@@ -50706,7 +50960,7 @@ exports[`Storyshots Design System/Components/ToggleInput size S 1`] = `
               <input
                 aria-disabled="false"
                 class="c16"
-                id="toggleinput-239"
+                id="toggleinput-240"
                 name="enable-provider"
                 type="checkbox"
               />
@@ -50714,7 +50968,7 @@ exports[`Storyshots Design System/Components/ToggleInput size S 1`] = `
           </label>
           <p
             class="c17"
-            id="toggleinput-239-hint"
+            id="toggleinput-240-hint"
           >
             Enable provider
           </p>
@@ -50777,7 +51031,7 @@ exports[`Storyshots Design System/Components/Tooltip base 1`] = `
         </span>
         <span>
           <span
-            aria-describedby="tooltip-240"
+            aria-describedby="tooltip-241"
             class="c3"
             tabindex="0"
           >
@@ -50877,7 +51131,7 @@ exports[`Storyshots Design System/Components/Tooltip grid 1`] = `
           >
             <span>
               <button
-                aria-describedby="tooltip-242"
+                aria-describedby="tooltip-243"
                 tabindex="0"
               >
                 <span
@@ -50897,7 +51151,7 @@ exports[`Storyshots Design System/Components/Tooltip grid 1`] = `
           >
             <span>
               <button
-                aria-describedby="tooltip-244"
+                aria-describedby="tooltip-245"
                 tabindex="0"
               >
                 <span
@@ -50917,7 +51171,7 @@ exports[`Storyshots Design System/Components/Tooltip grid 1`] = `
           >
             <span>
               <button
-                aria-describedby="tooltip-246"
+                aria-describedby="tooltip-247"
                 tabindex="0"
               >
                 <span
@@ -50937,7 +51191,7 @@ exports[`Storyshots Design System/Components/Tooltip grid 1`] = `
           >
             <span>
               <button
-                aria-describedby="tooltip-248"
+                aria-describedby="tooltip-249"
                 tabindex="0"
               >
                 <span
@@ -51002,7 +51256,7 @@ exports[`Storyshots Design System/Components/Tooltip with text inside 1`] = `
       <div>
         <span>
           <span
-            aria-describedby="tooltip-250"
+            aria-describedby="tooltip-251"
             class="c3"
             tabindex="0"
           >
@@ -51013,7 +51267,7 @@ exports[`Storyshots Design System/Components/Tooltip with text inside 1`] = `
       <div>
         <span>
           <button
-            aria-describedby="tooltip-252"
+            aria-describedby="tooltip-253"
             tabindex="0"
           >
             <span
@@ -51696,7 +51950,7 @@ exports[`Storyshots Design System/Components/v2/Breadcrumbs with-menu 1`] = `
             >
               <div>
                 <button
-                  aria-controls="simplemenu-254"
+                  aria-controls="simplemenu-255"
                   aria-disabled="false"
                   aria-expanded="false"
                   aria-haspopup="true"
@@ -56942,7 +57196,7 @@ exports[`Storyshots Design System/Components/v2/SimpleMenu sizes 1`] = `
       >
         <div>
           <button
-            aria-controls="simplemenu-255"
+            aria-controls="simplemenu-256"
             aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="true"
@@ -56983,7 +57237,7 @@ exports[`Storyshots Design System/Components/v2/SimpleMenu sizes 1`] = `
         </div>
         <div>
           <button
-            aria-controls="simplemenu-256"
+            aria-controls="simplemenu-257"
             aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="true"
@@ -57226,7 +57480,7 @@ exports[`Storyshots Design System/Components/v2/SimpleMenu with-custom-label 1`]
     >
       <div>
         <button
-          aria-controls="simplemenu-257"
+          aria-controls="simplemenu-258"
           aria-disabled="false"
           aria-expanded="false"
           aria-haspopup="true"
@@ -57411,11 +57665,11 @@ exports[`Storyshots Design System/Components/v2/SimpleMenu with-iconbutton 1`] =
       <div>
         <span>
           <button
-            aria-controls="simplemenu-258"
+            aria-controls="simplemenu-259"
             aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="true"
-            aria-labelledby="tooltip-259"
+            aria-labelledby="tooltip-260"
             class="c3 c4"
             tabindex="0"
             type="button"
@@ -57640,7 +57894,7 @@ exports[`Storyshots Design System/Components/v2/SimpleMenu with-links 1`] = `
     >
       <div>
         <button
-          aria-controls="simplemenu-261"
+          aria-controls="simplemenu-262"
           aria-disabled="false"
           aria-expanded="false"
           aria-haspopup="true"
@@ -58296,7 +58550,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                 <span>
                   <button
                     aria-disabled="false"
-                    aria-labelledby="tooltip-263"
+                    aria-labelledby="tooltip-264"
                     class="c10 c11"
                     tabindex="0"
                     type="button"
@@ -58345,7 +58599,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                         class="c22"
                       >
                         <button
-                          aria-controls="subnav-list-265"
+                          aria-controls="subnav-list-266"
                           aria-expanded="true"
                           class="c23 c3 c24"
                         >
@@ -58391,7 +58645,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                       </div>
                     </div>
                     <ol
-                      id="subnav-list-265"
+                      id="subnav-list-266"
                     >
                       <li>
                         <a
@@ -58586,7 +58840,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                         class="c22"
                       >
                         <button
-                          aria-controls="subnav-list-266"
+                          aria-controls="subnav-list-267"
                           aria-expanded="true"
                           class="c23 c3 c24"
                         >
@@ -58632,7 +58886,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                       </div>
                     </div>
                     <ol
-                      id="subnav-list-266"
+                      id="subnav-list-267"
                     >
                       <li>
                         <div
@@ -58645,7 +58899,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                               class="c42"
                             >
                               <button
-                                aria-controls="subnav-list-267"
+                                aria-controls="subnav-list-268"
                                 aria-expanded="true"
                                 class="c43"
                               >
@@ -58681,7 +58935,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                             </div>
                           </div>
                           <ul
-                            id="subnav-list-267"
+                            id="subnav-list-268"
                           >
                             <li>
                               <a
@@ -58989,7 +59243,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                       </div>
                     </div>
                     <ol
-                      id="subnav-list-269"
+                      id="subnav-list-270"
                     >
                       <li>
                         <a
@@ -59097,7 +59351,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                       </div>
                     </div>
                     <ol
-                      id="subnav-list-270"
+                      id="subnav-list-271"
                     >
                       <li>
                         <a
@@ -59300,7 +59554,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                       </div>
                     </div>
                     <ol
-                      id="subnav-list-272"
+                      id="subnav-list-273"
                     >
                       <li>
                         <div
@@ -59313,7 +59567,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                               class="c42"
                             >
                               <button
-                                aria-controls="subnav-list-273"
+                                aria-controls="subnav-list-274"
                                 aria-expanded="true"
                                 class="c43"
                               >
@@ -59349,7 +59603,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                             </div>
                           </div>
                           <ul
-                            id="subnav-list-273"
+                            id="subnav-list-274"
                           >
                             <li>
                               <a
@@ -59530,7 +59784,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                       </div>
                     </div>
                     <ol
-                      id="subnav-list-274"
+                      id="subnav-list-275"
                     >
                       <li>
                         <a


### PR DESCRIPTION
### What does it do?

Does not display the "clear" button if the field is disabled.

### Why is it needed?

To disallow clearing a field, if it is disabled.

### How to test it?

Use the disabled story of "ToggleInput"

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/design-system/issues/670
