### PR TITLE
DatePicker: Allow to pass in a locale

### DIFF
--- a/packages/strapi-design-system/src/DatePicker/DatePicker.js
+++ b/packages/strapi-design-system/src/DatePicker/DatePicker.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import CalendarIcon from '@strapi/icons/Calendar';
 import Cross from '@strapi/icons/Cross';
@@ -8,6 +8,7 @@ import { DatePickerButton, DatePickerWrapper, IconBox } from './components';
 import { DatePickerCalendar } from './DatePickerCalendar';
 import { formatDate } from './utils/formatDate';
 import { useId } from '../helpers/useId';
+import { getDefaultLocale } from '../helpers/getDefaultLocale';
 
 export const DatePicker = ({
   ariaLabel,
@@ -15,6 +16,7 @@ export const DatePicker = ({
   selectedDate,
   onChange,
   label,
+  locale: defaultLocale,
   selectedDateLabel,
   onClear,
   clearLabel,
@@ -26,7 +28,8 @@ export const DatePicker = ({
   const [visible, setVisible] = useState(false);
   const inputRef = useRef(null);
   const datePickerButtonRef = useRef(null);
-  const formattedDate = selectedDate ? formatDate(selectedDate) : '';
+  const locale = useMemo(() => defaultLocale || getDefaultLocale(), [locale]);
+  const formattedDate = selectedDate ? formatDate(selectedDate, locale) : '';
 
   const toggleVisibility = () => {
     if (disabled) return;
@@ -61,7 +64,7 @@ export const DatePicker = ({
           <DatePickerButton
             ref={datePickerButtonRef}
             onClick={toggleVisibility}
-            aria-label={selectedDate ? selectedDateLabel(formatDate(selectedDate)) : label}
+            aria-label={selectedDate ? selectedDateLabel(formatDate(selectedDate, locale)) : label}
             type="button"
             aria-disabled={disabled}
           >
@@ -117,6 +120,7 @@ DatePicker.propTypes = {
   id: PropTypes.string,
   initialDate: PropTypes.instanceOf(Date),
   label: PropTypes.string,
+  locale: PropTypes.string,
   maxDate: PropTypes.instanceOf(Date),
   minDate: PropTypes.instanceOf(Date),
   onChange: PropTypes.func.isRequired,

--- a/packages/strapi-design-system/src/DatePicker/DatePicker.js
+++ b/packages/strapi-design-system/src/DatePicker/DatePicker.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useMemo } from 'react';
+import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import CalendarIcon from '@strapi/icons/Calendar';
 import Cross from '@strapi/icons/Cross';
@@ -28,7 +28,7 @@ export const DatePicker = ({
   const [visible, setVisible] = useState(false);
   const inputRef = useRef(null);
   const datePickerButtonRef = useRef(null);
-  const locale = useMemo(() => defaultLocale || getDefaultLocale(), [locale]);
+  const locale = defaultLocale || getDefaultLocale();
   const formattedDate = selectedDate ? formatDate(selectedDate, locale) : '';
 
   const toggleVisibility = () => {

--- a/packages/strapi-design-system/src/DatePicker/DatePicker.stories.mdx
+++ b/packages/strapi-design-system/src/DatePicker/DatePicker.stories.mdx
@@ -142,6 +142,31 @@ By passing in `minDate` or `maxDate` it is possible to define the range of years
   </Story>
 </Canvas>
 
+## Locales
+
+<Canvas>
+  <Story name="locales">
+    {() => {
+      const [date, setDate] = useState();
+      return (
+        <DatePicker
+          onChange={setDate}
+          selectedDate={date}
+          label="Date picker"
+          name="datepicker"
+          clearLabel={'Clear the datepicker'}
+          onClear={() => setDate(undefined)}
+          placeholder="03/01/1970"
+          locale="de"
+          selectedDateLabel={(formattedDate) => `Date picker, current is ${formattedDate}`}
+          minDate={new Date(2000, 1, 1)}
+          maxDate={new Date(2040, 1, 1)}
+        />
+      );
+    }}
+  </Story>
+</Canvas>
+
 ## Props
 
 <ArgsTable of={DatePicker} />

--- a/packages/strapi-design-system/src/DatePicker/__tests__/DatePicker.spec.js
+++ b/packages/strapi-design-system/src/DatePicker/__tests__/DatePicker.spec.js
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { DatePicker } from '../DatePicker';
+
+import { lightTheme } from '../../themes';
+import { ThemeProvider } from '../../ThemeProvider';
+
+describe('DatePicker', () => {
+  describe('Locale prop', () => {
+    const renderDate = (locale) =>
+      render(
+        <ThemeProvider theme={lightTheme}>
+          <DatePicker
+            label="date"
+            locale={locale}
+            selectedDateLabel={(formattedDate) => `Date picker, current is ${formattedDate}`}
+            selectedDate={new Date('Tue Sep 06 2022 00:00:00 GMT+0100 (British Summer Time)')}
+          />
+        </ThemeProvider>,
+      );
+
+    it('should format by EN locale by default', () => {
+      renderDate();
+
+      const input = screen.getByRole('textbox');
+
+      expect(input.value).toMatchInlineSnapshot('"9/6/2022"');
+    });
+
+    it('should format by the DE locale when passed', () => {
+      renderDate('de-DE');
+
+      const input = screen.getByRole('textbox');
+
+      expect(input.value).toMatchInlineSnapshot('"6.9.2022"');
+    });
+  });
+});

--- a/packages/strapi-design-system/src/DatePicker/__tests__/DatePicker.spec.js
+++ b/packages/strapi-design-system/src/DatePicker/__tests__/DatePicker.spec.js
@@ -15,7 +15,7 @@ describe('DatePicker', () => {
             label="date"
             locale={locale}
             selectedDateLabel={(formattedDate) => `Date picker, current is ${formattedDate}`}
-            selectedDate={new Date('Tue Sep 06 2022 00:00:00 GMT+0100 (British Summer Time)')}
+            selectedDate={new Date('Tue Sep 06 2022')}
           />
         </ThemeProvider>,
       );

--- a/packages/strapi-design-system/src/DatePicker/utils/formatDate.js
+++ b/packages/strapi-design-system/src/DatePicker/utils/formatDate.js
@@ -1,5 +1,5 @@
-export const formatDate = (date) => {
-  const langFormatter = new Intl.DateTimeFormat();
+export const formatDate = (date, locale) => {
+  const langFormatter = new Intl.DateTimeFormat(locale);
 
   return langFormatter.format(date);
 };

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -13073,7 +13073,7 @@ exports[`Storyshots Design System/Components/DatePicker disabled 1`] = `
 </div>
 `;
 
-exports[`Storyshots Design System/Components/DatePicker min/ max date 1`] = `
+exports[`Storyshots Design System/Components/DatePicker locales 1`] = `
 .c1 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
@@ -13317,6 +13317,250 @@ exports[`Storyshots Design System/Components/DatePicker min/ max date 1`] = `
 </div>
 `;
 
+exports[`Storyshots Design System/Components/DatePicker min/ max date 1`] = `
+.c1 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c0 {
+  background: #ffffff;
+  padding: 8px;
+}
+
+.c2 {
+  padding: 8px;
+  height: 100%;
+}
+
+.c9 {
+  padding-right: 8px;
+  padding-left: 12px;
+}
+
+.c5 {
+  font-weight: 600;
+  color: #32324d;
+  font-size: 0.75rem;
+  line-height: 1.33;
+}
+
+.c3 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c6 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c4 > * {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.c4 > * + * {
+  margin-top: 4px;
+}
+
+.c11 {
+  border: none;
+  border-radius: 4px;
+  padding-bottom: 0.65625rem;
+  padding-left: 0;
+  padding-right: 16px;
+  padding-top: 0.65625rem;
+  color: #32324d;
+  font-weight: 400;
+  font-size: 0.875rem;
+  display: block;
+  width: 100%;
+  background: inherit;
+}
+
+.c11::-webkit-input-placeholder {
+  color: #8e8ea9;
+  opacity: 1;
+}
+
+.c11::-moz-placeholder {
+  color: #8e8ea9;
+  opacity: 1;
+}
+
+.c11:-ms-input-placeholder {
+  color: #8e8ea9;
+  opacity: 1;
+}
+
+.c11::placeholder {
+  color: #8e8ea9;
+  opacity: 1;
+}
+
+.c11[aria-disabled='true'] {
+  color: inherit;
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: none;
+}
+
+.c8 {
+  border: 1px solid #dcdce4;
+  border-radius: 4px;
+  background: #ffffff;
+  outline: none;
+  box-shadow: 0;
+  -webkit-transition-property: border-color,box-shadow,fill;
+  transition-property: border-color,box-shadow,fill;
+  -webkit-transition-duration: 0.2s;
+  transition-duration: 0.2s;
+}
+
+.c8:focus-within {
+  border: 1px solid #4945ff;
+  box-shadow: #4945ff 0px 0px 0px 2px;
+}
+
+.c10 {
+  border: none;
+  background: transparent;
+  border-radius: 4px;
+}
+
+.c10 svg path {
+  fill: #8e8ea9;
+}
+
+<div
+  class="c0"
+>
+  <main>
+    <div
+      class="c1"
+    >
+      <h1>
+        Storybook story
+      </h1>
+    </div>
+    <div
+      class="c2"
+      height="100%"
+    >
+      <div
+        class=""
+      >
+        <div>
+          <div>
+            <div
+              class="c3 c4"
+              spacing="1"
+            >
+              <label
+                class="c5"
+                for="datepicker-48"
+              >
+                <div
+                  class="c6"
+                >
+                  Date picker
+                </div>
+              </label>
+              <div
+                class="c7 c8"
+              >
+                <div
+                  class="c9"
+                >
+                  <button
+                    aria-disabled="false"
+                    aria-label="Date picker"
+                    class="c10"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      fill="none"
+                      height="1em"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M3.869 2.99V0h2.9v2.99h10.463V0h2.9v2.99h.629c2.768 0 3.203.498 3.239 2.926V21c0 2.124-.191 3-2.802 3H2.818C.208 24 0 23.363 0 20.785V6.21c.035-2.049.233-3.22 3.001-3.22h.868zM2.32 20.369c0 .811.245.865.776.865h17.905c.53 0 .68-.012.68-.825V8.233c-.015-.627-.219-.737-.631-.737H2.907c-.413 0-.592.09-.587.573v12.3z"
+                        fill="#212134"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </button>
+                </div>
+                <input
+                  aria-autocomplete="none"
+                  aria-disabled="false"
+                  aria-invalid="false"
+                  class="c11"
+                  id="datepicker-48"
+                  name="datepicker"
+                  placeholder="03/01/1970"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+</div>
+`;
+
 exports[`Storyshots Design System/Components/DatePicker size S 1`] = `
 .c1 {
   border: 0;
@@ -13511,7 +13755,7 @@ exports[`Storyshots Design System/Components/DatePicker size S 1`] = `
               >
                 <label
                   class="c5"
-                  for="datepicker-48"
+                  for="datepicker-49"
                 >
                   <div
                     class="c6"
@@ -13553,7 +13797,7 @@ exports[`Storyshots Design System/Components/DatePicker size S 1`] = `
                     aria-disabled="false"
                     aria-invalid="false"
                     class="c11"
-                    id="datepicker-48"
+                    id="datepicker-49"
                     name="datepicker"
                     value=""
                   />
@@ -14919,7 +15163,7 @@ exports[`Storyshots Design System/Components/Field base 1`] = `
         >
           <label
             class="c5"
-            for="field-50"
+            for="field-51"
           >
             <div
               class="c6"
@@ -14934,7 +15178,7 @@ exports[`Storyshots Design System/Components/Field base 1`] = `
               aria-disabled="false"
               aria-invalid="false"
               class="c9"
-              id="field-50"
+              id="field-51"
               name="email"
               placeholder="Placeholder"
               type="text"
@@ -15125,7 +15369,7 @@ exports[`Storyshots Design System/Components/Field disabled 1`] = `
         >
           <label
             class="c5"
-            for="field-51"
+            for="field-52"
           >
             <div
               class="c6"
@@ -15138,11 +15382,11 @@ exports[`Storyshots Design System/Components/Field disabled 1`] = `
             disabled=""
           >
             <input
-              aria-describedby="field-51-hint"
+              aria-describedby="field-52-hint"
               aria-disabled="true"
               aria-invalid="false"
               class="c9"
-              id="field-51"
+              id="field-52"
               name="password"
               placeholder="Placeholder"
               value="Hello world"
@@ -15150,7 +15394,7 @@ exports[`Storyshots Design System/Components/Field disabled 1`] = `
           </div>
           <p
             class="c10"
-            id="field-51-hint"
+            id="field-52-hint"
           >
             Description line
           </p>
@@ -15471,7 +15715,7 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
             >
               <label
                 class="c7"
-                for="field-52"
+                for="field-53"
               >
                 <div
                   class="c6"
@@ -15484,7 +15728,7 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
               >
                 <span>
                   <button
-                    aria-describedby="tooltip-53"
+                    aria-describedby="tooltip-54"
                     aria-label="Information about the email"
                     style="padding: 0px; background: transparent;"
                     tabindex="0"
@@ -15572,11 +15816,11 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
                 </button>
               </div>
               <input
-                aria-describedby="field-52-hint"
+                aria-describedby="field-53-hint"
                 aria-disabled="false"
                 aria-invalid="false"
                 class="c20"
-                id="field-52"
+                id="field-53"
                 name="password"
                 placeholder="example@domain.com"
                 value=""
@@ -15611,7 +15855,7 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
             </div>
             <p
               class="c22"
-              id="field-52-hint"
+              id="field-53-hint"
             >
               Description line
             </p>
@@ -15933,7 +16177,7 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
             >
               <label
                 class="c7"
-                for="field-55"
+                for="field-56"
               >
                 <div
                   class="c6"
@@ -15946,7 +16190,7 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
               >
                 <span>
                   <button
-                    aria-describedby="tooltip-56"
+                    aria-describedby="tooltip-57"
                     aria-label="Information about the email"
                     style="padding: 0px; background: transparent;"
                     tabindex="0"
@@ -16034,11 +16278,11 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
                 </button>
               </div>
               <input
-                aria-describedby="field-55-hint"
+                aria-describedby="field-56-hint"
                 aria-disabled="false"
                 aria-invalid="false"
                 class="c20"
-                id="field-55"
+                id="field-56"
                 name="password"
                 placeholder="example@domain.com"
                 value=""
@@ -16073,7 +16317,7 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
             </div>
             <p
               class="c22"
-              id="field-55-hint"
+              id="field-56-hint"
             >
               Description line
             </p>
@@ -16269,7 +16513,7 @@ exports[`Storyshots Design System/Components/Field with description 1`] = `
         >
           <label
             class="c5"
-            for="field-58"
+            for="field-59"
             required=""
           >
             <div
@@ -16287,11 +16531,11 @@ exports[`Storyshots Design System/Components/Field with description 1`] = `
             class="c9 c10"
           >
             <input
-              aria-describedby="field-58-hint"
+              aria-describedby="field-59-hint"
               aria-disabled="false"
               aria-invalid="false"
               class="c11"
-              id="field-58"
+              id="field-59"
               name="email"
               placeholder="Placeholder"
               type="text"
@@ -16300,7 +16544,7 @@ exports[`Storyshots Design System/Components/Field with description 1`] = `
           </div>
           <p
             class="c12"
-            id="field-58-hint"
+            id="field-59-hint"
           >
             Description line
           </p>
@@ -16485,7 +16729,7 @@ exports[`Storyshots Design System/Components/Field with error 1`] = `
         >
           <label
             class="c5"
-            for="field-59"
+            for="field-60"
           >
             <div
               class="c6"
@@ -16497,11 +16741,11 @@ exports[`Storyshots Design System/Components/Field with error 1`] = `
             class="c7 c8"
           >
             <input
-              aria-describedby="field-59-error"
+              aria-describedby="field-60-error"
               aria-disabled="false"
               aria-invalid="true"
               class="c9"
-              id="field-59"
+              id="field-60"
               name="password"
               placeholder="Placeholder"
               type="password"
@@ -16511,7 +16755,7 @@ exports[`Storyshots Design System/Components/Field with error 1`] = `
           <p
             class="c10"
             data-strapi-field-error="true"
-            id="field-59-error"
+            id="field-60-error"
           >
             Password is too short
           </p>
@@ -16712,7 +16956,7 @@ exports[`Storyshots Design System/Components/Field with label-action 1`] = `
         >
           <label
             class="c5"
-            for="field-60"
+            for="field-61"
             required=""
           >
             <div
@@ -16757,7 +17001,7 @@ exports[`Storyshots Design System/Components/Field with label-action 1`] = `
               aria-disabled="false"
               aria-invalid="false"
               class="c13"
-              id="field-60"
+              id="field-61"
               name="password"
               placeholder="Placeholder"
               type="password"
@@ -19305,7 +19549,7 @@ exports[`Storyshots Design System/Components/IconButton base 1`] = `
           <span>
             <button
               aria-disabled="false"
-              aria-labelledby="tooltip-61"
+              aria-labelledby="tooltip-62"
               class="c5 c6"
               tabindex="0"
               type="button"
@@ -19329,7 +19573,7 @@ exports[`Storyshots Design System/Components/IconButton base 1`] = `
           <span>
             <button
               aria-disabled="false"
-              aria-labelledby="tooltip-63"
+              aria-labelledby="tooltip-64"
               class="c5 c6"
               tabindex="0"
               type="button"
@@ -19351,7 +19595,7 @@ exports[`Storyshots Design System/Components/IconButton base 1`] = `
           <span>
             <button
               aria-disabled="false"
-              aria-labelledby="tooltip-65"
+              aria-labelledby="tooltip-66"
               class="c5 c6"
               tabindex="0"
               type="button"
@@ -19373,7 +19617,7 @@ exports[`Storyshots Design System/Components/IconButton base 1`] = `
           <span>
             <button
               aria-disabled="false"
-              aria-labelledby="tooltip-67"
+              aria-labelledby="tooltip-68"
               class="c5 c6"
               tabindex="0"
               type="button"
@@ -19562,7 +19806,7 @@ exports[`Storyshots Design System/Components/IconButton disabled 1`] = `
           <span>
             <button
               aria-disabled="true"
-              aria-labelledby="tooltip-69"
+              aria-labelledby="tooltip-70"
               class="c5 c6"
               tabindex="0"
               type="button"
@@ -19586,7 +19830,7 @@ exports[`Storyshots Design System/Components/IconButton disabled 1`] = `
           <span>
             <button
               aria-disabled="true"
-              aria-labelledby="tooltip-71"
+              aria-labelledby="tooltip-72"
               class="c5 c6"
               tabindex="0"
               type="button"
@@ -19608,7 +19852,7 @@ exports[`Storyshots Design System/Components/IconButton disabled 1`] = `
           <span>
             <button
               aria-disabled="true"
-              aria-labelledby="tooltip-73"
+              aria-labelledby="tooltip-74"
               class="c5 c6"
               tabindex="0"
               type="button"
@@ -19630,7 +19874,7 @@ exports[`Storyshots Design System/Components/IconButton disabled 1`] = `
           <span>
             <button
               aria-disabled="true"
-              aria-labelledby="tooltip-75"
+              aria-labelledby="tooltip-76"
               class="c5 c6"
               tabindex="0"
               type="button"
@@ -19857,7 +20101,7 @@ exports[`Storyshots Design System/Components/IconButton group 1`] = `
           <span>
             <button
               aria-disabled="false"
-              aria-labelledby="tooltip-77"
+              aria-labelledby="tooltip-78"
               class="c6 c7 c8"
               tabindex="0"
               type="button"
@@ -19881,7 +20125,7 @@ exports[`Storyshots Design System/Components/IconButton group 1`] = `
           <span>
             <button
               aria-disabled="false"
-              aria-labelledby="tooltip-79"
+              aria-labelledby="tooltip-80"
               class="c6 c7 c8"
               tabindex="0"
               type="button"
@@ -19903,7 +20147,7 @@ exports[`Storyshots Design System/Components/IconButton group 1`] = `
           <span>
             <button
               aria-disabled="false"
-              aria-labelledby="tooltip-81"
+              aria-labelledby="tooltip-82"
               class="c6 c7 c8"
               tabindex="0"
               type="button"
@@ -19925,7 +20169,7 @@ exports[`Storyshots Design System/Components/IconButton group 1`] = `
           <span>
             <button
               aria-disabled="false"
-              aria-labelledby="tooltip-83"
+              aria-labelledby="tooltip-84"
               class="c6 c7 c8"
               tabindex="0"
               type="button"
@@ -21208,7 +21452,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                 <span>
                   <button
                     aria-disabled="false"
-                    aria-labelledby="tooltip-86"
+                    aria-labelledby="tooltip-87"
                     class="c11 c12"
                     tabindex="0"
                     type="button"
@@ -21257,7 +21501,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                         class="c0 c23"
                       >
                         <button
-                          aria-controls="subnav-list-88"
+                          aria-controls="subnav-list-89"
                           aria-expanded="true"
                           class="c0 c24 c25 c26"
                         >
@@ -21303,7 +21547,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </div>
                     </div>
                     <ol
-                      id="subnav-list-88"
+                      id="subnav-list-89"
                     >
                       <li>
                         <a
@@ -21460,7 +21704,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                         class="c0 c23"
                       >
                         <button
-                          aria-controls="subnav-list-89"
+                          aria-controls="subnav-list-90"
                           aria-expanded="true"
                           class="c0 c24 c25 c26"
                         >
@@ -21506,7 +21750,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                       </div>
                     </div>
                     <ol
-                      id="subnav-list-89"
+                      id="subnav-list-90"
                     >
                       <li>
                         <div
@@ -21519,7 +21763,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                               class="c0 c39"
                             >
                               <button
-                                aria-controls="subnav-list-90"
+                                aria-controls="subnav-list-91"
                                 aria-expanded="true"
                                 class="c40"
                               >
@@ -21555,7 +21799,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                             </div>
                           </div>
                           <ul
-                            id="subnav-list-90"
+                            id="subnav-list-91"
                           >
                             <li>
                               <a
@@ -22979,7 +23223,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                               <span>
                                 <button
                                   aria-disabled="false"
-                                  aria-labelledby="tooltip-91"
+                                  aria-labelledby="tooltip-92"
                                   class="c11 c12"
                                   tabindex="-1"
                                   type="button"
@@ -23006,7 +23250,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                                 <span>
                                   <button
                                     aria-disabled="false"
-                                    aria-labelledby="tooltip-93"
+                                    aria-labelledby="tooltip-94"
                                     class="c11 c12"
                                     tabindex="-1"
                                     type="button"
@@ -23150,7 +23394,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                               <span>
                                 <button
                                   aria-disabled="false"
-                                  aria-labelledby="tooltip-95"
+                                  aria-labelledby="tooltip-96"
                                   class="c11 c12"
                                   tabindex="-1"
                                   type="button"
@@ -23177,7 +23421,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                                 <span>
                                   <button
                                     aria-disabled="false"
-                                    aria-labelledby="tooltip-97"
+                                    aria-labelledby="tooltip-98"
                                     class="c11 c12"
                                     tabindex="-1"
                                     type="button"
@@ -23321,7 +23565,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                               <span>
                                 <button
                                   aria-disabled="false"
-                                  aria-labelledby="tooltip-99"
+                                  aria-labelledby="tooltip-100"
                                   class="c11 c12"
                                   tabindex="-1"
                                   type="button"
@@ -23348,7 +23592,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                                 <span>
                                   <button
                                     aria-disabled="false"
-                                    aria-labelledby="tooltip-101"
+                                    aria-labelledby="tooltip-102"
                                     class="c11 c12"
                                     tabindex="-1"
                                     type="button"
@@ -23492,7 +23736,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                               <span>
                                 <button
                                   aria-disabled="false"
-                                  aria-labelledby="tooltip-103"
+                                  aria-labelledby="tooltip-104"
                                   class="c11 c12"
                                   tabindex="-1"
                                   type="button"
@@ -23519,7 +23763,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                                 <span>
                                   <button
                                     aria-disabled="false"
-                                    aria-labelledby="tooltip-105"
+                                    aria-labelledby="tooltip-106"
                                     class="c11 c12"
                                     tabindex="-1"
                                     type="button"
@@ -23663,7 +23907,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                               <span>
                                 <button
                                   aria-disabled="false"
-                                  aria-labelledby="tooltip-107"
+                                  aria-labelledby="tooltip-108"
                                   class="c11 c12"
                                   tabindex="-1"
                                   type="button"
@@ -23690,7 +23934,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
                                 <span>
                                   <button
                                     aria-disabled="false"
-                                    aria-labelledby="tooltip-109"
+                                    aria-labelledby="tooltip-110"
                                     class="c11 c12"
                                     tabindex="-1"
                                     type="button"
@@ -28539,7 +28783,7 @@ exports[`Storyshots Design System/Components/NumberInput base 1`] = `
           >
             <label
               class="c6"
-              for="numberinput-111"
+              for="numberinput-112"
             >
               <div
                 class="c7"
@@ -28550,7 +28794,7 @@ exports[`Storyshots Design System/Components/NumberInput base 1`] = `
                 >
                   <span>
                     <button
-                      aria-describedby="tooltip-112"
+                      aria-describedby="tooltip-113"
                       aria-label="Information about the email"
                       style="padding: 0px; background: transparent;"
                       tabindex="0"
@@ -28577,11 +28821,11 @@ exports[`Storyshots Design System/Components/NumberInput base 1`] = `
               class="c10 c11"
             >
               <input
-                aria-describedby="numberinput-111-hint"
+                aria-describedby="numberinput-112-hint"
                 aria-disabled="false"
                 aria-invalid="false"
                 class="c12"
-                id="numberinput-111"
+                id="numberinput-112"
                 name="content"
                 placeholder="This is a content placeholder"
                 type="text"
@@ -28640,7 +28884,7 @@ exports[`Storyshots Design System/Components/NumberInput base 1`] = `
             </div>
             <p
               class="c18"
-              id="numberinput-111-hint"
+              id="numberinput-112-hint"
             >
               Description line
             </p>
@@ -28910,7 +29154,7 @@ exports[`Storyshots Design System/Components/NumberInput disabled 1`] = `
           >
             <label
               class="c6"
-              for="numberinput-114"
+              for="numberinput-115"
             >
               <div
                 class="c7"
@@ -28923,11 +29167,11 @@ exports[`Storyshots Design System/Components/NumberInput disabled 1`] = `
               disabled=""
             >
               <input
-                aria-describedby="numberinput-114-hint"
+                aria-describedby="numberinput-115-hint"
                 aria-disabled="true"
                 aria-invalid="false"
                 class="c10"
-                id="numberinput-114"
+                id="numberinput-115"
                 name="content"
                 placeholder="This is a content placeholder"
                 type="text"
@@ -28988,7 +29232,7 @@ exports[`Storyshots Design System/Components/NumberInput disabled 1`] = `
             </div>
             <p
               class="c16"
-              id="numberinput-114-hint"
+              id="numberinput-115-hint"
             >
               Description line
             </p>
@@ -29247,7 +29491,7 @@ exports[`Storyshots Design System/Components/NumberInput required 1`] = `
           >
             <label
               class="c6"
-              for="numberinput-115"
+              for="numberinput-116"
               required=""
             >
               <div
@@ -29265,11 +29509,11 @@ exports[`Storyshots Design System/Components/NumberInput required 1`] = `
               class="c10 c11"
             >
               <input
-                aria-describedby="numberinput-115-hint"
+                aria-describedby="numberinput-116-hint"
                 aria-disabled="false"
                 aria-invalid="false"
                 class="c12"
-                id="numberinput-115"
+                id="numberinput-116"
                 name="content"
                 placeholder="This is a content placeholder"
                 type="text"
@@ -29328,7 +29572,7 @@ exports[`Storyshots Design System/Components/NumberInput required 1`] = `
             </div>
             <p
               class="c18"
-              id="numberinput-115-hint"
+              id="numberinput-116-hint"
             >
               Description line
             </p>
@@ -29600,7 +29844,7 @@ exports[`Storyshots Design System/Components/NumberInput size S 1`] = `
           >
             <label
               class="c6"
-              for="numberinput-116"
+              for="numberinput-117"
             >
               <div
                 class="c7"
@@ -29611,7 +29855,7 @@ exports[`Storyshots Design System/Components/NumberInput size S 1`] = `
                 >
                   <span>
                     <button
-                      aria-describedby="tooltip-117"
+                      aria-describedby="tooltip-118"
                       aria-label="Information about the email"
                       style="padding: 0px; background: transparent;"
                       tabindex="0"
@@ -29638,11 +29882,11 @@ exports[`Storyshots Design System/Components/NumberInput size S 1`] = `
               class="c10 c11"
             >
               <input
-                aria-describedby="numberinput-116-hint"
+                aria-describedby="numberinput-117-hint"
                 aria-disabled="false"
                 aria-invalid="false"
                 class="c12"
-                id="numberinput-116"
+                id="numberinput-117"
                 name="content"
                 placeholder="This is a content placeholder"
                 type="text"
@@ -29701,7 +29945,7 @@ exports[`Storyshots Design System/Components/NumberInput size S 1`] = `
             </div>
             <p
               class="c18"
-              id="numberinput-116-hint"
+              id="numberinput-117-hint"
             >
               Description line
             </p>
@@ -29989,7 +30233,7 @@ exports[`Storyshots Design System/Components/NumberInput with initial 0 1`] = `
           >
             <label
               class="c6"
-              for="numberinput-119"
+              for="numberinput-120"
             >
               <div
                 class="c7"
@@ -30000,7 +30244,7 @@ exports[`Storyshots Design System/Components/NumberInput with initial 0 1`] = `
                 >
                   <span>
                     <button
-                      aria-describedby="tooltip-120"
+                      aria-describedby="tooltip-121"
                       aria-label="Information about the email"
                       style="padding: 0px; background: transparent;"
                       tabindex="0"
@@ -30027,11 +30271,11 @@ exports[`Storyshots Design System/Components/NumberInput with initial 0 1`] = `
               class="c10 c11"
             >
               <input
-                aria-describedby="numberinput-119-hint"
+                aria-describedby="numberinput-120-hint"
                 aria-disabled="false"
                 aria-invalid="false"
                 class="c12"
-                id="numberinput-119"
+                id="numberinput-120"
                 name="content"
                 placeholder="This is a content placeholder"
                 type="text"
@@ -30090,7 +30334,7 @@ exports[`Storyshots Design System/Components/NumberInput with initial 0 1`] = `
             </div>
             <p
               class="c18"
-              id="numberinput-119-hint"
+              id="numberinput-120-hint"
             >
               Description line
             </p>
@@ -30378,7 +30622,7 @@ exports[`Storyshots Design System/Components/NumberInput with initial empty 1`] 
           >
             <label
               class="c6"
-              for="numberinput-122"
+              for="numberinput-123"
             >
               <div
                 class="c7"
@@ -30389,7 +30633,7 @@ exports[`Storyshots Design System/Components/NumberInput with initial empty 1`] 
                 >
                   <span>
                     <button
-                      aria-describedby="tooltip-123"
+                      aria-describedby="tooltip-124"
                       aria-label="Information about the email"
                       style="padding: 0px; background: transparent;"
                       tabindex="0"
@@ -30416,11 +30660,11 @@ exports[`Storyshots Design System/Components/NumberInput with initial empty 1`] 
               class="c10 c11"
             >
               <input
-                aria-describedby="numberinput-122-hint"
+                aria-describedby="numberinput-123-hint"
                 aria-disabled="false"
                 aria-invalid="false"
                 class="c12"
-                id="numberinput-122"
+                id="numberinput-123"
                 name="content"
                 placeholder="This is a content placeholder"
                 type="text"
@@ -30479,7 +30723,7 @@ exports[`Storyshots Design System/Components/NumberInput with initial empty 1`] 
             </div>
             <p
               class="c18"
-              id="numberinput-122-hint"
+              id="numberinput-123-hint"
             >
               Description line
             </p>
@@ -30736,12 +30980,12 @@ exports[`Storyshots Design System/Components/NumberInput withoutLabel 1`] = `
               class="c6 c7"
             >
               <input
-                aria-describedby="numberinput-125-hint"
+                aria-describedby="numberinput-126-hint"
                 aria-disabled="false"
                 aria-invalid="false"
                 aria-label="Content"
                 class="c8"
-                id="numberinput-125"
+                id="numberinput-126"
                 name="content"
                 placeholder="This is a content placeholder"
                 type="text"
@@ -30800,7 +31044,7 @@ exports[`Storyshots Design System/Components/NumberInput withoutLabel 1`] = `
             </div>
             <p
               class="c14"
-              id="numberinput-125-hint"
+              id="numberinput-126-hint"
             >
               Description line
             </p>
@@ -31931,7 +32175,7 @@ exports[`Storyshots Design System/Components/Searchbar base 1`] = `
             >
               <label
                 class="c4"
-                for="field-126"
+                for="field-127"
               >
                 <div
                   class="c5"
@@ -31970,7 +32214,7 @@ exports[`Storyshots Design System/Components/Searchbar base 1`] = `
                 aria-disabled="false"
                 aria-invalid="false"
                 class="c12"
-                id="field-126"
+                id="field-127"
                 name="searchbar"
                 placeholder="e.g: strapi-plugin-abcd"
                 value=""
@@ -32171,7 +32415,7 @@ exports[`Storyshots Design System/Components/Searchbar disabled 1`] = `
           >
             <label
               class="c4"
-              for="field-127"
+              for="field-128"
             >
               <div
                 class="c5"
@@ -32211,7 +32455,7 @@ exports[`Storyshots Design System/Components/Searchbar disabled 1`] = `
               aria-disabled="true"
               aria-invalid="false"
               class="c12"
-              id="field-127"
+              id="field-128"
               name="searchbar"
               placeholder="e.g: strapi-plugin-abcd"
               value=""
@@ -32411,7 +32655,7 @@ exports[`Storyshots Design System/Components/Searchbar size S 1`] = `
             >
               <label
                 class="c4"
-                for="field-128"
+                for="field-129"
               >
                 <div
                   class="c5"
@@ -32450,7 +32694,7 @@ exports[`Storyshots Design System/Components/Searchbar size S 1`] = `
                 aria-disabled="false"
                 aria-invalid="false"
                 class="c12"
-                id="field-128"
+                id="field-129"
                 name="searchbar"
                 placeholder="e.g: strapi-plugin-abcd"
                 value=""
@@ -35016,7 +35260,7 @@ exports[`Storyshots Design System/Components/SimpleMenu sizes 1`] = `
       >
         <div>
           <button
-            aria-controls="simplemenu-129"
+            aria-controls="simplemenu-130"
             aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="true"
@@ -35057,7 +35301,7 @@ exports[`Storyshots Design System/Components/SimpleMenu sizes 1`] = `
         </div>
         <div>
           <button
-            aria-controls="simplemenu-130"
+            aria-controls="simplemenu-131"
             aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="true"
@@ -35300,7 +35544,7 @@ exports[`Storyshots Design System/Components/SimpleMenu with-custom-label 1`] = 
     >
       <div>
         <button
-          aria-controls="simplemenu-131"
+          aria-controls="simplemenu-132"
           aria-disabled="false"
           aria-expanded="false"
           aria-haspopup="true"
@@ -35485,11 +35729,11 @@ exports[`Storyshots Design System/Components/SimpleMenu with-iconbutton 1`] = `
       <div>
         <span>
           <button
-            aria-controls="simplemenu-132"
+            aria-controls="simplemenu-133"
             aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="true"
-            aria-labelledby="tooltip-133"
+            aria-labelledby="tooltip-134"
             class="c3 c4"
             tabindex="0"
             type="button"
@@ -35714,7 +35958,7 @@ exports[`Storyshots Design System/Components/SimpleMenu with-links 1`] = `
     >
       <div>
         <button
-          aria-controls="simplemenu-135"
+          aria-controls="simplemenu-136"
           aria-disabled="false"
           aria-expanded="false"
           aria-haspopup="true"
@@ -36552,7 +36796,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                 <span>
                   <button
                     aria-disabled="false"
-                    aria-labelledby="tooltip-137"
+                    aria-labelledby="tooltip-138"
                     class="c10 c11"
                     tabindex="0"
                     type="button"
@@ -36601,7 +36845,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                         class="c22"
                       >
                         <button
-                          aria-controls="subnav-list-139"
+                          aria-controls="subnav-list-140"
                           aria-expanded="true"
                           class="c23 c3 c24"
                         >
@@ -36647,7 +36891,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       </div>
                     </div>
                     <ol
-                      id="subnav-list-139"
+                      id="subnav-list-140"
                     >
                       <li>
                         <a
@@ -36838,7 +37082,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                         class="c22"
                       >
                         <button
-                          aria-controls="subnav-list-140"
+                          aria-controls="subnav-list-141"
                           aria-expanded="true"
                           class="c23 c3 c24"
                         >
@@ -36884,7 +37128,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       </div>
                     </div>
                     <ol
-                      id="subnav-list-140"
+                      id="subnav-list-141"
                     >
                       <li>
                         <div
@@ -36897,7 +37141,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                               class="c41"
                             >
                               <button
-                                aria-controls="subnav-list-141"
+                                aria-controls="subnav-list-142"
                                 aria-expanded="true"
                                 class="c42"
                               >
@@ -36933,7 +37177,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             </div>
                           </div>
                           <ul
-                            id="subnav-list-141"
+                            id="subnav-list-142"
                           >
                             <li>
                               <a
@@ -37236,7 +37480,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       </div>
                     </div>
                     <ol
-                      id="subnav-list-143"
+                      id="subnav-list-144"
                     >
                       <li>
                         <a
@@ -37342,7 +37586,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       </div>
                     </div>
                     <ol
-                      id="subnav-list-144"
+                      id="subnav-list-145"
                     >
                       <li>
                         <a
@@ -37542,7 +37786,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       </div>
                     </div>
                     <ol
-                      id="subnav-list-146"
+                      id="subnav-list-147"
                     >
                       <li>
                         <div
@@ -37555,7 +37799,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                               class="c41"
                             >
                               <button
-                                aria-controls="subnav-list-147"
+                                aria-controls="subnav-list-148"
                                 aria-expanded="true"
                                 class="c42"
                               >
@@ -37591,7 +37835,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                             </div>
                           </div>
                           <ul
-                            id="subnav-list-147"
+                            id="subnav-list-148"
                           >
                             <li>
                               <a
@@ -37768,7 +38012,7 @@ exports[`Storyshots Design System/Components/SubNav base 1`] = `
                       </div>
                     </div>
                     <ol
-                      id="subnav-list-148"
+                      id="subnav-list-149"
                     >
                       <li>
                         <a
@@ -38858,7 +39102,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-149"
+                            aria-labelledby="tooltip-150"
                             class="c21 c22"
                             tabindex="-1"
                             type="button"
@@ -38885,7 +39129,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-151"
+                              aria-labelledby="tooltip-152"
                               class="c21 c22"
                               tabindex="-1"
                               type="button"
@@ -38996,7 +39240,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-153"
+                            aria-labelledby="tooltip-154"
                             class="c21 c22"
                             tabindex="-1"
                             type="button"
@@ -39023,7 +39267,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-155"
+                              aria-labelledby="tooltip-156"
                               class="c21 c22"
                               tabindex="-1"
                               type="button"
@@ -39134,7 +39378,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-157"
+                            aria-labelledby="tooltip-158"
                             class="c21 c22"
                             tabindex="-1"
                             type="button"
@@ -39161,7 +39405,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-159"
+                              aria-labelledby="tooltip-160"
                               class="c21 c22"
                               tabindex="-1"
                               type="button"
@@ -39272,7 +39516,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-161"
+                            aria-labelledby="tooltip-162"
                             class="c21 c22"
                             tabindex="-1"
                             type="button"
@@ -39299,7 +39543,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-163"
+                              aria-labelledby="tooltip-164"
                               class="c21 c22"
                               tabindex="-1"
                               type="button"
@@ -39410,7 +39654,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-165"
+                            aria-labelledby="tooltip-166"
                             class="c21 c22"
                             tabindex="-1"
                             type="button"
@@ -39437,7 +39681,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-167"
+                              aria-labelledby="tooltip-168"
                               class="c21 c22"
                               tabindex="-1"
                               type="button"
@@ -40101,7 +40345,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-169"
+                            aria-labelledby="tooltip-170"
                             class="c21 c22"
                             tabindex="-1"
                             type="button"
@@ -40128,7 +40372,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-171"
+                              aria-labelledby="tooltip-172"
                               class="c21 c22"
                               tabindex="-1"
                               type="button"
@@ -40239,7 +40483,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-173"
+                            aria-labelledby="tooltip-174"
                             class="c21 c22"
                             tabindex="-1"
                             type="button"
@@ -40266,7 +40510,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-175"
+                              aria-labelledby="tooltip-176"
                               class="c21 c22"
                               tabindex="-1"
                               type="button"
@@ -40377,7 +40621,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-177"
+                            aria-labelledby="tooltip-178"
                             class="c21 c22"
                             tabindex="-1"
                             type="button"
@@ -40404,7 +40648,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-179"
+                              aria-labelledby="tooltip-180"
                               class="c21 c22"
                               tabindex="-1"
                               type="button"
@@ -40515,7 +40759,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-181"
+                            aria-labelledby="tooltip-182"
                             class="c21 c22"
                             tabindex="-1"
                             type="button"
@@ -40542,7 +40786,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-183"
+                              aria-labelledby="tooltip-184"
                               class="c21 c22"
                               tabindex="-1"
                               type="button"
@@ -40653,7 +40897,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-185"
+                            aria-labelledby="tooltip-186"
                             class="c21 c22"
                             tabindex="-1"
                             type="button"
@@ -40680,7 +40924,7 @@ exports[`Storyshots Design System/Components/Table base without footer 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-187"
+                              aria-labelledby="tooltip-188"
                               class="c21 c22"
                               tabindex="-1"
                               type="button"
@@ -41186,7 +41430,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-189"
+                              aria-labelledby="tooltip-190"
                               class="c17 c18"
                               tabindex="-1"
                               type="button"
@@ -41393,7 +41637,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-191"
+                            aria-labelledby="tooltip-192"
                             class="c17 c18"
                             tabindex="-1"
                             type="button"
@@ -41420,7 +41664,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-193"
+                              aria-labelledby="tooltip-194"
                               class="c17 c18"
                               tabindex="-1"
                               type="button"
@@ -41531,7 +41775,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-195"
+                            aria-labelledby="tooltip-196"
                             class="c17 c18"
                             tabindex="-1"
                             type="button"
@@ -41558,7 +41802,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-197"
+                              aria-labelledby="tooltip-198"
                               class="c17 c18"
                               tabindex="-1"
                               type="button"
@@ -41669,7 +41913,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-199"
+                            aria-labelledby="tooltip-200"
                             class="c17 c18"
                             tabindex="-1"
                             type="button"
@@ -41696,7 +41940,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-201"
+                              aria-labelledby="tooltip-202"
                               class="c17 c18"
                               tabindex="-1"
                               type="button"
@@ -41807,7 +42051,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-203"
+                            aria-labelledby="tooltip-204"
                             class="c17 c18"
                             tabindex="-1"
                             type="button"
@@ -41834,7 +42078,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-205"
+                              aria-labelledby="tooltip-206"
                               class="c17 c18"
                               tabindex="-1"
                               type="button"
@@ -41945,7 +42189,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                         <span>
                           <button
                             aria-disabled="false"
-                            aria-labelledby="tooltip-207"
+                            aria-labelledby="tooltip-208"
                             class="c17 c18"
                             tabindex="-1"
                             type="button"
@@ -41972,7 +42216,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
                           <span>
                             <button
                               aria-disabled="false"
-                              aria-labelledby="tooltip-209"
+                              aria-labelledby="tooltip-210"
                               class="c17 c18"
                               tabindex="-1"
                               type="button"
@@ -43544,7 +43788,7 @@ exports[`Storyshots Design System/Components/TextInput base 1`] = `
             >
               <label
                 class="c6"
-                for="textinput-211"
+                for="textinput-212"
               >
                 <div
                   class="c7"
@@ -43555,7 +43799,7 @@ exports[`Storyshots Design System/Components/TextInput base 1`] = `
                   >
                     <span>
                       <button
-                        aria-describedby="tooltip-212"
+                        aria-describedby="tooltip-213"
                         aria-label="Information about the email"
                         style="padding: 0px; background: transparent;"
                         tabindex="0"
@@ -43582,11 +43826,11 @@ exports[`Storyshots Design System/Components/TextInput base 1`] = `
                 class="c10 c11"
               >
                 <input
-                  aria-describedby="textinput-211-hint"
+                  aria-describedby="textinput-212-hint"
                   aria-disabled="false"
                   aria-invalid="false"
                   class="c12"
-                  id="textinput-211"
+                  id="textinput-212"
                   name="content"
                   placeholder="This is a content placeholder"
                   value=""
@@ -43594,7 +43838,7 @@ exports[`Storyshots Design System/Components/TextInput base 1`] = `
               </div>
               <p
                 class="c13"
-                id="textinput-211-hint"
+                id="textinput-212-hint"
               >
                 Description line
               </p>
@@ -43804,7 +44048,7 @@ exports[`Storyshots Design System/Components/TextInput disabled 1`] = `
             >
               <label
                 class="c6"
-                for="textinput-214"
+                for="textinput-215"
               >
                 <div
                   class="c7"
@@ -43815,7 +44059,7 @@ exports[`Storyshots Design System/Components/TextInput disabled 1`] = `
                   >
                     <span>
                       <button
-                        aria-describedby="tooltip-215"
+                        aria-describedby="tooltip-216"
                         aria-label="Information about the email"
                         style="padding: 0px; background: transparent;"
                         tabindex="0"
@@ -43843,11 +44087,11 @@ exports[`Storyshots Design System/Components/TextInput disabled 1`] = `
                 disabled=""
               >
                 <input
-                  aria-describedby="textinput-214-hint"
+                  aria-describedby="textinput-215-hint"
                   aria-disabled="true"
                   aria-invalid="false"
                   class="c12"
-                  id="textinput-214"
+                  id="textinput-215"
                   name="content"
                   placeholder="This is a content placeholder"
                   value="Disabled ontent"
@@ -43855,7 +44099,7 @@ exports[`Storyshots Design System/Components/TextInput disabled 1`] = `
               </div>
               <p
                 class="c13"
-                id="textinput-214-hint"
+                id="textinput-215-hint"
               >
                 Description line
               </p>
@@ -44062,7 +44306,7 @@ exports[`Storyshots Design System/Components/TextInput password 1`] = `
             >
               <label
                 class="c6"
-                for="textinput-217"
+                for="textinput-218"
               >
                 <div
                   class="c7"
@@ -44073,7 +44317,7 @@ exports[`Storyshots Design System/Components/TextInput password 1`] = `
                   >
                     <span>
                       <button
-                        aria-describedby="tooltip-218"
+                        aria-describedby="tooltip-219"
                         aria-label="Information about the email"
                         style="padding: 0px; background: transparent;"
                         tabindex="0"
@@ -44100,11 +44344,11 @@ exports[`Storyshots Design System/Components/TextInput password 1`] = `
                 class="c10 c11"
               >
                 <input
-                  aria-describedby="textinput-217-hint"
+                  aria-describedby="textinput-218-hint"
                   aria-disabled="false"
                   aria-invalid="false"
                   class="c12"
-                  id="textinput-217"
+                  id="textinput-218"
                   name="password"
                   placeholder="This is a password placeholder"
                   type="password"
@@ -44113,7 +44357,7 @@ exports[`Storyshots Design System/Components/TextInput password 1`] = `
               </div>
               <p
                 class="c13"
-                id="textinput-217-hint"
+                id="textinput-218-hint"
               >
                 Description line
               </p>
@@ -44320,7 +44564,7 @@ exports[`Storyshots Design System/Components/TextInput size S 1`] = `
             >
               <label
                 class="c6"
-                for="textinput-220"
+                for="textinput-221"
               >
                 <div
                   class="c7"
@@ -44331,7 +44575,7 @@ exports[`Storyshots Design System/Components/TextInput size S 1`] = `
                   >
                     <span>
                       <button
-                        aria-describedby="tooltip-221"
+                        aria-describedby="tooltip-222"
                         aria-label="Information about the email"
                         style="padding: 0px; background: transparent;"
                         tabindex="0"
@@ -44358,11 +44602,11 @@ exports[`Storyshots Design System/Components/TextInput size S 1`] = `
                 class="c10 c11"
               >
                 <input
-                  aria-describedby="textinput-220-hint"
+                  aria-describedby="textinput-221-hint"
                   aria-disabled="false"
                   aria-invalid="false"
                   class="c12"
-                  id="textinput-220"
+                  id="textinput-221"
                   name="content"
                   placeholder="This is a content placeholder"
                   value="size S input"
@@ -44370,7 +44614,7 @@ exports[`Storyshots Design System/Components/TextInput size S 1`] = `
               </div>
               <p
                 class="c13"
-                id="textinput-220-hint"
+                id="textinput-221-hint"
               >
                 Description line
               </p>
@@ -44577,7 +44821,7 @@ exports[`Storyshots Design System/Components/TextInput with error 1`] = `
             >
               <label
                 class="c6"
-                for="textinput-223"
+                for="textinput-224"
               >
                 <div
                   class="c7"
@@ -44588,7 +44832,7 @@ exports[`Storyshots Design System/Components/TextInput with error 1`] = `
                   >
                     <span>
                       <button
-                        aria-describedby="tooltip-224"
+                        aria-describedby="tooltip-225"
                         aria-label="Information about the email"
                         style="padding: 0px; background: transparent;"
                         tabindex="0"
@@ -44615,11 +44859,11 @@ exports[`Storyshots Design System/Components/TextInput with error 1`] = `
                 class="c10 c11"
               >
                 <input
-                  aria-describedby="textinput-223-error"
+                  aria-describedby="textinput-224-error"
                   aria-disabled="false"
                   aria-invalid="true"
                   class="c12"
-                  id="textinput-223"
+                  id="textinput-224"
                   name="content"
                   placeholder="This is a content placeholder"
                   value="content"
@@ -44628,7 +44872,7 @@ exports[`Storyshots Design System/Components/TextInput with error 1`] = `
               <p
                 class="c13"
                 data-strapi-field-error="true"
-                id="textinput-223-error"
+                id="textinput-224-error"
               >
                 Content is too long
               </p>
@@ -44804,12 +45048,12 @@ exports[`Storyshots Design System/Components/TextInput withoutLabel 1`] = `
                 class="c6 c7"
               >
                 <input
-                  aria-describedby="textinput-226-hint"
+                  aria-describedby="textinput-227-hint"
                   aria-disabled="false"
                   aria-invalid="false"
                   aria-label="Password"
                   class="c8"
-                  id="textinput-226"
+                  id="textinput-227"
                   name="password"
                   placeholder="This is a password placeholder"
                   type="password"
@@ -44818,7 +45062,7 @@ exports[`Storyshots Design System/Components/TextInput withoutLabel 1`] = `
               </div>
               <p
                 class="c9"
-                id="textinput-226-hint"
+                id="textinput-227-hint"
               >
                 Description line
               </p>
@@ -45044,7 +45288,7 @@ exports[`Storyshots Design System/Components/Textarea base 1`] = `
               >
                 <label
                   class="c8"
-                  for="textarea-227"
+                  for="textarea-228"
                 >
                   <div
                     class="c7"
@@ -45055,7 +45299,7 @@ exports[`Storyshots Design System/Components/Textarea base 1`] = `
                     >
                       <span>
                         <button
-                          aria-describedby="tooltip-228"
+                          aria-describedby="tooltip-229"
                           aria-label="Information about the email"
                           style="padding: 0px; background: transparent;"
                           tabindex="0"
@@ -45083,10 +45327,10 @@ exports[`Storyshots Design System/Components/Textarea base 1`] = `
                 class="c11"
               >
                 <textarea
-                  aria-describedby="textarea-227-error"
+                  aria-describedby="textarea-228-error"
                   aria-invalid="true"
                   class="c12"
-                  id="textarea-227"
+                  id="textarea-228"
                   name="content"
                   placeholder="This is a content placeholder"
                 />
@@ -45094,7 +45338,7 @@ exports[`Storyshots Design System/Components/Textarea base 1`] = `
               <p
                 class="c13"
                 data-strapi-field-error="true"
-                id="textarea-227-error"
+                id="textarea-228-error"
               >
                 Content is too short
               </p>
@@ -45320,7 +45564,7 @@ exports[`Storyshots Design System/Components/Textarea disabled 1`] = `
               >
                 <label
                   class="c8"
-                  for="textarea-230"
+                  for="textarea-231"
                 >
                   <div
                     class="c7"
@@ -45331,7 +45575,7 @@ exports[`Storyshots Design System/Components/Textarea disabled 1`] = `
                     >
                       <span>
                         <button
-                          aria-describedby="tooltip-231"
+                          aria-describedby="tooltip-232"
                           aria-label="Information about the email"
                           style="padding: 0px; background: transparent;"
                           tabindex="0"
@@ -45360,18 +45604,18 @@ exports[`Storyshots Design System/Components/Textarea disabled 1`] = `
                 disabled=""
               >
                 <textarea
-                  aria-describedby="textarea-230-hint"
+                  aria-describedby="textarea-231-hint"
                   aria-invalid="false"
                   class="c12"
                   disabled=""
-                  id="textarea-230"
+                  id="textarea-231"
                   name="content"
                   placeholder="This is a content placeholder"
                 />
               </div>
               <p
                 class="c13"
-                id="textarea-230-hint"
+                id="textarea-231-hint"
               >
                 Description line
               </p>
@@ -49543,7 +49787,7 @@ exports[`Storyshots Design System/Components/ToggleInput base 1`] = `
           >
             <label
               class="c7"
-              for="toggleinput-233"
+              for="toggleinput-234"
             >
               <div
                 class="c6"
@@ -49554,7 +49798,7 @@ exports[`Storyshots Design System/Components/ToggleInput base 1`] = `
                 >
                   <span>
                     <button
-                      aria-describedby="tooltip-234"
+                      aria-describedby="tooltip-235"
                       aria-label="Information about the email"
                       style="padding: 0px; background: transparent;"
                       tabindex="0"
@@ -49614,7 +49858,7 @@ exports[`Storyshots Design System/Components/ToggleInput base 1`] = `
                 aria-disabled="false"
                 checked=""
                 class="c18"
-                id="toggleinput-233"
+                id="toggleinput-234"
                 name="enable-provider"
                 type="checkbox"
               />
@@ -49622,7 +49866,7 @@ exports[`Storyshots Design System/Components/ToggleInput base 1`] = `
           </label>
           <p
             class="c19"
-            id="toggleinput-233-hint"
+            id="toggleinput-234-hint"
           >
             Enable provider
           </p>
@@ -49897,7 +50141,7 @@ exports[`Storyshots Design System/Components/ToggleInput clear-value 1`] = `
           >
             <label
               class="c7"
-              for="toggleinput-236"
+              for="toggleinput-237"
             >
               <div
                 class="c6"
@@ -49953,7 +50197,7 @@ exports[`Storyshots Design System/Components/ToggleInput clear-value 1`] = `
                 aria-disabled="false"
                 checked=""
                 class="c19"
-                id="toggleinput-236"
+                id="toggleinput-237"
                 name="enable-provider"
                 type="checkbox"
               />
@@ -49961,7 +50205,7 @@ exports[`Storyshots Design System/Components/ToggleInput clear-value 1`] = `
           </label>
           <p
             class="c20"
-            id="toggleinput-236-hint"
+            id="toggleinput-237-hint"
           >
             Enable provider
           </p>
@@ -50159,7 +50403,7 @@ exports[`Storyshots Design System/Components/ToggleInput disabled 1`] = `
           >
             <label
               class="c7"
-              for="toggleinput-237"
+              for="toggleinput-238"
             >
               <div
                 class="c6"
@@ -50207,7 +50451,7 @@ exports[`Storyshots Design System/Components/ToggleInput disabled 1`] = `
                 aria-disabled="true"
                 checked=""
                 class="c15"
-                id="toggleinput-237"
+                id="toggleinput-238"
                 name="enable-provider"
                 type="checkbox"
               />
@@ -50215,7 +50459,7 @@ exports[`Storyshots Design System/Components/ToggleInput disabled 1`] = `
           </label>
           <p
             class="c16"
-            id="toggleinput-237-hint"
+            id="toggleinput-238-hint"
           >
             Enable provider
           </p>
@@ -50420,7 +50664,7 @@ exports[`Storyshots Design System/Components/ToggleInput error 1`] = `
           >
             <label
               class="c7"
-              for="toggleinput-238"
+              for="toggleinput-239"
             >
               <div
                 class="c6"
@@ -50464,7 +50708,7 @@ exports[`Storyshots Design System/Components/ToggleInput error 1`] = `
               <input
                 aria-disabled="false"
                 class="c16"
-                id="toggleinput-238"
+                id="toggleinput-239"
                 name="enable-provider"
                 type="checkbox"
               />
@@ -50473,7 +50717,7 @@ exports[`Storyshots Design System/Components/ToggleInput error 1`] = `
           <p
             class="c17"
             data-strapi-field-error="true"
-            id="toggleinput-238-error"
+            id="toggleinput-239-error"
           >
             this field is required
           </p>
@@ -50659,7 +50903,7 @@ exports[`Storyshots Design System/Components/ToggleInput null-value 1`] = `
           >
             <label
               class="c7"
-              for="toggleinput-239"
+              for="toggleinput-240"
             >
               <div
                 class="c6"
@@ -50703,7 +50947,7 @@ exports[`Storyshots Design System/Components/ToggleInput null-value 1`] = `
               <input
                 aria-disabled="false"
                 class="c14"
-                id="toggleinput-239"
+                id="toggleinput-240"
                 name="enable-provider"
                 type="checkbox"
               />
@@ -50711,7 +50955,7 @@ exports[`Storyshots Design System/Components/ToggleInput null-value 1`] = `
           </label>
           <p
             class="c15"
-            id="toggleinput-239-hint"
+            id="toggleinput-240-hint"
           >
             Enable provider
           </p>
@@ -50916,7 +51160,7 @@ exports[`Storyshots Design System/Components/ToggleInput size S 1`] = `
           >
             <label
               class="c7"
-              for="toggleinput-240"
+              for="toggleinput-241"
             >
               <div
                 class="c6"
@@ -50960,7 +51204,7 @@ exports[`Storyshots Design System/Components/ToggleInput size S 1`] = `
               <input
                 aria-disabled="false"
                 class="c16"
-                id="toggleinput-240"
+                id="toggleinput-241"
                 name="enable-provider"
                 type="checkbox"
               />
@@ -50968,7 +51212,7 @@ exports[`Storyshots Design System/Components/ToggleInput size S 1`] = `
           </label>
           <p
             class="c17"
-            id="toggleinput-240-hint"
+            id="toggleinput-241-hint"
           >
             Enable provider
           </p>
@@ -51031,7 +51275,7 @@ exports[`Storyshots Design System/Components/Tooltip base 1`] = `
         </span>
         <span>
           <span
-            aria-describedby="tooltip-241"
+            aria-describedby="tooltip-242"
             class="c3"
             tabindex="0"
           >
@@ -51131,7 +51375,7 @@ exports[`Storyshots Design System/Components/Tooltip grid 1`] = `
           >
             <span>
               <button
-                aria-describedby="tooltip-243"
+                aria-describedby="tooltip-244"
                 tabindex="0"
               >
                 <span
@@ -51151,7 +51395,7 @@ exports[`Storyshots Design System/Components/Tooltip grid 1`] = `
           >
             <span>
               <button
-                aria-describedby="tooltip-245"
+                aria-describedby="tooltip-246"
                 tabindex="0"
               >
                 <span
@@ -51171,7 +51415,7 @@ exports[`Storyshots Design System/Components/Tooltip grid 1`] = `
           >
             <span>
               <button
-                aria-describedby="tooltip-247"
+                aria-describedby="tooltip-248"
                 tabindex="0"
               >
                 <span
@@ -51191,7 +51435,7 @@ exports[`Storyshots Design System/Components/Tooltip grid 1`] = `
           >
             <span>
               <button
-                aria-describedby="tooltip-249"
+                aria-describedby="tooltip-250"
                 tabindex="0"
               >
                 <span
@@ -51256,7 +51500,7 @@ exports[`Storyshots Design System/Components/Tooltip with text inside 1`] = `
       <div>
         <span>
           <span
-            aria-describedby="tooltip-251"
+            aria-describedby="tooltip-252"
             class="c3"
             tabindex="0"
           >
@@ -51267,7 +51511,7 @@ exports[`Storyshots Design System/Components/Tooltip with text inside 1`] = `
       <div>
         <span>
           <button
-            aria-describedby="tooltip-253"
+            aria-describedby="tooltip-254"
             tabindex="0"
           >
             <span
@@ -51950,7 +52194,7 @@ exports[`Storyshots Design System/Components/v2/Breadcrumbs with-menu 1`] = `
             >
               <div>
                 <button
-                  aria-controls="simplemenu-255"
+                  aria-controls="simplemenu-256"
                   aria-disabled="false"
                   aria-expanded="false"
                   aria-haspopup="true"
@@ -57196,7 +57440,7 @@ exports[`Storyshots Design System/Components/v2/SimpleMenu sizes 1`] = `
       >
         <div>
           <button
-            aria-controls="simplemenu-256"
+            aria-controls="simplemenu-257"
             aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="true"
@@ -57237,7 +57481,7 @@ exports[`Storyshots Design System/Components/v2/SimpleMenu sizes 1`] = `
         </div>
         <div>
           <button
-            aria-controls="simplemenu-257"
+            aria-controls="simplemenu-258"
             aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="true"
@@ -57480,7 +57724,7 @@ exports[`Storyshots Design System/Components/v2/SimpleMenu with-custom-label 1`]
     >
       <div>
         <button
-          aria-controls="simplemenu-258"
+          aria-controls="simplemenu-259"
           aria-disabled="false"
           aria-expanded="false"
           aria-haspopup="true"
@@ -57665,11 +57909,11 @@ exports[`Storyshots Design System/Components/v2/SimpleMenu with-iconbutton 1`] =
       <div>
         <span>
           <button
-            aria-controls="simplemenu-259"
+            aria-controls="simplemenu-260"
             aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="true"
-            aria-labelledby="tooltip-260"
+            aria-labelledby="tooltip-261"
             class="c3 c4"
             tabindex="0"
             type="button"
@@ -57894,7 +58138,7 @@ exports[`Storyshots Design System/Components/v2/SimpleMenu with-links 1`] = `
     >
       <div>
         <button
-          aria-controls="simplemenu-262"
+          aria-controls="simplemenu-263"
           aria-disabled="false"
           aria-expanded="false"
           aria-haspopup="true"
@@ -58550,7 +58794,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                 <span>
                   <button
                     aria-disabled="false"
-                    aria-labelledby="tooltip-264"
+                    aria-labelledby="tooltip-265"
                     class="c10 c11"
                     tabindex="0"
                     type="button"
@@ -58599,7 +58843,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                         class="c22"
                       >
                         <button
-                          aria-controls="subnav-list-266"
+                          aria-controls="subnav-list-267"
                           aria-expanded="true"
                           class="c23 c3 c24"
                         >
@@ -58645,7 +58889,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                       </div>
                     </div>
                     <ol
-                      id="subnav-list-266"
+                      id="subnav-list-267"
                     >
                       <li>
                         <a
@@ -58840,7 +59084,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                         class="c22"
                       >
                         <button
-                          aria-controls="subnav-list-267"
+                          aria-controls="subnav-list-268"
                           aria-expanded="true"
                           class="c23 c3 c24"
                         >
@@ -58886,7 +59130,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                       </div>
                     </div>
                     <ol
-                      id="subnav-list-267"
+                      id="subnav-list-268"
                     >
                       <li>
                         <div
@@ -58899,7 +59143,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                               class="c42"
                             >
                               <button
-                                aria-controls="subnav-list-268"
+                                aria-controls="subnav-list-269"
                                 aria-expanded="true"
                                 class="c43"
                               >
@@ -58935,7 +59179,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                             </div>
                           </div>
                           <ul
-                            id="subnav-list-268"
+                            id="subnav-list-269"
                           >
                             <li>
                               <a
@@ -59243,7 +59487,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                       </div>
                     </div>
                     <ol
-                      id="subnav-list-270"
+                      id="subnav-list-271"
                     >
                       <li>
                         <a
@@ -59351,7 +59595,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                       </div>
                     </div>
                     <ol
-                      id="subnav-list-271"
+                      id="subnav-list-272"
                     >
                       <li>
                         <a
@@ -59554,7 +59798,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                       </div>
                     </div>
                     <ol
-                      id="subnav-list-273"
+                      id="subnav-list-274"
                     >
                       <li>
                         <div
@@ -59567,7 +59811,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                               class="c42"
                             >
                               <button
-                                aria-controls="subnav-list-274"
+                                aria-controls="subnav-list-275"
                                 aria-expanded="true"
                                 class="c43"
                               >
@@ -59603,7 +59847,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                             </div>
                           </div>
                           <ul
-                            id="subnav-list-274"
+                            id="subnav-list-275"
                           >
                             <li>
                               <a
@@ -59784,7 +60028,7 @@ exports[`Storyshots Design System/Components/v2/SubNav base 1`] = `
                       </div>
                     </div>
                     <ol
-                      id="subnav-list-275"
+                      id="subnav-list-276"
                     >
                       <li>
                         <a


### PR DESCRIPTION
### What does it do?

Similar to https://github.com/strapi/design-system/pull/687: it allows us to pass in a locale (e.g. from users choice in strapi core), which overrides the one from `navigator`.

### Why is it needed?

To locale fields to the selected locale of a users instead of the one from the browser.

### How to test it?

* I've added some snapshot testing of the input value for EN & DE
* Added a new story to illustrate the locale in DE

