### PR TITLE
[POC] Convert Popover to Radix-UI popover

### DIFF
--- a/packages/strapi-design-system/package.json
+++ b/packages/strapi-design-system/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "@internationalized/number": "^3.1.1",
+    "@radix-ui/react-popover": "^1.0.0",
     "compute-scroll-into-view": "^1.0.17",
     "prop-types": "^15.7.2"
   },

--- a/packages/strapi-design-system/src/Popover/Popover.js
+++ b/packages/strapi-design-system/src/Popover/Popover.js
@@ -1,59 +1,14 @@
-import React, { useRef, useState } from 'react';
+import * as React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Box } from '../Box';
-import { Portal } from '../Portal';
+import * as RadixPopover from '@radix-ui/react-popover';
+
 import { useIntersection } from '../helpers/useIntersection';
-import { useResizeObserver } from '../helpers/useResizeObserver';
 
-export const position = (source, popover, fullWidth, centered, spacing = 0) => {
-  const rect = source.getBoundingClientRect();
-  let top = rect.top + rect.height + window.pageYOffset + spacing;
-  let left = rect.left + window.pageXOffset;
-
-  if (!popover) {
-    return {
-      left,
-      top,
-      width: fullWidth ? rect.width : undefined,
-    };
-  }
-
-  const popoverRect = popover.getBoundingClientRect();
-
-  if (centered) {
-    const popoverBorderPadding = 10;
-    const popoverTotalWidth = popoverRect.width + popoverBorderPadding;
-    const widthDifference = (rect.width - popoverTotalWidth) / 2;
-
-    left = rect.left + widthDifference + window.pageXOffset;
-  }
-
-  // if popover overflows left or right viewport
-  if (popoverRect.left < 0) {
-    left = rect.left + window.pageXOffset;
-  } else if (popoverRect.left + popoverRect.width > window.innerWidth) {
-    left = window.innerWidth - popoverRect.width - 20;
-  }
-
-  const windowSizeAtPosition = window.innerHeight + window.pageYOffset;
-
-  // if popover overflows bottom of viewport
-  if (top + popoverRect.height + spacing > windowSizeAtPosition) {
-    const popoverBorderPadding = 10;
-    top = window.pageYOffset + rect.top - popoverRect.height - popoverBorderPadding - spacing;
-  }
-
-  return {
-    left,
-    top,
-    width: fullWidth ? rect.width : undefined,
-  };
-};
+import { Box } from '../Box';
 
 const PopoverWrapper = styled(Box)`
   box-shadow: ${({ theme }) => theme.shadows.filterShadow};
-  position: absolute;
   z-index: 4;
   border: 1px solid ${({ theme }) => theme.colors.neutral150};
   background: ${({ theme }) => theme.colors.neutral0};
@@ -81,62 +36,32 @@ const PopoverScrollable = styled(Box)`
   }
 `;
 
-const PopoverContent = ({ source, children, spacing, fullWidth, onReachEnd, intersectionId, centered, ...props }) => {
-  const popoverRef = useRef(null);
-  const [{ left, top, width }, setPosition] = useState(
-    position(source.current, popoverRef.current, fullWidth, centered, spacing),
-  );
-
-  useResizeObserver([source, popoverRef], () =>
-    setPosition(position(source.current, popoverRef.current, fullWidth, centered, spacing)),
-  );
+export const Content = ({ children, onReachEnd, intersectionId, className, align, spacing, ...props }) => {
+  const popoverRef = React.useRef(null);
 
   useIntersection(popoverRef, onReachEnd, {
     selectorToWatch: `#${intersectionId}`,
     skipWhen: !intersectionId || !onReachEnd,
   });
 
-  const style = {
-    left: `${left}px`,
-    top: `${top}px`,
-    width: width ? `${width}px` : undefined,
-  };
-
   return (
-    <PopoverWrapper style={style} hasRadius background="neutral0" padding={1}>
-      <PopoverScrollable ref={popoverRef} {...props}>
-        {children}
-        {intersectionId && onReachEnd && <Box id={intersectionId} width="100%" height="1px" />}
-      </PopoverScrollable>
-    </PopoverWrapper>
+    <RadixPopover.Portal>
+      <RadixPopover.Content asChild align={align} sideOffset={spacing}>
+        <PopoverWrapper className={className} hasRadius background="neutral0" padding={1}>
+          <PopoverScrollable ref={popoverRef} {...props}>
+            {children}
+            {intersectionId && onReachEnd && <Box id={intersectionId} width="100%" height="1px" />}
+          </PopoverScrollable>
+        </PopoverWrapper>
+      </RadixPopover.Content>
+    </RadixPopover.Portal>
   );
 };
 
-export const Popover = (props) => {
-  return (
-    <Portal>
-      <PopoverContent {...props} />
-    </Portal>
-  );
-};
-
-const popoverDefaultProps = {
-  fullWidth: false,
-  intersectionId: undefined,
-  onReachEnd: undefined,
-  centered: false,
-};
-
-const popoverProps = {
-  /**
-   * Horizontally center the popover
-   */
-  centered: PropTypes.bool,
+Content.propTypes = {
+  align: PropTypes.oneOf(['start', 'center', 'end']),
   children: PropTypes.node.isRequired,
-  /**
-   * Display full width popover
-   */
-  fullWidth: PropTypes.bool,
+  className: PropTypes.string,
   /**
    * Element id to watch for the onReachEnd event
    */
@@ -145,16 +70,29 @@ const popoverProps = {
    * The callback invoked after a scroll to the bottom of the popover content.
    */
   onReachEnd: PropTypes.func,
-  /**
-   * A React ref. Used to defined the position of the popover.
-   */
-  source: PropTypes.shape({
-    current: (typeof Element === 'undefined' ? PropTypes.any : PropTypes.instanceOf(Element)).isRequired,
-  }).isRequired,
   spacing: PropTypes.number,
 };
 
-PopoverContent.propTypes = popoverProps;
-PopoverContent.defaultProps = popoverDefaultProps;
-Popover.propTypes = popoverProps;
-Popover.defaultProps = popoverDefaultProps;
+Content.defaultProps = {
+  intersectionId: undefined,
+  onReachEnd: undefined,
+};
+
+export const Root = RadixPopover.Root;
+
+/**
+ * Wraps your popover button and by default merges the props of the RadixTrigger
+ * with that of your button to avoid too many changes to your components.
+ */
+export const Trigger = ({ asChild, children }) => (
+  <RadixPopover.Trigger asChild={asChild}>{children}</RadixPopover.Trigger>
+);
+
+Trigger.propTypes = {
+  asChild: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+};
+
+Trigger.defaultProps = {
+  asChild: true,
+};

--- a/packages/strapi-design-system/src/Popover/Popover.stories.mdx
+++ b/packages/strapi-design-system/src/Popover/Popover.stories.mdx
@@ -3,7 +3,7 @@
 import { useRef, useState } from 'react';
 import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
-import { Popover } from './Popover';
+import * as Popover from './Popover';
 import { Box } from '../Box';
 import { Typography } from '../Typography';
 
@@ -28,27 +28,25 @@ The popover can be centered relatively to their triggering element.
 <Canvas>
   <Story name="centered">
     {() => {
-      const [visible, setVisible] = useState(false);
-      const buttonRef = useRef();
       return (
-        <div style={{ marginLeft: '200px' }}>
-          <button ref={buttonRef} onClick={() => setVisible((s) => !s)}>
-            <Typography>Open popover</Typography>
-          </button>
-          {visible && (
-            <Popover centered source={buttonRef} spacing={16}>
+        <Popover.Root>
+          <div style={{ marginLeft: '200px' }}>
+            <Popover.Trigger asChild={false}>
+              <Typography>Open popover</Typography>
+            </Popover.Trigger>
+            <Popover.Content>
               <ul style={{ width: '200px' }}>
                 {Array(15)
                   .fill(null)
                   .map((_, index) => (
                     <Box color="neutral800" key={index} padding={3} as="li">
-                      Element {index}
+                      Elements {index}
                     </Box>
                   ))}
               </ul>
-            </Popover>
-          )}
-        </div>
+            </Popover.Content>
+          </div>
+        </Popover.Root>
       );
     }}
   </Story>
@@ -57,29 +55,27 @@ The popover can be centered relatively to their triggering element.
 ## Open by default
 
 <Canvas>
-  <Story name="base">
+  <Story name="default opened">
     {() => {
-      const [visible, setVisible] = useState(false);
-      const buttonRef = useRef();
       return (
-        <Box padding={10}>
-          <button ref={buttonRef} onClick={() => setVisible((s) => !s)}>
-            <Typography>Open popover</Typography>
-          </button>
-          {visible && (
-            <Popover source={buttonRef} spacing={16}>
+        <Popover.Root defaultOpen>
+          <div style={{ marginLeft: '200px' }}>
+            <Popover.Trigger asChild={false}>
+              <Typography>Open popover</Typography>
+            </Popover.Trigger>
+            <Popover.Content>
               <ul style={{ width: '200px' }}>
                 {Array(15)
                   .fill(null)
                   .map((_, index) => (
                     <Box color="neutral800" key={index} padding={3} as="li">
-                      Element {index}
+                      Elements {index}
                     </Box>
                   ))}
               </ul>
-            </Popover>
-          )}
-        </Box>
+            </Popover.Content>
+          </div>
+        </Popover.Root>
       );
     }}
   </Story>
@@ -92,22 +88,14 @@ You can define an action to be performed when the end of the popover is reached.
 <Canvas>
   <Story name="onReachEnd">
     {() => {
-      const [visible, setVisible] = useState(false);
       const [items, setItems] = useState(Array(10).fill(null));
-      const buttonRef = useRef();
       return (
-        <Box padding={10}>
-          <button id="popover1" ref={buttonRef} onClick={() => setVisible((s) => !s)}>
-            <Typography>Open popover</Typography>
-          </button>
-          {visible && (
-            <Popover
-              source={buttonRef}
-              spacing={16}
-              id="on-reach-end"
-              intersectionId="test-123"
-              onReachEnd={() => setItems(Array(15).fill(null))}
-            >
+        <Popover.Root>
+          <Box padding={10}>
+            <Popover.Trigger asChild={false}>
+              <Typography>Open popover</Typography>
+            </Popover.Trigger>
+            <Popover.Content spacing={16} intersectionId="test-123" onReachEnd={() => setItems(Array(15).fill(null))}>
               <ul style={{ width: '200px' }} id="list" tabIndex={-1}>
                 {items.map((_, index) => (
                   <Box color="neutral800" key={index} padding={3} as="li" id={`item-${index}`}>
@@ -115,9 +103,9 @@ You can define an action to be performed when the end of the popover is reached.
                   </Box>
                 ))}
               </ul>
-            </Popover>
-          )}
-        </Box>
+            </Popover.Content>
+          </Box>
+        </Popover.Root>
       );
     }}
   </Story>
@@ -130,29 +118,27 @@ The popover will overflow over other elements.
 <Canvas>
   <Story name="overflow-right">
     {() => {
-      const [visible, setVisible] = useState(false);
-      const buttonRef = useRef();
       return (
         <div style={{ height: '20vh' }}>
           <div style={{ position: 'absolute', bottom: 40, right: 20 }}>
-            <div>
-              <button ref={buttonRef} onClick={() => setVisible((s) => !s)}>
-                <Typography>Open popover</Typography>
-              </button>
-              {visible && (
-                <Popover centered source={buttonRef} spacing={16}>
+            <Popover.Root>
+              <div style={{ marginLeft: '200px' }}>
+                <Popover.Trigger asChild={false}>
+                  <Typography>Open popover</Typography>
+                </Popover.Trigger>
+                <Popover.Content>
                   <ul style={{ width: '200px' }}>
                     {Array(15)
                       .fill(null)
                       .map((_, index) => (
                         <Box color="neutral800" key={index} padding={3} as="li">
-                          Element {index}
+                          Elements {index}
                         </Box>
                       ))}
                   </ul>
-                </Popover>
-              )}
-            </div>
+                </Popover.Content>
+              </div>
+            </Popover.Root>
           </div>
         </div>
       );

--- a/packages/strapi-design-system/src/Popover/__tests__/Popover.spec.js
+++ b/packages/strapi-design-system/src/Popover/__tests__/Popover.spec.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
-import { Popover, position } from '../Popover';
+import * as Popover from '../Popover';
 import { ThemeProvider } from '../../ThemeProvider';
 import { lightTheme } from '../../themes';
 
@@ -18,46 +18,8 @@ describe('Popover', () => {
     window.pageYOffset = pageYOffset;
   });
 
-  describe('position', () => {
-    it('position the tooltip correctly', () => {
-      window.pageXOffset = 10;
-      window.pageYOffset = 10;
-      const source = { getBoundingClientRect: () => ({ left: 10, top: 10, width: 100, height: 20 }) };
-
-      expect(position(source)).toEqual({ left: 20, top: 40, width: undefined });
-    });
-
-    it('position the tooltip correctly when offscreen', () => {
-      window.pageXOffset = 10;
-      window.pageYOffset = 10;
-      window.innerWidth = 1300;
-
-      const source = { getBoundingClientRect: () => ({ left: 1200, top: 10, width: 100, height: 20 }) };
-      const popover = {
-        offsetWidth: 100,
-        clientWidth: 85,
-        getBoundingClientRect: () => ({ left: 1200, top: 10, width: 100, height: 20 }),
-      };
-
-      expect(position(source, popover)).toEqual({ left: 1210, top: 40, width: undefined });
-    });
-
-    it('position the tooltip centered to source element if centered props', () => {
-      const source = { getBoundingClientRect: () => ({ left: 500, top: 10, width: 200, height: 20 }) };
-      const centered = true;
-      const popover = {
-        offsetWidth: 100,
-        clientWidth: 85,
-        getBoundingClientRect: () => ({ width: 100 }),
-      };
-      const fullWidth = null;
-
-      expect(position(source, popover, fullWidth, centered)).toEqual({ left: 545, top: 30, width: undefined });
-    });
-  });
-
   describe('rendering', () => {
-    it('snapshots the component', async () => {
+    it.skip('snapshots the component', async () => {
       const Component = () => {
         const divRef = React.useRef(null);
         const [visible, setVisible] = React.useState(true);

--- a/packages/strapi-design-system/src/helpers/useIntersection.js
+++ b/packages/strapi-design-system/src/helpers/useIntersection.js
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 
 export const useIntersection = (scrollableAreaRef, callback, { selectorToWatch, skipWhen = false }) => {
   useEffect(() => {
-    if (skipWhen) return;
+    if (skipWhen || !scrollableAreaRef.current) return;
 
     const options = {
       root: scrollableAreaRef.current,
@@ -11,7 +11,7 @@ export const useIntersection = (scrollableAreaRef, callback, { selectorToWatch, 
 
     const onEnterZone = (entries) => {
       entries.forEach((entry) => {
-        if (entry.isIntersecting) {
+        if (entry.isIntersecting && scrollableAreaRef.current) {
           if (scrollableAreaRef.current.scrollHeight > scrollableAreaRef.current.clientHeight) {
             callback(entry);
           }

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -31317,6 +31317,72 @@ exports[`Storyshots Design System/Components/Popover centered 1`] = `
 </div>
 `;
 
+exports[`Storyshots Design System/Components/Popover default opened 1`] = `
+.c1 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c0 {
+  background: #ffffff;
+  padding: 8px;
+}
+
+.c2 {
+  padding: 8px;
+  height: 100%;
+}
+
+.c3 {
+  color: #32324d;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
+<div
+  class="c0"
+>
+  <main>
+    <div
+      class="c1"
+    >
+      <h1>
+        Storybook story
+      </h1>
+    </div>
+    <div
+      class="c2"
+      height="100%"
+    >
+      <div
+        style="margin-left: 200px;"
+      >
+        <button
+          aria-controls="radix-1"
+          aria-expanded="true"
+          aria-haspopup="dialog"
+          data-state="open"
+          type="button"
+        >
+          <span
+            class="c3"
+          >
+            Open popover
+          </span>
+        </button>
+      </div>
+    </div>
+  </main>
+</div>
+`;
+
 exports[`Storyshots Design System/Components/Popover onReachEnd 1`] = `
 .c1 {
   border: 0;

--- a/packages/strapi-design-system/yarn.lock
+++ b/packages/strapi-design-system/yarn.lock
@@ -1404,6 +1404,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.13.10":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
+  integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.12.7", "@babel/template@^7.16.0", "@babel/template@^7.3.3":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.0.tgz#d16a35ebf4cd74e202083356fab21dd89363ddd6"
@@ -1624,6 +1631,26 @@
   integrity sha512-oi0JL8uIXgJ+PWRl4LDxJ7WWa80E3jdYmi6wsHAFDq1vT0rKuyhqimEJzCezIrHHz4fXKpNRO98TO7ccma6hjw==
   dependencies:
     "@figspec/components" "^0.1.1"
+
+"@floating-ui/core@^0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-0.7.3.tgz#d274116678ffae87f6b60e90f88cc4083eefab86"
+  integrity sha512-buc8BXHmG9l82+OQXOFU3Kr2XQx9ys01U/Q9HMIrZ300iLc8HLMgh7dcCqgYzAzf4BkoQvDcXf5Y+CuEZ5JBYg==
+
+"@floating-ui/dom@^0.5.3":
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-0.5.4.tgz#4eae73f78bcd4bd553ae2ade30e6f1f9c73fe3f1"
+  integrity sha512-419BMceRLq0RrmTSDxn8hf9R3VCJv2K9PUfugh5JyEFmdjzDo+e8U5EdR8nzKq8Yj1htzLm3b6eQEEam3/rrtg==
+  dependencies:
+    "@floating-ui/core" "^0.7.3"
+
+"@floating-ui/react-dom@0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-0.7.2.tgz#0bf4ceccb777a140fc535c87eb5d6241c8e89864"
+  integrity sha512-1T0sJcpHgX/u4I1OzIEhlcrvkUN8ln39nz7fMoE/2HDHrPiMFoOGR7++GYyfUmIQHkkrTinaeQsO3XWubjSvGg==
+  dependencies:
+    "@floating-ui/dom" "^0.5.3"
+    use-isomorphic-layout-effect "^1.1.1"
 
 "@gar/promisify@^1.0.1":
   version "1.1.2"
@@ -2018,6 +2045,196 @@
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.0.tgz#6734f8ebc106a0860dff7f92bf90df193f0935d7"
   integrity sha512-zrsUxjLOKAzdewIDRWy9nsV1GQsKBCWaGwsZQlCgr6/q+vjyZhFgqedLfFBuI9anTPEUT4APq9Mu0SZBTzIcGQ==
+
+"@radix-ui/primitive@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.0.0.tgz#e1d8ef30b10ea10e69c76e896f608d9276352253"
+  integrity sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-arrow@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-1.0.0.tgz#c461f4c2cab3317e3d42a1ae62910a4cbb0192a1"
+  integrity sha512-1MUuv24HCdepi41+qfv125EwMuxgQ+U+h0A9K3BjCO/J8nVRREKHHpkD9clwfnjEDk9hgGzCnff4aUKCPiRepw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.0"
+
+"@radix-ui/react-compose-refs@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz#37595b1f16ec7f228d698590e78eeed18ff218ae"
+  integrity sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-context@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.0.0.tgz#f38e30c5859a9fb5e9aa9a9da452ee3ed9e0aee0"
+  integrity sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-dismissable-layer@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.0.tgz#35b7826fa262fd84370faef310e627161dffa76b"
+  integrity sha512-n7kDRfx+LB1zLueRDvZ1Pd0bxdJWDUZNQ/GWoxDn2prnuJKRdxsjulejX/ePkOsLi2tTm6P24mDqlMSgQpsT6g==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.0"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.0"
+    "@radix-ui/react-use-callback-ref" "1.0.0"
+    "@radix-ui/react-use-escape-keydown" "1.0.0"
+
+"@radix-ui/react-focus-guards@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.0.tgz#339c1c69c41628c1a5e655f15f7020bf11aa01fa"
+  integrity sha512-UagjDk4ijOAnGu4WMUPj9ahi7/zJJqNZ9ZAiGPp7waUWJO0O1aWXi/udPphI0IUjvrhBsZJGSN66dR2dsueLWQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-focus-scope@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.0.tgz#95a0c1188276dc8933b1eac5f1cdb6471e01ade5"
+  integrity sha512-C4SWtsULLGf/2L4oGeIHlvWQx7Rf+7cX/vKOAD2dXW0A1b5QXwi3wWeaEgW+wn+SEVrraMUk05vLU9fZZz5HbQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.0"
+    "@radix-ui/react-use-callback-ref" "1.0.0"
+
+"@radix-ui/react-id@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-1.0.0.tgz#8d43224910741870a45a8c9d092f25887bb6d11e"
+  integrity sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-layout-effect" "1.0.0"
+
+"@radix-ui/react-popover@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popover/-/react-popover-1.0.0.tgz#5ee72013089fdf9038417fc1eb98a749c17457fd"
+  integrity sha512-osxFFO0TiZ9ABpEOitZu0R1Fdd+tSpJgAqLZxRLLdZQ7ya0onSODcITp5hXDVuYQeVXH6pKEBGwXN6ZGjZ0a5g==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.0"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-context" "1.0.0"
+    "@radix-ui/react-dismissable-layer" "1.0.0"
+    "@radix-ui/react-focus-guards" "1.0.0"
+    "@radix-ui/react-focus-scope" "1.0.0"
+    "@radix-ui/react-id" "1.0.0"
+    "@radix-ui/react-popper" "1.0.0"
+    "@radix-ui/react-portal" "1.0.0"
+    "@radix-ui/react-presence" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.0"
+    "@radix-ui/react-slot" "1.0.0"
+    "@radix-ui/react-use-controllable-state" "1.0.0"
+    aria-hidden "^1.1.1"
+    react-remove-scroll "2.5.4"
+
+"@radix-ui/react-popper@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popper/-/react-popper-1.0.0.tgz#fb4f937864bf39c48f27f55beee61fa9f2bef93c"
+  integrity sha512-k2dDd+1Wl0XWAMs9ZvAxxYsB9sOsEhrFQV4CINd7IUZf0wfdye4OHen9siwxvZImbzhgVeKTJi68OQmPRvVdMg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@floating-ui/react-dom" "0.7.2"
+    "@radix-ui/react-arrow" "1.0.0"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-context" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.0"
+    "@radix-ui/react-use-layout-effect" "1.0.0"
+    "@radix-ui/react-use-rect" "1.0.0"
+    "@radix-ui/react-use-size" "1.0.0"
+    "@radix-ui/rect" "1.0.0"
+
+"@radix-ui/react-portal@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.0.0.tgz#7220b66743394fabb50c55cb32381395cc4a276b"
+  integrity sha512-a8qyFO/Xb99d8wQdu4o7qnigNjTPG123uADNecz0eX4usnQEj7o+cG4ZX4zkqq98NYekT7UoEQIjxBNWIFuqTA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.0"
+
+"@radix-ui/react-presence@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.0.0.tgz#814fe46df11f9a468808a6010e3f3ca7e0b2e84a"
+  integrity sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-use-layout-effect" "1.0.0"
+
+"@radix-ui/react-primitive@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-1.0.0.tgz#376cd72b0fcd5e0e04d252ed33eb1b1f025af2b0"
+  integrity sha512-EyXe6mnRlHZ8b6f4ilTDrXmkLShICIuOTTj0GX4w1rp+wSxf3+TD05u1UOITC8VsJ2a9nwHvdXtOXEOl0Cw/zQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-slot" "1.0.0"
+
+"@radix-ui/react-slot@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.0.0.tgz#7fa805b99891dea1e862d8f8fbe07f4d6d0fd698"
+  integrity sha512-3mrKauI/tWXo1Ll+gN5dHcxDPdm/Df1ufcDLCecn+pnCIVcdWE7CujXo8QaXOWRJyZyQWWbpB8eFwHzWXlv5mQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.0"
+
+"@radix-ui/react-use-callback-ref@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz#9e7b8b6b4946fe3cbe8f748c82a2cce54e7b6a90"
+  integrity sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-use-controllable-state@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.0.tgz#a64deaafbbc52d5d407afaa22d493d687c538b7f"
+  integrity sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-callback-ref" "1.0.0"
+
+"@radix-ui/react-use-escape-keydown@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.0.tgz#aef375db4736b9de38a5a679f6f49b45a060e5d1"
+  integrity sha512-JwfBCUIfhXRxKExgIqGa4CQsiMemo1Xt0W/B4ei3fpzpvPENKpMKQ8mZSB6Acj3ebrAEgi2xiQvcI1PAAodvyg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-callback-ref" "1.0.0"
+
+"@radix-ui/react-use-layout-effect@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz#2fc19e97223a81de64cd3ba1dc42ceffd82374dc"
+  integrity sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-use-rect@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-rect/-/react-use-rect-1.0.0.tgz#b040cc88a4906b78696cd3a32b075ed5b1423b3e"
+  integrity sha512-TB7pID8NRMEHxb/qQJpvSt3hQU4sqNPM1VCTjTRjEOa7cEop/QMuq8S6fb/5Tsz64kqSvB9WnwsDHtjnrM9qew==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/rect" "1.0.0"
+
+"@radix-ui/react-use-size@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-size/-/react-use-size-1.0.0.tgz#a0b455ac826749419f6354dc733e2ca465054771"
+  integrity sha512-imZ3aYcoYCKhhgNpkNDh/aTiU05qw9hX+HHI1QDBTyIlcFjgeFlKKySNGMwTp7nYFLQg/j0VA2FmCY4WPDDHMg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-layout-effect" "1.0.0"
+
+"@radix-ui/rect@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/rect/-/rect-1.0.0.tgz#0dc8e6a829ea2828d53cbc94b81793ba6383bf3c"
+  integrity sha512-d0O68AYy/9oeEy1DdC07bz1/ZXX+DqCskRd3i4JzLSTXwefzaepQrKjXC7aNM8lTHjFLDO0pDgaEiQ7jEk+HVg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
@@ -3667,6 +3884,13 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+aria-hidden@^1.1.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.2.1.tgz#ad8c1edbde360b454eb2bf717ea02da00bfee0f8"
+  integrity sha512-PN344VAf9j1EAi+jyVHOJ8XidQdPVssGco39eNcsGdM4wcsILtxrKLkbuiMfLWYROK1FjRQasMWCBttrhjnr6A==
+  dependencies:
+    tslib "^2.0.0"
+
 aria-query@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
@@ -5282,6 +5506,11 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
+detect-node-es@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.1.0.tgz#163acdf643330caa0b4cd7c21e7ee7755d6fa493"
+  integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
+
 detect-port-alt@1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/detect-port-alt/-/detect-port-alt-1.1.6.tgz#24707deabe932d4a3cf621302027c2b266568275"
@@ -6483,6 +6712,11 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
     function-bind "^1.1.1"
     has "^1.0.3"
     has-symbols "^1.0.1"
+
+get-nonce@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-nonce/-/get-nonce-1.0.1.tgz#fdf3f0278073820d2ce9426c18f07481b1e0cdf3"
+  integrity sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==
 
 get-package-type@^0.1.0:
   version "0.1.0"
@@ -10227,6 +10461,25 @@ react-refresh@^0.10.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.10.0.tgz#2f536c9660c0b9b1d500684d9e52a65e7404f7e3"
   integrity sha512-PgidR3wST3dDYKr6b4pJoqQFpPGNKDSCDx4cZoshjXipw3LzO7mG1My2pwEzz2JVkF+inx3xRpDeQLFQGH/hsQ==
 
+react-remove-scroll-bar@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.3.tgz#e291f71b1bb30f5f67f023765b7435f4b2b2cd94"
+  integrity sha512-i9GMNWwpz8XpUpQ6QlevUtFjHGqnPG4Hxs+wlIJntu/xcsZVEpJcIV71K3ZkqNy2q3GfgvkD7y6t/Sv8ofYSbw==
+  dependencies:
+    react-style-singleton "^2.2.1"
+    tslib "^2.0.0"
+
+react-remove-scroll@2.5.4:
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.5.4.tgz#afe6491acabde26f628f844b67647645488d2ea0"
+  integrity sha512-xGVKJJr0SJGQVirVFAUZ2k1QLyO6m+2fy0l8Qawbp5Jgrv3DeLalrfMNBFSlmz5kriGGzsVBtGVnf4pTKIhhWA==
+  dependencies:
+    react-remove-scroll-bar "^2.3.3"
+    react-style-singleton "^2.2.1"
+    tslib "^2.1.0"
+    use-callback-ref "^1.3.0"
+    use-sidecar "^1.1.2"
+
 react-router-dom@^5.2.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.3.0.tgz#da1bfb535a0e89a712a93b97dd76f47ad1f32363"
@@ -10288,6 +10541,15 @@ react-sizeme@^3.0.1:
     invariant "^2.2.4"
     shallowequal "^1.1.0"
     throttle-debounce "^3.0.1"
+
+react-style-singleton@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.2.1.tgz#f99e420492b2d8f34d38308ff660b60d0b1205b4"
+  integrity sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==
+  dependencies:
+    get-nonce "^1.0.0"
+    invariant "^2.2.4"
+    tslib "^2.0.0"
 
 react-syntax-highlighter@^13.5.3:
   version "13.5.3"
@@ -11757,7 +12019,7 @@ tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.3.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
-tslib@^2.3.1:
+tslib@^2.1.0, tslib@^2.3.1:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
@@ -12040,6 +12302,13 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
+use-callback-ref@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.3.0.tgz#772199899b9c9a50526fedc4993fc7fa1f7e32d5"
+  integrity sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==
+  dependencies:
+    tslib "^2.0.0"
+
 use-composed-ref@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/use-composed-ref/-/use-composed-ref-1.1.0.tgz#9220e4e94a97b7b02d7d27eaeab0b37034438bbc"
@@ -12052,12 +12321,25 @@ use-isomorphic-layout-effect@^1.0.0:
   resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz#7bb6589170cd2987a152042f9084f9effb75c225"
   integrity sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==
 
+use-isomorphic-layout-effect@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz#497cefb13d863d687b08477d9e5a164ad8c1a6fb"
+  integrity sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==
+
 use-latest@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/use-latest/-/use-latest-1.2.0.tgz#a44f6572b8288e0972ec411bdd0840ada366f232"
   integrity sha512-d2TEuG6nSLKQLAfW3By8mKr8HurOlTkul0sOpxbClIv4SQ4iOd7BYr7VIzdbktUCnv7dua/60xzd8igMU6jmyw==
   dependencies:
     use-isomorphic-layout-effect "^1.0.0"
+
+use-sidecar@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.1.2.tgz#2f43126ba2d7d7e117aa5855e5d8f0276dfe73c2"
+  integrity sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==
+  dependencies:
+    detect-node-es "^1.1.0"
+    tslib "^2.0.0"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

This is a POC for the upcoming DS sync, it shows the potential of replacing difficult components (such as Popover / Accordion / Dropdowns) with `radix-ui` components as a base.

### Why is it needed?

Radix-UI is a un-styled design system full of UI primitives enabling user to create accessible interfaces without the technical knowledge (full accessibility is hard and not every dev has the same level of knowledge on the subject). It would mean we could focus on design implementation and adding variations based on the needs of the product.

I haven't resolved any of the tests, nor added the actual `PropTypes` that the radix components expose, hence why this is *definitely* a draft PR.

### Related issue(s)/PR(s)

This came about as a response from #674 where we were using a `ResizeObserver` as the handler for it's floating placement in conjunction with a custom `position` function.

### Other thoughts

* I find it odd that the popover is trapped in a fixed height space, what happens if we want to use a non-list ui in the component? There might be some issues? It feels like the list version warrants being it's own variation of a base `Popover` styled in the Strapi themes?
* This might be part of a larger effort to expand & simplify our design system in a largely framework agnostic way (v2)
