### PR TITLE
Jest: Respect os specific files for the check-exports test

### DIFF
--- a/packages/strapi-design-system/tests/check-exports.spec.js
+++ b/packages/strapi-design-system/tests/check-exports.spec.js
@@ -1,10 +1,15 @@
 const fs = require('fs-extra');
-const path = require('path');
-const filesToKeep = require('./filesToKeep');
+const { resolve } = require('path');
+
+// List of files we want to ignore when running the equality check
+const FILES_NAMES_TO_IGNORE = ['.DS_Store'];
+
+// List of files we want to include in the index.js file
+const FILES_TO_KEEP = ['themes'];
 
 describe('Check components are all exported correctly (index.js)', () => {
   it('should generate the exports correctly', async () => {
-    const dest = path.resolve(__dirname, '..', 'src', 'index.js');
+    const dest = resolve(__dirname, '..', 'src', 'index.js');
     const buffer = await fs.readFile(dest);
     const content = buffer.toString();
     const exportedComponents = content
@@ -16,13 +21,15 @@ describe('Check components are all exported correctly (index.js)', () => {
       })
       .sort();
 
-    const dirs = await fs.readdir(path.resolve(__dirname, '..', 'src'));
+    const dirs = await fs.readdir(resolve(__dirname, '..', 'src'));
     const components = dirs.filter((file) => {
       const isComponent = file.charAt(0) === file.charAt(0).toUpperCase() || file === 'v2';
 
       return isComponent;
     });
-    const expected = [...filesToKeep, ...components].sort();
+    const expected = [...FILES_TO_KEEP, ...components]
+      .filter((fileName) => !FILES_NAMES_TO_IGNORE.includes(fileName))
+      .sort();
 
     expect(exportedComponents).toEqual(expected);
   });

--- a/packages/strapi-design-system/tests/filesToKeep.js
+++ b/packages/strapi-design-system/tests/filesToKeep.js
@@ -1,6 +1,0 @@
-/**
- * List of files we want to include in the index.js file
- */
-const filesToKeep = ['themes'];
-
-module.exports = filesToKeep;


### PR DESCRIPTION
### What does it do?

Adds an exception for `.DS_Store` files, when comparing exports.

### Why is it needed?

I often have one failing test, which stems from the fact that my os creates a file called `.DS_Store`. I'd like the test to ignore that file when checking for export equality.

### How to test it?

Believe in jest.
