### PR TITLE
fix: dismissible layer closing prematurely

### DIFF
--- a/packages/strapi-design-system/src/DismissibleLayer/DismissibleLayer.js
+++ b/packages/strapi-design-system/src/DismissibleLayer/DismissibleLayer.js
@@ -26,7 +26,21 @@ export const DismissibleLayer = ({ children, className, onEscapeKeyDown, onPoint
      * @type {(event: PointerEvent) => void}
      */
     const handlePointerDownOutside = (event) => {
-      if (layerRef.current && !layerRef.current.contains(event.target)) {
+      /**
+       * Because certain elements that live inside modals e.g. Selects
+       * render their dropdowns in portals the `layerRef.current.contains(event.target)` fails.
+       *
+       * Therefore we check the closest portal of the DimissibleLayer (which we're trying to close)
+       * and the event that _may_ prematurely close the layer and see if they are equal.
+       */
+      const dismissibleLayersReactPortal = layerRef.current.closest('[data-react-portal]');
+      const eventsReactPortal = event.target.closest('[data-react-portal]');
+
+      if (
+        layerRef.current &&
+        !layerRef.current.contains(event.target) &&
+        dismissibleLayersReactPortal === eventsReactPortal
+      ) {
         onPointerDownOutsideHandler();
       }
     };


### PR DESCRIPTION


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* checks the closest react-portal to avoid other portalled elements closing the layer

### Why is it needed?

* because it breaks the CMS

### Related issue(s)/PR(s)

* #752 
