### PR TITLE
GitHub: Use ubuntu as GitHub Action base image instead of macos

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   lint:
     name: "Lint"
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -22,7 +22,7 @@ jobs:
   unit_tests:
     name: "unit tests"
     needs: [lint]
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -42,7 +42,7 @@ jobs:
   e2e_tests:
     name: "e2e tests (browser: ${{ matrix.browser }})"
     needs: [lint]
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         browser: [chromium, webkit, firefox]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,20 +5,20 @@ on:
   workflow_dispatch:
 
 jobs:
-  lint:
-    name: "Lint"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: "14"
-          cache: "yarn"
-      - uses: ./.github/actions/install-modules
-      - name: Link locale packages and install their dependencies
-        run: yarn bootstrap
-      - name: Run lint
-        run: yarn lint
+  # lint:
+  #   name: "Lint"
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/setup-node@v2
+  #       with:
+  #         node-version: "14"
+  #         cache: "yarn"
+  #     - uses: ./.github/actions/install-modules
+  #     - name: Link locale packages and install their dependencies
+  #       run: yarn bootstrap
+  #     - name: Run lint
+  #       run: yarn lint
   unit_tests:
     name: "unit tests"
     needs: [lint]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
           globalPackages: http-server
 
       - name: Install Playwright
-        run: npx playwright@1.27.1 install --with-deps
+        run: npx playwright@1.28.0 install --with-deps
 
       - name: Link locale packages and install their dependencies
         run: yarn bootstrap

--- a/packages/strapi-design-system/package.json
+++ b/packages/strapi-design-system/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@figspec/react": "^0.1.5",
     "@juggle/resize-observer": "^3.4.0",
-    "@playwright/test": "1.27.1",
+    "@playwright/test": "1.28.0",
     "@storybook/addon-actions": "^6.5.13",
     "@storybook/addon-essentials": "^6.5.13",
     "@storybook/addon-links": "^6.5.13",

--- a/packages/strapi-design-system/src/Popover/__tests__/Popover.e2e.js
+++ b/packages/strapi-design-system/src/Popover/__tests__/Popover.e2e.js
@@ -29,7 +29,9 @@ test.describe.parallel('Popover', () => {
         expect(lis.length).toBe(10);
 
         await page.focus('#list');
-        await page.keyboard.press('PageDown', { delay: 2000 });
+        await page.keyboard.press('PageDown', { delay: 50 });
+        await page.keyboard.press('PageDown', { delay: 50 });
+        await page.keyboard.press('PageDown', { delay: 50 });
 
         const lis2 = await page.$$('#on-reach-end li');
         expect(lis2.length).toBe(15);

--- a/packages/strapi-design-system/src/Popover/__tests__/Popover.e2e.js
+++ b/packages/strapi-design-system/src/Popover/__tests__/Popover.e2e.js
@@ -31,6 +31,8 @@ test.describe.parallel('Popover', () => {
         await page.focus('#list');
         await page.keyboard.press('PageDown', { delay: 1000 });
 
+        await page.waitForTimeout(1000);
+
         const lis2 = await page.$$('#on-reach-end li');
         expect(lis2.length).toBe(15);
       });

--- a/packages/strapi-design-system/src/Popover/__tests__/Popover.e2e.js
+++ b/packages/strapi-design-system/src/Popover/__tests__/Popover.e2e.js
@@ -23,10 +23,12 @@ test.describe.parallel('Popover', () => {
       });
 
       test('adds item when reaching the end', async ({ page }) => {
-        await page.focus('#popover1');
-        await page.keyboard.press('Enter');
+        await page.locator('#popover1').press('Enter');
         const lis = page.locator('#on-reach-end li');
+
         await expect(lis).toHaveCount(10);
+
+        console.log(lis.innerHTML());
 
         await page.focus('#list');
         await page.keyboard.press('PageDown', { delay: 1000 });

--- a/packages/strapi-design-system/src/Popover/__tests__/Popover.e2e.js
+++ b/packages/strapi-design-system/src/Popover/__tests__/Popover.e2e.js
@@ -29,9 +29,7 @@ test.describe.parallel('Popover', () => {
         await expect(lis).toHaveCount(10);
 
         await page.focus('#list');
-        await page.keyboard.press('PageDown', { delay: 50 });
-        await page.keyboard.press('PageDown', { delay: 50 });
-        await page.keyboard.press('PageDown', { delay: 50 });
+        await page.keyboard.press('PageDown', { delay: 1000 });
 
         const lis2 = page.locator('#on-reach-end li');
 

--- a/packages/strapi-design-system/src/Popover/__tests__/Popover.e2e.js
+++ b/packages/strapi-design-system/src/Popover/__tests__/Popover.e2e.js
@@ -25,16 +25,17 @@ test.describe.parallel('Popover', () => {
       test('adds item when reaching the end', async ({ page }) => {
         await page.focus('#popover1');
         await page.keyboard.press('Enter');
-        const lis = await page.$$('#on-reach-end li');
-        expect(lis.length).toBe(10);
+        const lis = page.locator('#on-reach-end li');
+        await expect(lis).toHaveCount(10);
 
         await page.focus('#list');
         await page.keyboard.press('PageDown', { delay: 50 });
         await page.keyboard.press('PageDown', { delay: 50 });
         await page.keyboard.press('PageDown', { delay: 50 });
 
-        const lis2 = await page.$$('#on-reach-end li');
-        expect(lis2.length).toBe(15);
+        const lis2 = page.locator('#on-reach-end li');
+
+        await expect(lis2).toHaveCount(15);
       });
     });
   });

--- a/packages/strapi-design-system/src/Popover/__tests__/Popover.e2e.js
+++ b/packages/strapi-design-system/src/Popover/__tests__/Popover.e2e.js
@@ -29,9 +29,7 @@ test.describe.parallel('Popover', () => {
         expect(lis.length).toBe(10);
 
         await page.focus('#list');
-        await page.keyboard.press('PageDown', { delay: 1000 });
-
-        await page.waitForTimeout(1000);
+        await page.keyboard.press('PageDown', { delay: 2000 });
 
         const lis2 = await page.$$('#on-reach-end li');
         expect(lis2.length).toBe(15);

--- a/packages/strapi-design-system/yarn.lock
+++ b/packages/strapi-design-system/yarn.lock
@@ -1969,13 +1969,13 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@playwright/test@1.27.1":
-  version "1.27.1"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.27.1.tgz#9364d1e02021261211c8ff586d903faa79ce95c4"
-  integrity sha512-mrL2q0an/7tVqniQQF6RBL2saskjljXzqNcCOVMUjRIgE6Y38nCNaP+Dc2FBW06bcpD3tqIws/HT9qiMHbNU0A==
+"@playwright/test@1.28.0":
+  version "1.28.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.28.0.tgz#8de83f9d2291bba3f37883e33431b325661720d9"
+  integrity sha512-vrHs5DFTPwYox5SGKq/7TDn/S4q6RA1zArd7uhO6EyP9hj3XgZBBM12ktMbnDQNxh/fL1IUKsTNLxihmsU38lQ==
   dependencies:
     "@types/node" "*"
-    playwright-core "1.27.1"
+    playwright-core "1.28.0"
 
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.3":
   version "0.5.8"
@@ -9781,10 +9781,10 @@ pkg-dir@^5.0.0:
   dependencies:
     find-up "^5.0.0"
 
-playwright-core@1.27.1:
-  version "1.27.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.27.1.tgz#840ef662e55a3ed759d8b5d3d00a5f885a7184f4"
-  integrity sha512-9EmeXDncC2Pmp/z+teoVYlvmPWUC6ejSSYZUln7YaP89Z6lpAaiaAnqroUt/BoLo8tn7WYShcfaCh+xofZa44Q==
+playwright-core@1.28.0:
+  version "1.28.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.28.0.tgz#61df5c714f45139cca07095eccb4891e520e06f2"
+  integrity sha512-nJLknd28kPBiCNTbqpu6Wmkrh63OEqJSFw9xOfL9qxfNwody7h6/L3O2dZoWQ6Oxcm0VOHjWmGiCUGkc0X3VZA==
 
 pnp-webpack-plugin@1.6.4:
   version "1.6.4"


### PR DESCRIPTION
### What does it do?

Changes the GitHub Actions base image from macOS to ubuntu.

### Why is it needed?

Running macOS is relatively slow (~ 40min down to ...) and expensive (minutes are multiplied by 10) compared to the ubuntu base image.

I don't see a specific reason we should use macOS to run our tests. This might change in case we enable visual regression tests one day.

