### PR TITLE
[enhancement]: IconButton

### DIFF
--- a/packages/strapi-design-system/.eslintrc.js
+++ b/packages/strapi-design-system/.eslintrc.js
@@ -1,4 +1,9 @@
 module.exports = {
+  env: {
+    jest: true,
+    browser: true,
+    node: true,
+  },
   parserOptions: {
     ecmaVersion: 2020, // Allows for the parsing of modern ECMAScript features
     sourceType: 'module', // Allows for the use of imports
@@ -20,9 +25,6 @@ module.exports = {
     'default-case': 'error',
     'no-unused-vars': ['error', { vars: 'all', args: 'after-used', ignoreRestSiblings: false }],
     'no-undef': 'error',
-  },
-  globals: {
-    module: true,
   },
   overrides: [
     {

--- a/packages/strapi-design-system/.eslintrc.js
+++ b/packages/strapi-design-system/.eslintrc.js
@@ -19,6 +19,10 @@ module.exports = {
     'react/sort-prop-types': 1,
     'default-case': 'error',
     'no-unused-vars': ['error', { vars: 'all', args: 'after-used', ignoreRestSiblings: false }],
+    'no-undef': 'error',
+  },
+  globals: {
+    module: true,
   },
   overrides: [
     {

--- a/packages/strapi-design-system/src/BaseCheckbox/BaseCheckbox.stories.mdx
+++ b/packages/strapi-design-system/src/BaseCheckbox/BaseCheckbox.stories.mdx
@@ -41,7 +41,7 @@ The `BaseCheckbox` can have an indeterminate state.
 <Canvas>
   <Story name="indeterminate">
     {() => {
-      const [checkedItems, setCheckedItems] = React.useState([true, false]);
+      const [checkedItems, setCheckedItems] = useState([true, false]);
       const allChecked = checkedItems.every(Boolean);
       const isIndeterminate = checkedItems.some(Boolean) && !allChecked;
       return (

--- a/packages/strapi-design-system/src/Checkbox/Checkbox.stories.mdx
+++ b/packages/strapi-design-system/src/Checkbox/Checkbox.stories.mdx
@@ -55,7 +55,7 @@ import { Checkbox } from '@strapi/design-system/Checkbox';
     }}
   >
     {() => {
-      const [checkedItems, setCheckedItems] = React.useState([true, false]);
+      const [checkedItems, setCheckedItems] = useState([true, false]);
       const allChecked = checkedItems.every(Boolean);
       const isIndeterminate = checkedItems.some(Boolean) && !allChecked;
       return (

--- a/packages/strapi-design-system/src/DatePicker/__tests__/DatePicker.spec.js
+++ b/packages/strapi-design-system/src/DatePicker/__tests__/DatePicker.spec.js
@@ -16,6 +16,7 @@ describe('DatePicker', () => {
             locale={locale}
             selectedDateLabel={(formattedDate) => `Date picker, current is ${formattedDate}`}
             selectedDate={new Date('Tue Sep 06 2022')}
+            onChange={() => null}
           />
         </ThemeProvider>,
       );

--- a/packages/strapi-design-system/src/DismissibleLayer/__test__/DimissibleLayer.spec.js
+++ b/packages/strapi-design-system/src/DismissibleLayer/__test__/DimissibleLayer.spec.js
@@ -5,8 +5,9 @@ import { DismissibleLayer } from '../DismissibleLayer';
 describe('DismissibleLayer', () => {
   it('should fire onEscapeKeyDown when the ESCAPE key is pressed', () => {
     const onEscapeKeyDownMock = jest.fn();
+    const onPointerDownOutsideMock = jest.fn();
     render(
-      <DismissibleLayer onEscapeKeyDown={onEscapeKeyDownMock}>
+      <DismissibleLayer onEscapeKeyDown={onEscapeKeyDownMock} onPointerDownOutside={onPointerDownOutsideMock}>
         <h1>hello world</h1>
       </DismissibleLayer>,
     );
@@ -18,9 +19,10 @@ describe('DismissibleLayer', () => {
 
   it('should fire onPointerDownOutside when the user clicks outside the DismissibleLayer', () => {
     const onPointerDownOutsideMock = jest.fn();
+    const onEscapeKeyDownMock = jest.fn();
     render(
       <>
-        <DismissibleLayer onPointerDownOutside={onPointerDownOutsideMock}>
+        <DismissibleLayer onPointerDownOutside={onPointerDownOutsideMock} onEscapeKeyDown={onEscapeKeyDownMock}>
           <h1>hello world</h1>
         </DismissibleLayer>
         <button>Click me</button>

--- a/packages/strapi-design-system/src/IconButton/IconButton.js
+++ b/packages/strapi-design-system/src/IconButton/IconButton.js
@@ -144,18 +144,32 @@ IconButton.defaultProps = {
 /**
  * @type {(otherProps: string[]) => (props: Record<string, unknown>, propName: string) => Error | undefined}
  */
-const throwPropErrorIfNoneAreDefined = (otherProps) => (props, propName) => {
+const throwPropErrorIfNoneAreDefined = (otherProps, propType) => (props, propName) => {
   if (!props[propName] && otherProps.every((otherProp) => !props[otherProp])) {
     return new Error(`One of the following props is required: ${propName}, ${otherProps.join(', ')}`);
   }
+
+  PropTypes.checkPropTypes({ [propName]: PropTypes[propType] }, props, 'prop', 'IconButton');
 };
 
 IconButton.propTypes = {
-  ['aria-label']: throwPropErrorIfNoneAreDefined(['label']),
-  children: throwPropErrorIfNoneAreDefined(['icon']),
+  /**
+   * `PropTypes.string` – must be defined if `label` is not defined.
+   */
+  ['aria-label']: throwPropErrorIfNoneAreDefined(['label'], 'string'),
+  /**
+   * `PropTypes.node` – must be defined if `icon` is not defined.
+   */
+  children: throwPropErrorIfNoneAreDefined(['icon'], 'node'),
   disabled: PropTypes.bool,
-  icon: throwPropErrorIfNoneAreDefined(['children']),
-  label: throwPropErrorIfNoneAreDefined(['aria-label']),
+  /**
+   * `PropTypes.node` – must be defined if `children` is not defined.
+   */
+  icon: throwPropErrorIfNoneAreDefined(['children'], 'node'),
+  /**
+   * `PropTypes.string` – must be defined if `aria-label` is not defined.
+   */
+  label: throwPropErrorIfNoneAreDefined(['aria-label'], 'string'),
   noBorder: PropTypes.bool,
   onClick: PropTypes.func,
 };

--- a/packages/strapi-design-system/src/IconButton/IconButton.stories.mdx
+++ b/packages/strapi-design-system/src/IconButton/IconButton.stories.mdx
@@ -95,6 +95,31 @@ IconButtons can be used within another component is a Group shape.
   </Story>
 </Canvas>
 
+### Icons as Children & aria-label
+
+IconButtons can take Icons as their children and can be fully accessible without a tooltip.
+
+<Canvas>
+  <Story name="children">
+    <Box padding={7}>
+      <Flex>
+        <IconButton onClick={() => console.log('edit')} aria-label="Edit">
+          <Pencil />
+        </IconButton>
+        <IconButton onClick={() => console.log('Create')} aria-label="Create">
+          <Plus />
+        </IconButton>
+        <IconButton onClick={() => console.log('Delete')} aria-label="Delete">
+          <Trash />
+        </IconButton>
+        <IconButton onClick={() => console.log('Publish')} aria-label="Publish">
+          <Play />
+        </IconButton>
+      </Flex>
+    </Box>
+  </Story>
+</Canvas>
+
 ## Props
 
 <ArgsTable of={IconButton} />

--- a/packages/strapi-design-system/src/IconButton/IconButton.stories.mdx
+++ b/packages/strapi-design-system/src/IconButton/IconButton.stories.mdx
@@ -2,13 +2,16 @@
 
 import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
+
 import Pencil from '@strapi/icons/Pencil';
 import Play from '@strapi/icons/Play';
 import Trash from '@strapi/icons/Trash';
 import Plus from '@strapi/icons/Plus';
+
 import { IconButton, IconButtonGroup } from './IconButton';
 import { Box } from '../Box';
 import { Flex } from '../Flex';
+import { Typography } from '../Typography';
 
 <Meta title="Design System/Components/IconButton" component={IconButton} />
 
@@ -38,14 +41,22 @@ Icon Buttons are used to perform actions within a page, a table or another objec
 
 <Canvas>
   <Story name="base">
-    <Box padding={7}>
-      <Flex>
-        <IconButton onClick={() => console.log('edit')} label="Edit" icon={<Pencil />} />
-        <IconButton onClick={() => console.log('Create')} label="Create" icon={<Plus />} />
-        <IconButton onClick={() => console.log('Delete')} label="Delete" icon={<Trash />} />
-        <IconButton onClick={() => console.log('Publish')} label="Publish" icon={<Play />} />
-      </Flex>
-    </Box>
+    {() => {
+      const [currentAction, setCurrentAction] = React.useState('None Selected');
+      return (
+        <Box padding={7}>
+          <Box paddingBottom={3}>
+            <Typography>{currentAction}</Typography>
+          </Box>
+          <Flex>
+            <IconButton onClick={() => setCurrentAction('edit')} label="Edit" icon={<Pencil />} />
+            <IconButton onClick={() => setCurrentAction('Create')} label="Create" icon={<Plus />} />
+            <IconButton onClick={() => setCurrentAction('Delete')} label="Delete" icon={<Trash />} />
+            <IconButton onClick={() => setCurrentAction('Publish')} label="Publish" icon={<Play />} />
+          </Flex>
+        </Box>
+      );
+    }}
   </Story>
 </Canvas>
 
@@ -55,14 +66,22 @@ Depending on the status of an action or the permissions, an IconButton can be un
 
 <Canvas>
   <Story name="disabled">
-    <Box padding={7}>
-      <Flex>
-        <IconButton disabled onClick={() => console.log('edit')} label="Edit" icon={<Pencil />} />
-        <IconButton disabled onClick={() => console.log('Create')} label="Create" icon={<Plus />} />
-        <IconButton disabled onClick={() => console.log('Delete')} label="Delete" icon={<Trash />} />
-        <IconButton disabled onClick={() => console.log('Publish')} label="Publish" icon={<Play />} />
-      </Flex>
-    </Box>
+    {() => {
+      const [currentAction, setCurrentAction] = React.useState('None Selected');
+      return (
+        <Box padding={7}>
+          <Box paddingBottom={3}>
+            <Typography>{currentAction}</Typography>
+          </Box>
+          <Flex>
+            <IconButton disabled onClick={() => setCurrentAction('edit')} label="Edit" icon={<Pencil />} />
+            <IconButton disabled onClick={() => setCurrentAction('Create')} label="Create" icon={<Plus />} />
+            <IconButton disabled onClick={() => setCurrentAction('Delete')} label="Delete" icon={<Trash />} />
+            <IconButton disabled onClick={() => setCurrentAction('Publish')} label="Publish" icon={<Play />} />
+          </Flex>
+        </Box>
+      );
+    }}
   </Story>
 </Canvas>
 
@@ -101,22 +120,30 @@ IconButtons can take Icons as their children and can be fully accessible without
 
 <Canvas>
   <Story name="children">
-    <Box padding={7}>
-      <Flex>
-        <IconButton onClick={() => console.log('edit')} aria-label="Edit">
-          <Pencil />
-        </IconButton>
-        <IconButton onClick={() => console.log('Create')} aria-label="Create">
-          <Plus />
-        </IconButton>
-        <IconButton onClick={() => console.log('Delete')} aria-label="Delete">
-          <Trash />
-        </IconButton>
-        <IconButton onClick={() => console.log('Publish')} aria-label="Publish">
-          <Play />
-        </IconButton>
-      </Flex>
-    </Box>
+    {() => {
+      const [currentAction, setCurrentAction] = React.useState('None Selected');
+      return (
+        <Box padding={7}>
+          <Box paddingBottom={3}>
+            <Typography>{currentAction}</Typography>
+          </Box>
+          <Flex>
+            <IconButton onClick={() => setCurrentAction('Edit')} aria-label={'Edit'}>
+              <Pencil />
+            </IconButton>
+            <IconButton onClick={() => setCurrentAction('Create')} aria-label="Create">
+              <Plus />
+            </IconButton>
+            <IconButton onClick={() => setCurrentAction('Delete')} aria-label="Delete">
+              <Trash />
+            </IconButton>
+            <IconButton onClick={() => setCurrentAction('Publish')} aria-label="Publish">
+              <Play />
+            </IconButton>
+          </Flex>
+        </Box>
+      );
+    }}
   </Story>
 </Canvas>
 

--- a/packages/strapi-design-system/src/IconButton/IconButton.stories.mdx
+++ b/packages/strapi-design-system/src/IconButton/IconButton.stories.mdx
@@ -2,6 +2,7 @@
 
 import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
+import { useState } from 'react';
 
 import Pencil from '@strapi/icons/Pencil';
 import Play from '@strapi/icons/Play';
@@ -42,7 +43,7 @@ Icon Buttons are used to perform actions within a page, a table or another objec
 <Canvas>
   <Story name="base">
     {() => {
-      const [currentAction, setCurrentAction] = React.useState('None Selected');
+      const [currentAction, setCurrentAction] = useState('None Selected');
       return (
         <Box padding={7}>
           <Box paddingBottom={3}>
@@ -67,7 +68,7 @@ Depending on the status of an action or the permissions, an IconButton can be un
 <Canvas>
   <Story name="disabled">
     {() => {
-      const [currentAction, setCurrentAction] = React.useState('None Selected');
+      const [currentAction, setCurrentAction] = useState('None Selected');
       return (
         <Box padding={7}>
           <Box paddingBottom={3}>
@@ -121,7 +122,7 @@ IconButtons can take Icons as their children and can be fully accessible without
 <Canvas>
   <Story name="children">
     {() => {
-      const [currentAction, setCurrentAction] = React.useState('None Selected');
+      const [currentAction, setCurrentAction] = useState('None Selected');
       return (
         <Box padding={7}>
           <Box paddingBottom={3}>

--- a/packages/strapi-design-system/src/ModalLayout/__tests__/ModalLayout.spec.js
+++ b/packages/strapi-design-system/src/ModalLayout/__tests__/ModalLayout.spec.js
@@ -506,12 +506,18 @@ describe('ModalLayout', () => {
                       Modal Title
                       <button
                         aria-disabled="false"
-                        aria-label="Close the modal"
                         class="c8 c9"
                         type="button"
                       >
+                        <span
+                          class="c0"
+                        >
+                          Close the modal
+                        </span>
                         <svg
+                          aria-hidden="true"
                           fill="none"
+                          focusable="false"
                           height="1em"
                           viewBox="0 0 24 24"
                           width="1em"

--- a/packages/strapi-design-system/src/Status/Status.stories.mdx
+++ b/packages/strapi-design-system/src/Status/Status.stories.mdx
@@ -49,20 +49,25 @@ Use a Status sparingly within forms to give an important visual indication. Stat
   </Story>
 </Canvas>
 
-
 ### Size
 
 <Canvas>
   <Story name="size S">
     <Stack spacing={3}>
       <Status variant="success" size="S" showBullet={false}>
-        <Typography fontWeight="bold" textColor="success700">Published</Typography>
+        <Typography fontWeight="bold" textColor="success700">
+          Published
+        </Typography>
       </Status>
       <Status variant="secondary" size="S" showBullet={false}>
-        <Typography fontWeight="bold" textColor="secondary700">Draft</Typography>
+        <Typography fontWeight="bold" textColor="secondary700">
+          Draft
+        </Typography>
       </Status>
       <Status variant="alternative" size="S" showBullet={false}>
-        <Typography fontWeight="bold" textColor="alternative700">Updated</Typography>
+        <Typography fontWeight="bold" textColor="alternative700">
+          Updated
+        </Typography>
       </Status>
     </Stack>
   </Story>

--- a/packages/strapi-design-system/src/Switch/Switch.stories.mdx
+++ b/packages/strapi-design-system/src/Switch/Switch.stories.mdx
@@ -36,7 +36,17 @@ Activated state is one of two of them available for a Switch.
 
 <Canvas>
   <Story name="activated">
-    <Switch label="Activate the microphone" selected={true} onChange={(e) => console.log(e)} visibleLabels />
+    {() => {
+      const [activated, setActivated] = React.useState(true);
+      return (
+        <Switch
+          label="Activate the microphone"
+          selected={activated}
+          onChange={() => setActivated((s) => !s)}
+          visibleLabels
+        />
+      );
+    }}
   </Story>
 </Canvas>
 
@@ -46,7 +56,17 @@ Deactivated state is one of two of them available for a Switch.
 
 <Canvas>
   <Story name="not-activated">
-    <Switch label="Activate the microphone" selected={false} onChange={(e) => console.log(e)} visibleLabels />
+    {() => {
+      const [activated, setActivated] = React.useState(false);
+      return (
+        <Switch
+          label="Activate the microphone"
+          selected={activated}
+          onChange={() => setActivated((s) => !s)}
+          visibleLabels
+        />
+      );
+    }}
   </Story>
 </Canvas>
 

--- a/packages/strapi-design-system/src/Switch/Switch.stories.mdx
+++ b/packages/strapi-design-system/src/Switch/Switch.stories.mdx
@@ -1,5 +1,6 @@
 <!--- Switch.stories.mdx --->
 
+import { useState } from 'react';
 import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
 import { Switch } from './Switch';
@@ -37,7 +38,7 @@ Activated state is one of two of them available for a Switch.
 <Canvas>
   <Story name="activated">
     {() => {
-      const [activated, setActivated] = React.useState(true);
+      const [activated, setActivated] = useState(true);
       return (
         <Switch
           label="Activate the microphone"
@@ -57,7 +58,7 @@ Deactivated state is one of two of them available for a Switch.
 <Canvas>
   <Story name="not-activated">
     {() => {
-      const [activated, setActivated] = React.useState(false);
+      const [activated, setActivated] = useState(false);
       return (
         <Switch
           label="Activate the microphone"

--- a/packages/strapi-design-system/src/Switch/Switch.stories.mdx
+++ b/packages/strapi-design-system/src/Switch/Switch.stories.mdx
@@ -36,7 +36,7 @@ Activated state is one of two of them available for a Switch.
 
 <Canvas>
   <Story name="activated">
-    <Switch label="Activate the microphone" selected={true} onChange={() => setChecked((s) => !s)} visibleLabels />
+    <Switch label="Activate the microphone" selected={true} onChange={(e) => console.log(e)} visibleLabels />
   </Story>
 </Canvas>
 
@@ -46,7 +46,7 @@ Deactivated state is one of two of them available for a Switch.
 
 <Canvas>
   <Story name="not-activated">
-    <Switch label="Activate the microphone" selected={false} onChange={() => setChecked((s) => !s)} visibleLabels />
+    <Switch label="Activate the microphone" selected={false} onChange={(e) => console.log(e)} visibleLabels />
   </Story>
 </Canvas>
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* Allows passing children as opposed to icon (although PropTypes aims to enforce we should pass one or the other)
* Ensure if you don't pass a label you pass an `aria-label` cause there's no excuse for no accessibility
* Set no-undef in `eslint` to `error` cause it's a better DX imo
* Adds extra accessibility flags to the `icon`/`children` via `cloneElement`
* Use's `VisuallyHidden` spans because iirc translators are more likely to translate those than aria-labels and it's clearer from a code POV

### Why is it needed?

* Because I'm adding drag and drop to relation items and the drag icon _needs_ to be accessible.
