### PR TITLE
NumberInput: Fix value assignment during focus

### DIFF
--- a/packages/strapi-design-system/src/NumberInput/NumberInput.js
+++ b/packages/strapi-design-system/src/NumberInput/NumberInput.js
@@ -50,7 +50,7 @@ export const NumberInput = React.forwardRef(
     const [inputValue, setInputValue] = useState(value === undefined || value === null ? INITIAL_VALUE : String(value));
     const generatedId = useId('numberinput', id);
     const numberParserRef = useRef(new NumberParser(getDefaultLocale()));
-    const numberFormaterRef = useRef(new NumberFormatter(getDefaultLocale(), { maximumSignificantDigits: 21 }));
+    const numberFormaterRef = useRef(new NumberFormatter(getDefaultLocale(), { maximumFractionDigits: 20 }));
 
     const handleChange = (e) => {
       const nextValue = e.target.value;
@@ -143,9 +143,7 @@ export const NumberInput = React.forwardRef(
     };
 
     const handleFocus = () => {
-      if (value !== undefined) {
-        setInputValue(String(numberParserRef.current.format(inputValue) ?? INITIAL_VALUE));
-      }
+      setInputValue(inputValue ?? INITIAL_VALUE);
     };
 
     const handleBlur = () => {


### PR DESCRIPTION
### What does it do?

It fixes the `NumberInput` field:

- `maximumSignificantDigits` -> `maximumFractionDigits`: The maximum number of fraction digits to use: this is what I wanted in the first place, to fix scientific numbers.
- `numberParserRef` does not have a `.format()` method. I broke that in https://github.com/strapi/design-system/pull/683 and have no idea why the tests worked.

### Why is it needed?

Fixes https://github.com/strapi/design-system/issues/693

