### PR TITLE
BaseCheckbox: Wrap component into Box to isolate style resets

### DIFF
--- a/packages/strapi-design-system/src/BaseCheckbox/BaseCheckbox.js
+++ b/packages/strapi-design-system/src/BaseCheckbox/BaseCheckbox.js
@@ -1,7 +1,10 @@
 import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+
+import { Box } from '../Box';
 import { getCheckboxSize } from './utils';
+
 import checkmarkIcon from './assets/checkmark.svg';
 import checkmarkIconDisabled from './assets/checkmark-black.svg';
 
@@ -84,15 +87,17 @@ export const BaseCheckbox = ({ indeterminate, size, name, value, onValueChange, 
   };
 
   return (
-    <CheckboxInput
-      size={size}
-      checked={value}
-      onChange={handleValueChange}
-      type="checkbox"
-      ref={checkboxRef}
-      name={name}
-      {...inputProps}
-    />
+    <Box>
+      <CheckboxInput
+        size={size}
+        checked={value}
+        onChange={handleValueChange}
+        type="checkbox"
+        ref={checkboxRef}
+        name={name}
+        {...inputProps}
+      />
+    </Box>
   );
 };
 


### PR DESCRIPTION
### What does it do?

Wraps the component into a `div` so that styles don't interfere with parent styles.

### Why is it needed?

`CheckboxInput` overwrites `margin`. In case of the settings pages for example, this creates a problem because it would overwrite spacing defined by `Stack`:

<img width="995" alt="Screenshot 2022-11-04 at 14 43 21" src="https://user-images.githubusercontent.com/2244375/199987007-8adc80ba-90c1-45bd-b317-a1d906c72d87.png">

With this fix the `margin` reset is properly isolated:

<img width="995" alt="Screenshot 2022-11-04 at 14 45 04" src="https://user-images.githubusercontent.com/2244375/199987370-4b6c8483-e509-47d0-9eff-50397feb7da8.png">

### Related issue(s)/PR(s)

- Refs https://github.com/strapi/strapi/issues/14763
