### PR TITLE
Relax hint prop-types from string to node

### DIFF
--- a/packages/strapi-design-system/src/CarouselInput/Carousel.js
+++ b/packages/strapi-design-system/src/CarouselInput/Carousel.js
@@ -126,7 +126,7 @@ Carousel.propTypes = {
   actions: PropTypes.node,
   children: PropTypes.node.isRequired,
   error: PropTypes.string,
-  hint: PropTypes.string,
+  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
   label: PropTypes.string.isRequired,
   nextLabel: PropTypes.string.isRequired,
   onNext: PropTypes.func.isRequired,

--- a/packages/strapi-design-system/src/CarouselInput/CarouselInput.js
+++ b/packages/strapi-design-system/src/CarouselInput/CarouselInput.js
@@ -66,7 +66,7 @@ CarouselInput.propTypes = {
   actions: PropTypes.node,
   children: PropTypes.node.isRequired,
   error: PropTypes.string,
-  hint: PropTypes.string,
+  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
   id: PropTypes.string,
   label: PropTypes.string.isRequired,
   labelAction: PropTypes.element,

--- a/packages/strapi-design-system/src/Checkbox/Checkbox.js
+++ b/packages/strapi-design-system/src/Checkbox/Checkbox.js
@@ -58,6 +58,6 @@ Checkbox.propTypes = {
   children: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   error: PropTypes.string,
-  hint: PropTypes.string,
+  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
   id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };

--- a/packages/strapi-design-system/src/Combobox/Combobox.js
+++ b/packages/strapi-design-system/src/Combobox/Combobox.js
@@ -394,7 +394,7 @@ Combobox.propTypes = {
   disabled: PropTypes.bool,
   error: PropTypes.string,
   hasMoreItems: PropTypes.bool,
-  hint: PropTypes.string,
+  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
   label: PropTypes.string,
   loading: PropTypes.bool,
   loadingMessage: PropTypes.string,

--- a/packages/strapi-design-system/src/Field/Field.js
+++ b/packages/strapi-design-system/src/Field/Field.js
@@ -23,7 +23,7 @@ Field.defaultProps = {
 Field.propTypes = {
   children: PropTypes.node.isRequired,
   error: PropTypes.string,
-  hint: PropTypes.string,
+  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
   id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   name: PropTypes.string,
 };

--- a/packages/strapi-design-system/src/NumberInput/NumberInput.js
+++ b/packages/strapi-design-system/src/NumberInput/NumberInput.js
@@ -238,7 +238,7 @@ NumberInput.propTypes = {
   'aria-label': PropTypes.string,
   disabled: PropTypes.bool,
   error: PropTypes.string,
-  hint: PropTypes.string,
+  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
   id: PropTypes.string,
   label: PropTypes.string,
   labelAction: PropTypes.element,

--- a/packages/strapi-design-system/src/Select/Select.js
+++ b/packages/strapi-design-system/src/Select/Select.js
@@ -288,7 +288,7 @@ Select.propTypes = {
   customizeContent: PropTypes.func,
   disabled: PropTypes.bool,
   error: PropTypes.string,
-  hint: PropTypes.string,
+  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
   id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   label: PropTypes.string,
   labelAction: PropTypes.element,

--- a/packages/strapi-design-system/src/TextInput/TextInput.js
+++ b/packages/strapi-design-system/src/TextInput/TextInput.js
@@ -56,7 +56,7 @@ TextInput.propTypes = {
   'aria-label': PropTypes.string,
   endAction: PropTypes.element,
   error: PropTypes.string,
-  hint: PropTypes.string,
+  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
   id: PropTypes.string,
   label: PropTypes.string,
   labelAction: PropTypes.element,

--- a/packages/strapi-design-system/src/Textarea/Textarea.js
+++ b/packages/strapi-design-system/src/Textarea/Textarea.js
@@ -65,7 +65,7 @@ Textarea.propTypes = {
   'aria-label': PropTypes.string,
   children: PropTypes.string,
   error: PropTypes.string,
-  hint: PropTypes.string,
+  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
   id: PropTypes.string,
   label: PropTypes.string,
   labelAction: PropTypes.element,

--- a/packages/strapi-design-system/src/TimePicker/TimePicker.js
+++ b/packages/strapi-design-system/src/TimePicker/TimePicker.js
@@ -110,7 +110,7 @@ TimePicker.propTypes = {
   clearLabel: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   error: PropTypes.string,
-  hint: PropTypes.string,
+  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
   id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   label: PropTypes.string,
   onChange: PropTypes.func.isRequired,

--- a/packages/strapi-design-system/src/ToggleInput/ToggleInput.js
+++ b/packages/strapi-design-system/src/ToggleInput/ToggleInput.js
@@ -73,7 +73,7 @@ ToggleInput.propTypes = {
   checked: PropTypes.bool,
   clearLabel: PropTypes.string,
   error: PropTypes.string,
-  hint: PropTypes.string,
+  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
   id: PropTypes.string,
   label: PropTypes.string,
   labelAction: PropTypes.node,


### PR DESCRIPTION
### What does it do?

Allows `node` prop-types to be passed in as `hint` for `TextInput` components.

### Why is it needed?

I think it makes sense to open that prop, so that users can add e.g. multiline-text.

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/design-system/issues/667
