### PR TITLE
fix: set z-index on Label to avoid z-index breaking out of parent

### DIFF
--- a/packages/strapi-design-system/src/ToggleCheckbox/ToggleCheckbox.js
+++ b/packages/strapi-design-system/src/ToggleCheckbox/ToggleCheckbox.js
@@ -11,6 +11,7 @@ import { Flex } from '../Flex';
 const Label = styled.label`
   position: relative;
   display: inline-block;
+  z-index: 0;
 `;
 
 const ToggleCheckboxWrapper = styled(Box)`

--- a/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-design-system/tests/__snapshots__/storyshots.spec.js.snap
@@ -49721,6 +49721,7 @@ exports[`Storyshots Design System/Components/ToggleCheckbox base 1`] = `
 .c3 {
   position: relative;
   display: inline-block;
+  z-index: 0;
 }
 
 .c5 {
@@ -49897,6 +49898,7 @@ exports[`Storyshots Design System/Components/ToggleCheckbox disabled 1`] = `
 .c3 {
   position: relative;
   display: inline-block;
+  z-index: 0;
 }
 
 .c5 {
@@ -50078,6 +50080,7 @@ exports[`Storyshots Design System/Components/ToggleCheckbox null-value 1`] = `
 .c3 {
   position: relative;
   display: inline-block;
+  z-index: 0;
 }
 
 .c5 {
@@ -50251,6 +50254,7 @@ exports[`Storyshots Design System/Components/ToggleCheckbox size S 1`] = `
 .c3 {
   position: relative;
   display: inline-block;
+  z-index: 0;
 }
 
 .c5 {
@@ -50483,6 +50487,7 @@ exports[`Storyshots Design System/Components/ToggleInput base 1`] = `
 .c10 {
   position: relative;
   display: inline-block;
+  z-index: 0;
 }
 
 .c12 {
@@ -50830,6 +50835,7 @@ exports[`Storyshots Design System/Components/ToggleInput clear-value 1`] = `
 .c11 {
   position: relative;
   display: inline-block;
+  z-index: 0;
 }
 
 .c13 {
@@ -51098,6 +51104,7 @@ exports[`Storyshots Design System/Components/ToggleInput disabled 1`] = `
 .c8 {
   position: relative;
   display: inline-block;
+  z-index: 0;
 }
 
 .c10 {
@@ -51360,6 +51367,7 @@ exports[`Storyshots Design System/Components/ToggleInput error 1`] = `
 .c8 {
   position: relative;
   display: inline-block;
+  z-index: 0;
 }
 
 .c10 {
@@ -51610,6 +51618,7 @@ exports[`Storyshots Design System/Components/ToggleInput null-value 1`] = `
 .c8 {
   position: relative;
   display: inline-block;
+  z-index: 0;
 }
 
 .c10 {
@@ -51856,6 +51865,7 @@ exports[`Storyshots Design System/Components/ToggleInput size S 1`] = `
 .c8 {
   position: relative;
   display: inline-block;
+  z-index: 0;
 }
 
 .c10 {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Set `z-index` to `0` on the `Label` of ToggleCheckbox.

### Why is it needed?

it's absolute children break out of the parent currently and will therefore show on top of popovers

### Related issue(s)/PR(s)

CONTENT-572
