### PR TITLE
fix: link active & hover not affecting Typography

### DIFF
--- a/packages/strapi-design-system/src/Link/Link.js
+++ b/packages/strapi-design-system/src/Link/Link.js
@@ -12,18 +12,34 @@ const LinkWrapper = styled.a`
   align-items: center;
   text-decoration: none;
   pointer-events: ${({ disabled }) => (disabled ? 'none' : undefined)};
+
+  ${Typography} {
+    transition: color 150ms ease-out;
+  }
+
   svg path {
     fill: ${({ disabled, theme }) => (disabled ? theme.colors.neutral600 : theme.colors.primary600)};
   }
+
   svg {
     font-size: ${10 / 16}rem;
   }
-  &:hover,
-  &:active {
-    color: ${({ theme }) => theme.colors.primary800};
+
+  &:hover {
+    ${Typography} {
+      color: ${({ theme }) => theme.colors.primary500};
+    }
   }
+
+  &:active {
+    ${Typography} {
+      color: ${({ theme }) => theme.colors.primary700};
+    }
+  }
+
   ${buttonFocusStyle};
 `;
+
 const IconWrapper = styled(Box)`
   display: flex;
 `;

--- a/packages/strapi-design-system/src/Link/Link.js
+++ b/packages/strapi-design-system/src/Link/Link.js
@@ -12,29 +12,28 @@ const LinkWrapper = styled.a`
   align-items: center;
   text-decoration: none;
   pointer-events: ${({ disabled }) => (disabled ? 'none' : undefined)};
-
-  ${Typography} {
-    transition: color 150ms ease-out;
-  }
+  color: ${({ disabled, theme }) => (disabled ? theme.colors.neutral600 : theme.colors.primary600)};
 
   svg path {
-    fill: ${({ disabled, theme }) => (disabled ? theme.colors.neutral600 : theme.colors.primary600)};
+    transition: fill 150ms ease-out;
+    fill: currentColor;
   }
 
   svg {
     font-size: ${10 / 16}rem;
   }
 
+  ${Typography} {
+    transition: color 150ms ease-out;
+    color: currentColor;
+  }
+
   &:hover {
-    ${Typography} {
-      color: ${({ theme }) => theme.colors.primary500};
-    }
+    color: ${({ theme }) => theme.colors.primary500};
   }
 
   &:active {
-    ${Typography} {
-      color: ${({ theme }) => theme.colors.primary700};
-    }
+    color: ${({ theme }) => theme.colors.primary700};
   }
 
   ${buttonFocusStyle};
@@ -63,7 +62,7 @@ export const Link = ({ href, to, children, disabled, startIcon, endIcon, ...prop
           {startIcon}
         </IconWrapper>
       )}
-      <Typography textColor={disabled ? 'neutral600' : 'primary600'}>{children}</Typography>
+      <Typography>{children}</Typography>
 
       {endIcon && !href && (
         <IconWrapper as="span" aria-hidden={true} paddingLeft={2}>

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -3522,30 +3522,24 @@ exports[`Storyshots Design System/Components/Alert with action 1`] = `
   padding-bottom: 8px;
 }
 
-.c11 {
+.c12 {
   padding-right: 8px;
   padding-bottom: 8px;
 }
 
-.c13 {
+.c14 {
   padding-bottom: 20px;
 }
 
-.c10 {
+.c11 {
   font-weight: 600;
   color: #32324d;
   font-size: 0.875rem;
   line-height: 1.43;
 }
 
-.c12 {
+.c13 {
   color: #32324d;
-  font-size: 0.875rem;
-  line-height: 1.43;
-}
-
-.c16 {
-  color: #4945ff;
   font-size: 0.875rem;
   line-height: 1.43;
 }
@@ -3637,19 +3631,19 @@ exports[`Storyshots Design System/Components/Alert with action 1`] = `
   fill: #271fe0;
 }
 
-.c14 {
+.c15 {
   padding-top: 1px;
 }
 
-.c14 a > span {
+.c15 a > span {
   color: #271fe0;
 }
 
-.c14 a > span svg path {
+.c15 a > span svg path {
   fill: #271fe0;
 }
 
-.c15 {
+.c16 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -3660,19 +3654,36 @@ exports[`Storyshots Design System/Components/Alert with action 1`] = `
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
+  color: #4945ff;
   position: relative;
   outline: none;
 }
 
-.c15 svg path {
-  fill: #4945ff;
+.c16 svg path {
+  -webkit-transition: fill 150ms ease-out;
+  transition: fill 150ms ease-out;
+  fill: currentColor;
 }
 
-.c15 svg {
+.c16 svg {
   font-size: 0.625rem;
 }
 
-.c15:after {
+.c16 .c10 {
+  -webkit-transition: color 150ms ease-out;
+  transition: color 150ms ease-out;
+  color: currentColor;
+}
+
+.c16:hover {
+  color: #7b79ff;
+}
+
+.c16:active {
+  color: #271fe0;
+}
+
+.c16:after {
   -webkit-transition-property: all;
   transition-property: all;
   -webkit-transition-duration: 0.2s;
@@ -3687,11 +3698,11 @@ exports[`Storyshots Design System/Components/Alert with action 1`] = `
   border: 2px solid transparent;
 }
 
-.c15:focus-visible {
+.c16:focus-visible {
   outline: none;
 }
 
-.c15:focus-visible:after {
+.c16:focus-visible:after {
   border-radius: 8px;
   content: '';
   position: absolute;
@@ -3752,29 +3763,29 @@ exports[`Storyshots Design System/Components/Alert with action 1`] = `
                 class="c9"
               >
                 <p
-                  class="c10"
+                  class="c10 c11"
                 >
                   This is the title of the alert
                 </p>
               </div>
               <div
-                class="c11"
+                class="c12"
               >
                 <p
-                  class="c12"
+                  class="c10 c13"
                 >
                   Alert with title and longer description, lorem ipsum dolor sit amet constrectum adipisicng lorem ipsum dolor sit amet consrectumis adipisingus.
                 </p>
               </div>
               <div
-                class="c13 c14"
+                class="c14 c15"
               >
                 <a
-                  class="c15"
+                  class="c16"
                   href="/somewhere"
                 >
                   <span
-                    class="c16"
+                    class="c10 c13"
                   >
                     See more
                   </span>
@@ -15433,42 +15444,42 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
   padding: 40px;
 }
 
-.c8 {
+.c9 {
   padding-left: 8px;
 }
 
-.c9 {
+.c10 {
   color: #32324d;
 }
 
-.c11 {
+.c12 {
   width: 100%;
 }
 
-.c18 {
+.c19 {
   padding-right: 8px;
   padding-left: 12px;
 }
 
-.c21 {
+.c22 {
   padding-right: 12px;
   padding-left: 8px;
 }
 
-.c7 {
+.c8 {
   font-weight: 600;
   color: #32324d;
   font-size: 0.75rem;
   line-height: 1.33;
 }
 
-.c14 {
-  color: #4945ff;
+.c15 {
+  color: #32324d;
   font-size: 0.875rem;
   line-height: 1.43;
 }
 
-.c22 {
+.c23 {
   color: #666687;
   font-size: 0.75rem;
   line-height: 1.33;
@@ -15502,7 +15513,7 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
   flex-direction: row;
 }
 
-.c12 {
+.c13 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -15520,7 +15531,7 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
   justify-content: flex-end;
 }
 
-.c16 {
+.c17 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -15547,11 +15558,11 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
   margin-top: 4px;
 }
 
-.c10 path {
+.c11 path {
   fill: #32324d;
 }
 
-.c20 {
+.c21 {
   border: none;
   border-radius: 4px;
   padding-bottom: 0.65625rem;
@@ -15566,36 +15577,36 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
   background: inherit;
 }
 
-.c20::-webkit-input-placeholder {
+.c21::-webkit-input-placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c20::-moz-placeholder {
+.c21::-moz-placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c20:-ms-input-placeholder {
+.c21:-ms-input-placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c20::placeholder {
+.c21::placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c20[aria-disabled='true'] {
+.c21[aria-disabled='true'] {
   color: inherit;
 }
 
-.c20:focus {
+.c21:focus {
   outline: none;
   box-shadow: none;
 }
 
-.c17 {
+.c18 {
   border: 1px solid #dcdce4;
   border-radius: 4px;
   background: #ffffff;
@@ -15607,12 +15618,12 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
   transition-duration: 0.2s;
 }
 
-.c17:focus-within {
+.c18:focus-within {
   border: 1px solid #4945ff;
   box-shadow: #4945ff 0px 0px 0px 2px;
 }
 
-.c19 {
+.c20 {
   border: none;
   background: transparent;
   font-size: 1.6rem;
@@ -15628,7 +15639,7 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
   align-items: center;
 }
 
-.c13 {
+.c14 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -15639,19 +15650,36 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
+  color: #4945ff;
   position: relative;
   outline: none;
 }
 
-.c13 svg path {
-  fill: #4945ff;
+.c14 svg path {
+  -webkit-transition: fill 150ms ease-out;
+  transition: fill 150ms ease-out;
+  fill: currentColor;
 }
 
-.c13 svg {
+.c14 svg {
   font-size: 0.625rem;
 }
 
-.c13:after {
+.c14 .c7 {
+  -webkit-transition: color 150ms ease-out;
+  transition: color 150ms ease-out;
+  color: currentColor;
+}
+
+.c14:hover {
+  color: #7b79ff;
+}
+
+.c14:active {
+  color: #271fe0;
+}
+
+.c14:after {
   -webkit-transition-property: all;
   transition-property: all;
   -webkit-transition-duration: 0.2s;
@@ -15666,11 +15694,11 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
   border: 2px solid transparent;
 }
 
-.c13:focus-visible {
+.c14:focus-visible {
   outline: none;
 }
 
-.c13:focus-visible:after {
+.c14:focus-visible:after {
   border-radius: 8px;
   content: '';
   position: absolute;
@@ -15681,7 +15709,7 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
   border: 2px solid #4945ff;
 }
 
-.c15 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -15715,7 +15743,7 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
               class="c6"
             >
               <label
-                class="c7"
+                class="c7 c8"
                 for="field-53"
               >
                 <div
@@ -15725,7 +15753,7 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
                 </div>
               </label>
               <div
-                class="c8"
+                class="c9"
               >
                 <span>
                   <button
@@ -15736,7 +15764,7 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="c9 c10"
+                      class="c10 c11"
                       fill="none"
                       height="1em"
                       viewBox="0 0 24 24"
@@ -15752,23 +15780,23 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
                 </span>
               </div>
               <div
-                class="c11 c12"
+                class="c12 c13"
                 width="100%"
               >
                 <a
-                  class="c13"
+                  class="c14"
                   href="#"
                   rel="noreferrer noopener"
                   target="_blank"
                 >
                   <span
-                    class="c14"
+                    class="c7 c15"
                   >
                     Details
                   </span>
                   <span
                     aria-hidden="true"
-                    class="c8 c15"
+                    class="c9 c16"
                   >
                     <svg
                       fill="none"
@@ -15787,14 +15815,14 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
               </div>
             </div>
             <div
-              class="c16 c17"
+              class="c17 c18"
             >
               <div
-                class="c18"
+                class="c19"
               >
                 <button
                   aria-label="Show password"
-                  class="c19"
+                  class="c20"
                   type="button"
                 >
                   <svg
@@ -15820,18 +15848,18 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
                 aria-describedby="field-53-hint"
                 aria-disabled="false"
                 aria-invalid="false"
-                class="c20"
+                class="c21"
                 id="field-53"
                 name="password"
                 placeholder="example@domain.com"
                 value=""
               />
               <div
-                class="c21"
+                class="c22"
               >
                 <button
                   aria-label="Show password"
-                  class="c19"
+                  class="c20"
                   type="button"
                 >
                   <svg
@@ -15855,7 +15883,7 @@ exports[`Storyshots Design System/Components/Field most complex input 1`] = `
               </div>
             </div>
             <p
-              class="c22"
+              class="c7 c23"
               id="field-53-hint"
             >
               Description line
@@ -15895,42 +15923,42 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
   padding: 40px;
 }
 
-.c8 {
+.c9 {
   padding-left: 8px;
 }
 
-.c9 {
+.c10 {
   color: #32324d;
 }
 
-.c11 {
+.c12 {
   width: 100%;
 }
 
-.c18 {
+.c19 {
   padding-right: 8px;
   padding-left: 12px;
 }
 
-.c21 {
+.c22 {
   padding-right: 12px;
   padding-left: 8px;
 }
 
-.c7 {
+.c8 {
   font-weight: 600;
   color: #32324d;
   font-size: 0.75rem;
   line-height: 1.33;
 }
 
-.c14 {
-  color: #4945ff;
+.c15 {
+  color: #32324d;
   font-size: 0.875rem;
   line-height: 1.43;
 }
 
-.c22 {
+.c23 {
   color: #666687;
   font-size: 0.75rem;
   line-height: 1.33;
@@ -15964,7 +15992,7 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
   flex-direction: row;
 }
 
-.c12 {
+.c13 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -15982,7 +16010,7 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
   justify-content: flex-end;
 }
 
-.c16 {
+.c17 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -16009,11 +16037,11 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
   margin-top: 4px;
 }
 
-.c10 path {
+.c11 path {
   fill: #32324d;
 }
 
-.c20 {
+.c21 {
   border: none;
   border-radius: 4px;
   padding-bottom: 0.40625rem;
@@ -16028,36 +16056,36 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
   background: inherit;
 }
 
-.c20::-webkit-input-placeholder {
+.c21::-webkit-input-placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c20::-moz-placeholder {
+.c21::-moz-placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c20:-ms-input-placeholder {
+.c21:-ms-input-placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c20::placeholder {
+.c21::placeholder {
   color: #8e8ea9;
   opacity: 1;
 }
 
-.c20[aria-disabled='true'] {
+.c21[aria-disabled='true'] {
   color: inherit;
 }
 
-.c20:focus {
+.c21:focus {
   outline: none;
   box-shadow: none;
 }
 
-.c17 {
+.c18 {
   border: 1px solid #dcdce4;
   border-radius: 4px;
   background: #ffffff;
@@ -16069,12 +16097,12 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
   transition-duration: 0.2s;
 }
 
-.c17:focus-within {
+.c18:focus-within {
   border: 1px solid #4945ff;
   box-shadow: #4945ff 0px 0px 0px 2px;
 }
 
-.c19 {
+.c20 {
   border: none;
   background: transparent;
   font-size: 1.6rem;
@@ -16090,7 +16118,7 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
   align-items: center;
 }
 
-.c13 {
+.c14 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -16101,19 +16129,36 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
+  color: #4945ff;
   position: relative;
   outline: none;
 }
 
-.c13 svg path {
-  fill: #4945ff;
+.c14 svg path {
+  -webkit-transition: fill 150ms ease-out;
+  transition: fill 150ms ease-out;
+  fill: currentColor;
 }
 
-.c13 svg {
+.c14 svg {
   font-size: 0.625rem;
 }
 
-.c13:after {
+.c14 .c7 {
+  -webkit-transition: color 150ms ease-out;
+  transition: color 150ms ease-out;
+  color: currentColor;
+}
+
+.c14:hover {
+  color: #7b79ff;
+}
+
+.c14:active {
+  color: #271fe0;
+}
+
+.c14:after {
   -webkit-transition-property: all;
   transition-property: all;
   -webkit-transition-duration: 0.2s;
@@ -16128,11 +16173,11 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
   border: 2px solid transparent;
 }
 
-.c13:focus-visible {
+.c14:focus-visible {
   outline: none;
 }
 
-.c13:focus-visible:after {
+.c14:focus-visible:after {
   border-radius: 8px;
   content: '';
   position: absolute;
@@ -16143,7 +16188,7 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
   border: 2px solid #4945ff;
 }
 
-.c15 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -16177,7 +16222,7 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
               class="c6"
             >
               <label
-                class="c7"
+                class="c7 c8"
                 for="field-56"
               >
                 <div
@@ -16187,7 +16232,7 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
                 </div>
               </label>
               <div
-                class="c8"
+                class="c9"
               >
                 <span>
                   <button
@@ -16198,7 +16243,7 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
                   >
                     <svg
                       aria-hidden="true"
-                      class="c9 c10"
+                      class="c10 c11"
                       fill="none"
                       height="1em"
                       viewBox="0 0 24 24"
@@ -16214,23 +16259,23 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
                 </span>
               </div>
               <div
-                class="c11 c12"
+                class="c12 c13"
                 width="100%"
               >
                 <a
-                  class="c13"
+                  class="c14"
                   href="#"
                   rel="noreferrer noopener"
                   target="_blank"
                 >
                   <span
-                    class="c14"
+                    class="c7 c15"
                   >
                     Details
                   </span>
                   <span
                     aria-hidden="true"
-                    class="c8 c15"
+                    class="c9 c16"
                   >
                     <svg
                       fill="none"
@@ -16249,14 +16294,14 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
               </div>
             </div>
             <div
-              class="c16 c17"
+              class="c17 c18"
             >
               <div
-                class="c18"
+                class="c19"
               >
                 <button
                   aria-label="Show password"
-                  class="c19"
+                  class="c20"
                   type="button"
                 >
                   <svg
@@ -16282,18 +16327,18 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
                 aria-describedby="field-56-hint"
                 aria-disabled="false"
                 aria-invalid="false"
-                class="c20"
+                class="c21"
                 id="field-56"
                 name="password"
                 placeholder="example@domain.com"
                 value=""
               />
               <div
-                class="c21"
+                class="c22"
               >
                 <button
                   aria-label="Show password"
-                  class="c19"
+                  class="c20"
                   type="button"
                 >
                   <svg
@@ -16317,7 +16362,7 @@ exports[`Storyshots Design System/Components/Field most complex s size input 1`]
               </div>
             </div>
             <p
-              class="c22"
+              class="c7 c23"
               id="field-56-hint"
             >
               Description line
@@ -17247,7 +17292,7 @@ exports[`Storyshots Design System/Components/HeaderLayout base 1`] = `
 }
 
 .c11 {
-  color: #4945ff;
+  color: #32324d;
   font-size: 0.875rem;
   line-height: 1.43;
 }
@@ -17373,16 +17418,33 @@ exports[`Storyshots Design System/Components/HeaderLayout base 1`] = `
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
+  color: #4945ff;
   position: relative;
   outline: none;
 }
 
 .c7 svg path {
-  fill: #4945ff;
+  -webkit-transition: fill 150ms ease-out;
+  transition: fill 150ms ease-out;
+  fill: currentColor;
 }
 
 .c7 svg {
   font-size: 0.625rem;
+}
+
+.c7 .c10 {
+  -webkit-transition: color 150ms ease-out;
+  transition: color 150ms ease-out;
+  color: currentColor;
+}
+
+.c7:hover {
+  color: #7b79ff;
+}
+
+.c7:active {
+  color: #271fe0;
 }
 
 .c7:after {
@@ -18385,7 +18447,7 @@ exports[`Storyshots Design System/Components/HeaderLayout combined w/ scroll 1`]
 }
 
 .c11 {
-  color: #4945ff;
+  color: #32324d;
   font-size: 0.875rem;
   line-height: 1.43;
 }
@@ -18511,16 +18573,33 @@ exports[`Storyshots Design System/Components/HeaderLayout combined w/ scroll 1`]
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
+  color: #4945ff;
   position: relative;
   outline: none;
 }
 
 .c7 svg path {
-  fill: #4945ff;
+  -webkit-transition: fill 150ms ease-out;
+  transition: fill 150ms ease-out;
+  fill: currentColor;
 }
 
 .c7 svg {
   font-size: 0.625rem;
+}
+
+.c7 .c10 {
+  -webkit-transition: color 150ms ease-out;
+  transition: color 150ms ease-out;
+  color: currentColor;
+}
+
+.c7:hover {
+  color: #7b79ff;
+}
+
+.c7:active {
+  color: #271fe0;
 }
 
 .c7:after {
@@ -18902,7 +18981,7 @@ exports[`Storyshots Design System/Components/HeaderLayout sticky 1`] = `
 }
 
 .c14 {
-  color: #4945ff;
+  color: #32324d;
   font-size: 0.875rem;
   line-height: 1.43;
 }
@@ -19028,16 +19107,33 @@ exports[`Storyshots Design System/Components/HeaderLayout sticky 1`] = `
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
+  color: #4945ff;
   position: relative;
   outline: none;
 }
 
 .c10 svg path {
-  fill: #4945ff;
+  -webkit-transition: fill 150ms ease-out;
+  transition: fill 150ms ease-out;
+  fill: currentColor;
 }
 
 .c10 svg {
   font-size: 0.625rem;
+}
+
+.c10 .c13 {
+  -webkit-transition: color 150ms ease-out;
+  transition: color 150ms ease-out;
+  color: currentColor;
+}
+
+.c10:hover {
+  color: #7b79ff;
+}
+
+.c10:active {
+  color: #271fe0;
 }
 
 .c10:after {
@@ -69807,12 +69903,12 @@ exports[`Storyshots Design System/Technical Components/RawTable simple 1`] = `
   color: #32324d;
 }
 
-.c8 {
+.c9 {
   padding-left: 8px;
 }
 
-.c7 {
-  color: #4945ff;
+.c8 {
+  color: #32324d;
   font-size: 0.875rem;
   line-height: 1.43;
 }
@@ -69828,16 +69924,33 @@ exports[`Storyshots Design System/Technical Components/RawTable simple 1`] = `
   align-items: center;
   -webkit-text-decoration: none;
   text-decoration: none;
+  color: #4945ff;
   position: relative;
   outline: none;
 }
 
 .c6 svg path {
-  fill: #4945ff;
+  -webkit-transition: fill 150ms ease-out;
+  transition: fill 150ms ease-out;
+  fill: currentColor;
 }
 
 .c6 svg {
   font-size: 0.625rem;
+}
+
+.c6 .c7 {
+  -webkit-transition: color 150ms ease-out;
+  transition: color 150ms ease-out;
+  color: currentColor;
+}
+
+.c6:hover {
+  color: #7b79ff;
+}
+
+.c6:active {
+  color: #271fe0;
 }
 
 .c6:after {
@@ -69870,7 +69983,7 @@ exports[`Storyshots Design System/Technical Components/RawTable simple 1`] = `
   border: 2px solid #4945ff;
 }
 
-.c9 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -70025,13 +70138,13 @@ exports[`Storyshots Design System/Technical Components/RawTable simple 1`] = `
                   target="_blank"
                 >
                   <span
-                    class="c7"
+                    class="c7 c8"
                   >
                     Link to somewhere
                   </span>
                   <span
                     aria-hidden="true"
-                    class="c8 c9"
+                    class="c9 c10"
                   >
                     <svg
                       fill="none"


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Specifically targets the `Typography` class nested in the `Link` component

### Why is it needed?

Styles applied for `hover` and `active` were not affecting the text color accurately.

### Related issue(s)/PR(s)

CONTENT-477
