### PR TITLE
Status: Make preceding bullet configurable

### DIFF
--- a/packages/strapi-design-system/src/Status/Status.js
+++ b/packages/strapi-design-system/src/Status/Status.js
@@ -19,7 +19,7 @@ const StatusWrapper = styled(Box)`
   }
 `;
 
-export const Status = ({ variant, children, ...props }) => {
+export const Status = ({ variant, showBullet, children, ...props }) => {
   const backgroundColor = `${variant}100`;
   const borderColor = `${variant}200`;
   const bulletColor = `${variant}600`;
@@ -37,19 +37,34 @@ export const Status = ({ variant, children, ...props }) => {
       paddingRight={5}
       {...props}
     >
-      <Flex>
-        <Bullet backgroundColor={bulletColor} />
-        {children}
-      </Flex>
+      {showBullet ? (
+        <Flex>
+          <Bullet backgroundColor={bulletColor} />
+          {children}
+        </Flex>
+      ) : (
+        children
+      )}
     </StatusWrapper>
   );
 };
 
 Status.defaultProps = {
+  showBullet: true,
   variant: 'primary',
 };
 
 Status.propTypes = {
   children: PropTypes.node.isRequired,
+
+  /**
+   * If `false`, the preceeding bullet of the status won't be displayed.
+   * This prop and the bullet will be removed in the next major version.
+   */
+  showBullet: PropTypes.bool, // TODO V2: remove prop and bullet
+
+  /**
+   * Color variation
+   */
   variant: PropTypes.oneOf(['alternative', 'danger', 'neutral', 'primary', 'secondary', 'success', 'warning']),
 };

--- a/packages/strapi-design-system/src/Status/__tests__/Status.spec.js
+++ b/packages/strapi-design-system/src/Status/__tests__/Status.spec.js
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { render, waitFor } from '@testing-library/react';
+
+import { Status } from '../Status';
+import { ThemeProvider } from '../../ThemeProvider';
+import { lightTheme } from '../../themes';
+
+describe('Status', () => {
+  it('it displays its children', async () => {
+    const { getByText } = render(
+      <ThemeProvider theme={lightTheme}>
+        <Status>My status</Status>
+      </ThemeProvider>,
+    );
+
+    await waitFor(() => {
+      expect(getByText('My status')).toBeInTheDocument();
+    });
+  });
+
+  it('it displays a preceeding bullet by default', async () => {
+    const { queryByText } = render(
+      <ThemeProvider theme={lightTheme}>
+        <Status>My status</Status>
+      </ThemeProvider>,
+    );
+
+    const textNode = queryByText('My status');
+
+    await waitFor(() => {
+      expect(textNode.querySelector('div')).toBeInTheDocument();
+    });
+  });
+
+  it('it is possible to disable the preceeding bullet', async () => {
+    const { queryByText } = render(
+      <ThemeProvider theme={lightTheme}>
+        <Status showBullet={false}>My status</Status>
+      </ThemeProvider>,
+    );
+
+    const textNode = queryByText('My status');
+
+    await waitFor(() => {
+      expect(textNode.innerHTML).toBe('My status');
+    });
+  });
+});


### PR DESCRIPTION
### What does it do?

It makes the preceding bullet of the [`Status`](https://design-system-git-main-strapijs.vercel.app/?path=/story/design-system-components-status--base) component configurable through a prop called `showBullet`.

### Why is it needed?

The bullet is not part of any `Status` component any longer. To stay visually consistent, I've added a new prop, which allows disabling the bullet and renders only `children` instead.

I think we could approach this differently if we'd want:

1. We could argue the bullet is decoration and, therefore, we can change it right away. This way, we'd have to keep the child `Flex` around.
2. We could create a new v2 version of the component which does not know about `Bullet` or `Flex`, but I feel like it adds too much unnecessary overhead.

In the spirit of composability, I think getting rid of any child wrappers is a sensible default for the future because it is less opinionated.

### How to test it?

The automated tests do that for you.
