### PR TITLE
Theme: Remove default color from icons

### DIFF
--- a/packages/strapi-design-system/src/themes/Theme.stories.mdx
+++ b/packages/strapi-design-system/src/themes/Theme.stories.mdx
@@ -193,16 +193,12 @@ Icons are used to emphasize actions and specific menus in the admin panel. We ca
               {iconsArray.map((icon) => {
                 const RealIcon = Icons[icon];
                 return (
-                  <GridItem padding={2} col={2} key={icon} background={'neutral0'}>
+                  <GridItem padding={2} col={2} key={icon} background='neutral0'>
                     <Box>
                       <Icon
                         aria-hidden={true}
-                        colors={(theme) => ({
-                          rect: {
-                            fill: theme.colors.danger600,
-                          },
-                        })}
                         as={RealIcon}
+                        color="false"
                         fontSize={5}
                       />
                     </Box>


### PR DESCRIPTION
### What does it do?

It removes the default color assignment in the `Icon` documentation in

### Why is it needed?

> **Note**
> This is meant to be a discussion starter rather than a final implementation. Maybe I don't see the full picture, but I don't see how to not pass in a default color.

I found it quite confusing when working on https://github.com/strapi/design-system/pull/726 that my icon doesn't show up in the original color. I think not recoloring these icons will help us to spot problems easier in the future.

Looking it the current icons, I don't think it is necessary for many of them to be colored by default:

| Before | After |
|-|-|
| ![Screen Shot 2022-10-31 at 12 07 24](https://user-images.githubusercontent.com/2244375/198994407-398ce874-663f-49ec-8db0-06ab49ed4511.png) | ![Screen Shot 2022-10-31 at 11 11 53](https://user-images.githubusercontent.com/2244375/198984513-cab57b23-c310-42ef-8681-52cc7549199f.png) |


