### PR TITLE
Popover: Fix onReachEnd callback

### DIFF
--- a/packages/strapi-design-system/src/Popover/Popover.js
+++ b/packages/strapi-design-system/src/Popover/Popover.js
@@ -90,6 +90,7 @@ const PopoverContent = ({ source, children, spacing, fullWidth, onReachEnd, inte
   useResizeObserver([source, popoverRef], () =>
     setPosition(position(source.current, popoverRef.current, fullWidth, centered, spacing)),
   );
+
   useIntersection(popoverRef, onReachEnd, {
     selectorToWatch: `#${intersectionId}`,
     skipWhen: !intersectionId || !onReachEnd,
@@ -105,7 +106,7 @@ const PopoverContent = ({ source, children, spacing, fullWidth, onReachEnd, inte
     <PopoverWrapper style={style} hasRadius background="neutral0" padding={1}>
       <PopoverScrollable ref={popoverRef} {...props}>
         {children}
-        {intersectionId && onReachEnd && <div id={intersectionId} />}
+        {intersectionId && onReachEnd && <Box id={intersectionId} width="100%" height="1px" />}
       </PopoverScrollable>
     </PopoverWrapper>
   );

--- a/packages/strapi-design-system/src/helpers/useIntersection.js
+++ b/packages/strapi-design-system/src/helpers/useIntersection.js
@@ -7,11 +7,9 @@ export const useIntersection = (scrollableAreaRef, callback, { selectorToWatch, 
     const options = {
       root: scrollableAreaRef.current,
       rootMargin: '0px',
-      threshold: 1.0,
     };
 
-    // eslint-disable-next-line no-unused-vars
-    const onEnterZone = (entries, _observer) => {
+    const onEnterZone = (entries) => {
       entries.forEach((entry) => {
         if (entry.isIntersecting) {
           if (scrollableAreaRef.current.scrollHeight > scrollableAreaRef.current.clientHeight) {


### PR DESCRIPTION
### What does it do?

Fixes the `onReachEnd` callback on `Popover` components. It is currently broken due to 2 reasons: 1) the element that is being checked for intersection has a width/ height of 9 2) the element is never fully intersecting (threshold).

### Why is it needed?

Fixes a bug, where the callback was not called.

### How to test it?

1. Add `hasMoreItems` to the `base` `Combobox` example
2. Add a `onReachEnd` callback
3. Scroll to the end

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/design-system/issues/672
