### PR TITLE
[Fix] Document button color tokens to sroy

### DIFF
--- a/packages/strapi-design-system/src/themes/Theme.stories.mdx
+++ b/packages/strapi-design-system/src/themes/Theme.stories.mdx
@@ -31,7 +31,7 @@ This is the light colors used for the light mode
     {() => {
       const { color } = lightColorTokenObject;
       /* Excluding warning since they don't have enough contrast on for neutral900 and neutral0 */
-      const colorsKey = Object.keys(color).filter((color) => !color.includes('warning') && !color.includes('button'));
+      const colorsKey = Object.keys(color).filter((color) => !color.includes('warning'));
       const colors = [];
       const conditions = ['600', '700', '800', '900', '1000'];
       let ruptureKey;

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -46371,6 +46371,46 @@ exports[`Storyshots Design System/Components/Theme light colors 1`] = `
                 spacing="2"
               >
                 <div
+                  style="padding: 12px; background: rgb(255, 255, 255);"
+                >
+                  <p
+                    style="color: black;"
+                  >
+                    buttonNeutral0
+                  </p>
+                </div>
+                <div
+                  style="padding: 12px; background: rgb(123, 121, 255);"
+                >
+                  <p
+                    style="color: black;"
+                  >
+                    buttonPrimary500
+                  </p>
+                </div>
+                <div
+                  style="padding: 12px; background: rgb(73, 69, 255);"
+                >
+                  <p
+                    style="color: white;"
+                  >
+                    buttonPrimary600
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="c4"
+          >
+            <div
+              class="c5"
+            >
+              <div
+                class="c6 c7"
+                spacing="2"
+              >
+                <div
                   style="padding: 12px; background: rgb(252, 236, 234);"
                 >
                   <p


### PR DESCRIPTION
## What

`buttonNeutral0`, `buttonPrimary500` and `buttonPrimary600` were excluded from the documentation which makes it hard to customize theme in Strapi 

## Snapshot 

<img width="1126" alt="image" src="https://user-images.githubusercontent.com/71838159/191263591-75c23cbb-2615-4eb4-836e-9bc00d20ce7e.png">
