### PR TITLE
Typography: Add textAlign property

### DIFF
--- a/packages/strapi-design-system/src/Typography/Typography.js
+++ b/packages/strapi-design-system/src/Typography/Typography.js
@@ -14,6 +14,7 @@ export const Typography = styled.span.withConfig({
   font-size: ${({ theme, fontSize }) => theme.fontSizes[fontSize]};
   line-height: ${({ theme, lineHeight }) => theme.lineHeights[lineHeight]};
   color: ${handleColor};
+  text-align: ${({ textAlign }) => textAlign};
   text-transform: ${({ textTransform }) => textTransform};
   ${ellipsisStyle}
   ${variantStyle}

--- a/packages/strapi-design-system/src/Typography/TypographyProps.js
+++ b/packages/strapi-design-system/src/Typography/TypographyProps.js
@@ -10,6 +10,7 @@ export const typographyDefaultProps = {
   fontSize: undefined,
   lineHeight: undefined,
   textColor: undefined,
+  textAlign: undefined,
   textTransform: undefined,
   variant: OMEGA,
 };
@@ -19,6 +20,7 @@ export const typographyPropTypes = {
   fontSize: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   fontWeight: PropTypes.string,
   lineHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  textAlign: PropTypes.string,
   textColor: PropTypes.string,
   textTransform: PropTypes.string,
   variant: PropTypes.oneOf(TEXT_VARIANTS),

--- a/packages/strapi-design-system/src/Typography/__tests__/Typography.spec.js
+++ b/packages/strapi-design-system/src/Typography/__tests__/Typography.spec.js
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { Typography } from '../Typography';
+import { ThemeProvider } from '../../ThemeProvider';
+import { lightTheme } from '../../themes';
+
+const setup = (props) =>
+  render(
+    <ThemeProvider theme={lightTheme}>
+      <Typography {...props} />
+    </ThemeProvider>,
+  );
+
+describe('Typography', () => {
+  test('textAlign', async () => {
+    const { container } = setup({
+      children: 'Test',
+      textAlign: 'center',
+    });
+
+    expect(container).toMatchSnapshot();
+  });
+
+  test('textTransform', () => {
+    const { container } = setup({
+      children: 'Test',
+      textTransform: 'uppercase',
+    });
+
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/strapi-design-system/src/Typography/__tests__/__snapshots__/Typography.spec.js.snap
+++ b/packages/strapi-design-system/src/Typography/__tests__/__snapshots__/Typography.spec.js.snap
@@ -1,0 +1,103 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Typography textAlign 1`] = `
+.c0 {
+  color: #32324d;
+  text-align: center;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
+.c1 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+<div>
+  <span
+    class="c0"
+  >
+    Test
+  </span>
+  <div
+    class="c1"
+  >
+    <p
+      aria-live="polite"
+      aria-relevant="all"
+      id="live-region-log"
+      role="log"
+    />
+    <p
+      aria-live="polite"
+      aria-relevant="all"
+      id="live-region-status"
+      role="status"
+    />
+    <p
+      aria-live="assertive"
+      aria-relevant="all"
+      id="live-region-alert"
+      role="alert"
+    />
+  </div>
+</div>
+`;
+
+exports[`Typography textTransform 1`] = `
+.c0 {
+  color: #32324d;
+  text-transform: uppercase;
+  font-size: 0.875rem;
+  line-height: 1.43;
+}
+
+.c1 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+<div>
+  <span
+    class="c0"
+  >
+    Test
+  </span>
+  <div
+    class="c1"
+  >
+    <p
+      aria-live="polite"
+      aria-relevant="all"
+      id="live-region-log"
+      role="log"
+    />
+    <p
+      aria-live="polite"
+      aria-relevant="all"
+      id="live-region-status"
+      role="status"
+    />
+    <p
+      aria-live="assertive"
+      aria-relevant="all"
+      id="live-region-alert"
+      role="alert"
+    />
+  </div>
+</div>
+`;


### PR DESCRIPTION
### What does it do?

Implements `textAlign` as alias for `text-align` on the `Typography` component.

### Why is it needed?

To support more properties that control the text-rendering.

### Related issue(s)/PR(s)

- Closes https://github.com/strapi/design-system/issues/718
