### PR TITLE
NumberInput: Keep scientific numbers after blur/ focus as value

### DIFF
--- a/packages/strapi-design-system/src/NumberInput/NumberInput.js
+++ b/packages/strapi-design-system/src/NumberInput/NumberInput.js
@@ -144,7 +144,7 @@ export const NumberInput = React.forwardRef(
 
     const handleFocus = () => {
       if (value !== undefined) {
-        setInputValue(String(numberParserRef.current.parse(inputValue) ?? INITIAL_VALUE));
+        setInputValue(String(numberParserRef.current.format(inputValue) ?? INITIAL_VALUE));
       }
     };
 

--- a/packages/strapi-design-system/src/NumberInput/__tests__/NumberInput.e2e.js
+++ b/packages/strapi-design-system/src/NumberInput/__tests__/NumberInput.e2e.js
@@ -33,6 +33,16 @@ test.describe.parallel('NumberInput', () => {
         expect(value).toBe('1.23456789');
       });
 
+      test('keeps a scientific number after blur / focus', async ({ page }) => {
+        await page.fill('input', '0.00000001');
+
+        await page.keyboard.press('Tab');
+        await page.focus('input');
+
+        const value = await page.$eval('input', (el) => el.value);
+        expect(value).toBe('0.00000001');
+      });
+
       test('fills the input when typing a valid numeric and a trailing comma', async ({ page }) => {
         await page.fill('input', '123456,');
         await page.keyboard.press('Tab');


### PR DESCRIPTION
### What does it do?

Fixes `NumberInput`, if scientific values were entered. 

### Why is it needed?

Currently, if you enter a scientific number into the `NumberInput` the following happens:

- enter `0.00000001`
- blur
- focus
- values switches to `1e-8` and can not be edited any longer

This PR makes sure, we display `0.00000001` even after the focus event.

### How to test it?

I've added an automated test.

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/design-system/issues/671
