### PR TITLE
Status: Add small variant

### DIFF
--- a/packages/strapi-design-system/src/Status/Status.js
+++ b/packages/strapi-design-system/src/Status/Status.js
@@ -19,11 +19,14 @@ const StatusWrapper = styled(Box)`
   }
 `;
 
-export const Status = ({ variant, showBullet, children, ...props }) => {
+export const Status = ({ variant, showBullet, size, children, ...props }) => {
   const backgroundColor = `${variant}100`;
   const borderColor = `${variant}200`;
   const bulletColor = `${variant}600`;
   const textColor = `${variant}600`;
+
+  const paddingX = size === 'S' ? 2 : 5;
+  const paddingY = size === 'S' ? 1 : 4;
 
   return (
     <StatusWrapper
@@ -31,10 +34,10 @@ export const Status = ({ variant, showBullet, children, ...props }) => {
       textColor={textColor}
       background={backgroundColor}
       hasRadius
-      paddingTop={4}
-      paddingBottom={4}
-      paddingLeft={5}
-      paddingRight={5}
+      paddingTop={paddingY}
+      paddingBottom={paddingY}
+      paddingLeft={paddingX}
+      paddingRight={paddingX}
       {...props}
     >
       {showBullet ? (
@@ -51,6 +54,7 @@ export const Status = ({ variant, showBullet, children, ...props }) => {
 
 Status.defaultProps = {
   showBullet: true,
+  size: 'M',
   variant: 'primary',
 };
 
@@ -62,6 +66,8 @@ Status.propTypes = {
    * This prop and the bullet will be removed in the next major version.
    */
   showBullet: PropTypes.bool, // TODO V2: remove prop and bullet
+
+  size: PropTypes.oneOf(['S', 'M']),
 
   /**
    * Color variation

--- a/packages/strapi-design-system/src/Status/Status.stories.mdx
+++ b/packages/strapi-design-system/src/Status/Status.stories.mdx
@@ -35,15 +35,34 @@ Use a Status sparingly within forms to give an important visual indication. Stat
 <Canvas>
   <Story name="base">
     <Stack spacing={3}>
-      <Status variant="success">
+      <Status variant="success" showBullet={false}>
         <Typography>
           Hello world <Typography fontWeight="bold">thing happens</Typography>
         </Typography>
       </Status>
-      <Status variant="secondary">
+      <Status variant="secondary" showBullet={false}>
         <Typography>
           Hello world <Typography fontWeight="bold">thing happens</Typography>
         </Typography>
+      </Status>
+    </Stack>
+  </Story>
+</Canvas>
+
+
+### Size
+
+<Canvas>
+  <Story name="size S">
+    <Stack spacing={3}>
+      <Status variant="success" size="S" showBullet={false}>
+        <Typography fontWeight="bold" textColor="success700">Published</Typography>
+      </Status>
+      <Status variant="secondary" size="S" showBullet={false}>
+        <Typography fontWeight="bold" textColor="secondary700">Draft</Typography>
+      </Status>
+      <Status variant="alternative" size="S" showBullet={false}>
+        <Typography fontWeight="bold" textColor="alternative700">Updated</Typography>
       </Status>
     </Stack>
   </Story>


### PR DESCRIPTION
### What does it do?

Adds a new `size` prop (possible values are `S` and `M`) to the `Status` component.

➡️ [Preview](https://design-system-git-enhancement-status-strapijs.vercel.app/?path=/story/design-system-components-status--size-s)

### Why is it needed?

The current UI Kit styles know two states for `Status`: the one we have (M) and small (S):

#### Medium
<img width="280" alt="Screenshot 2022-11-02 at 13 12 06" src="https://user-images.githubusercontent.com/2244375/199486841-1a5fba6e-0d2c-4444-804f-af9417deca6d.png">

#### Small
<img width="246" alt="Screenshot 2022-11-02 at 13 11 45" src="https://user-images.githubusercontent.com/2244375/199486848-0a6594cb-8820-41b8-b86d-2970147e6b19.png">

- Refs https://github.com/strapi/strapi/pull/14761
