### PR TITLE
Add: SimpleNav and SimpleNavItem components

### DIFF
--- a/packages/strapi-design-system/src/Box/Box.js
+++ b/packages/strapi-design-system/src/Box/Box.js
@@ -6,15 +6,16 @@ import { boxPropTypes, boxDefaultProps } from './BoxProps';
  * Prevents these attributes from being spread on the DOM node
  */
 const transientProps = {
+  background: true,
   color: true,
+  cursor: true,
+  display: true,
+  width: true,
 };
 
 export const Box = styled.div.withConfig({
   shouldForwardProp: (prop, defPropValFN) => !transientProps[prop] && defPropValFN(prop),
 })`
-  // Font
-  font-size: ${({ fontSize, theme }) => theme.fontSizes[fontSize] || fontSize};
-
   // Colors
   background: ${({ theme, background }) => theme.colors[background]};
   color: ${({ theme, color }) => theme.colors[color]};
@@ -33,7 +34,6 @@ export const Box = styled.div.withConfig({
   // Responsive hiding
   ${({ theme, hiddenS }) => (hiddenS ? `${theme.mediaQueries.tablet} { display: none; }` : undefined)}
   ${({ theme, hiddenXS }) => (hiddenXS ? `${theme.mediaQueries.mobile} { display: none; }` : undefined)}
-  
 
   // Borders
   border-radius: ${({ theme, hasRadius, borderRadius }) => (hasRadius ? theme.borderRadius : borderRadius)};
@@ -69,7 +69,6 @@ export const Box = styled.div.withConfig({
   bottom: ${({ bottom, theme }) => theme.spaces[bottom] || bottom};
   z-index: ${({ zIndex }) => zIndex};
   overflow: ${({ overflow }) => overflow};
-  cursor: ${({ cursor }) => cursor};
 
   // Size
   width: ${({ width, theme }) => theme.spaces[width] || width};
@@ -89,9 +88,12 @@ export const Box = styled.div.withConfig({
   flex-grow: ${({ grow }) => grow};
   flex-basis: ${({ basis }) => basis};
   flex: ${({ flex }) => flex};
+  gap: ${({ gap, theme }) => theme.spaces[gap] || gap};
 
   // Text
+  font-size: ${({ fontSize, theme }) => theme.fontSizes[fontSize] || fontSize};
   text-align: ${({ textAlign }) => textAlign};
+  text-decoration: ${({ textDecoration }) => textDecoration};
   text-transform: ${({ textTransform }) => textTransform};
   line-height: ${({ lineHeight }) => lineHeight};
 

--- a/packages/strapi-design-system/src/Box/BoxProps.js
+++ b/packages/strapi-design-system/src/Box/BoxProps.js
@@ -21,6 +21,7 @@ export const boxDefaultProps = {
   grow: undefined,
   basis: undefined,
   flex: undefined,
+  gap: undefined,
   _hover: () => undefined,
 };
 export const boxPropTypes = {
@@ -49,6 +50,10 @@ export const boxPropTypes = {
    * Flex
    */
   flex: PropTypes.oneOfType([PropTypes.string, PropTypes.string]),
+  /**
+   * Flex/Grid gap
+   */
+  gap: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /**
    * Flex grow
    */

--- a/packages/strapi-design-system/src/SimpleNav/SimpleNav.js
+++ b/packages/strapi-design-system/src/SimpleNav/SimpleNav.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Flex } from '../Flex';
+
+export const SimpleNav = (props) => {
+  return <Flex {...props} />;
+};
+
+SimpleNav.defaultProps = {
+  ...Flex.defaultProps,
+  as: 'nav',
+  display: 'flex',
+  direction: 'column',
+  alignItems: 'stretch',
+  position: 'sticky',
+  top: 4,
+  gap: 2,
+};
+
+SimpleNav.propTypes = {
+  ...Flex.propTypes,
+};

--- a/packages/strapi-design-system/src/SimpleNav/SimpleNav.stories.mdx
+++ b/packages/strapi-design-system/src/SimpleNav/SimpleNav.stories.mdx
@@ -1,0 +1,132 @@
+<!--- Nav.stories.mdx --->
+
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
+import { ArgsTable } from '@storybook/addon-docs';
+import IconAlien from '@strapi/icons/Alien';
+import IconArrowRight from '@strapi/icons/ArrowRight';
+import IconChevronRight from '@strapi/icons/ChevronRight';
+import IconExclamationMarkCircle from '@strapi/icons/ExclamationMarkCircle';
+import { NavLink } from 'react-router-dom';
+import { SimpleNav } from './SimpleNav';
+import { SimpleNavItem } from './SimpleNavItem';
+import { Box } from '../Box';
+import { Flex } from '../Flex';
+import { Typography } from '../Typography';
+
+<Meta title="Design System/Components/SimpleNav" component={SimpleNav} />
+
+# SimpleNav
+
+A list of simple-navigable components, mostly to be used as side nav.
+
+[View source](https://github.com/strapi/design-system/tree/main/packages/strapi-design-system/src/SimpleNav)
+
+## Imports
+
+```js
+import { SimpleNav, SimpleNavItem } from '@strapi/design-system/SimpleNav';
+```
+
+### Base
+
+<Canvas>
+  <Story name="base">
+    <SimpleNav aria-label="Secondary navigation">
+      <SimpleNavItem href="#">Item #1</SimpleNavItem>
+      <SimpleNavItem as={NavLink} to="/?path=/docs/design-system-components-v2-simplenav--base">
+        Item #2 - active by route
+      </SimpleNavItem>
+      <SimpleNavItem href="#" isActive>
+        Item #3 - &quot;isActive&quot;
+      </SimpleNavItem>
+      <SimpleNavItem href="#" withError>
+        Item #4 - &quot;withError&quot;
+      </SimpleNavItem>
+      <SimpleNavItem href="#" withError endIcon={<IconExclamationMarkCircle />}>
+        Item #5 - &quot;withError&quot; and &quot;endIcon&quot;
+      </SimpleNavItem>
+      <SimpleNavItem href="#" isActive withError>
+        Item #6 - &quot;withError&quot; and &quot;isActive&quot;
+      </SimpleNavItem>
+      <SimpleNavItem
+        as={NavLink}
+        to="/?path=/docs/design-system-components-v2-simplenav--base"
+        endIcon={<IconExclamationMarkCircle />}
+        withError
+      >
+        Item #7 - &quot;withError&quot;, active by route and &quot;endIcon&quot;
+      </SimpleNavItem>
+    </SimpleNav>
+  </Story>
+</Canvas>
+
+### Usage of icons
+
+Regarding `startIcon` and `endIcon` props, the `SimpleNavItem` component works similar as [Button](https://design-system-git-main-strapijs.vercel.app/?path=/docs/design-system-technical-components-button--icons) component.
+
+<Canvas>
+  <Story name="icons">
+    <SimpleNav aria-label="Tertiary navigation">
+      <Flex as="section" direction="row" gap={2}>
+        <Box as="article" id="startIcon" flex="1">
+          <Typography as="h2" variant="delta">
+            &quot;startIcon&quot;
+          </Typography>
+          <Box marginTop={2}>
+            <SimpleNav>
+              <SimpleNavItem href="#" startIcon={<IconAlien />} isActive>
+                &quot;startIcon&quot; example #1
+              </SimpleNavItem>
+              <SimpleNavItem href="#" startIcon={<IconExclamationMarkCircle />}>
+                &quot;startIcon&quot; example #2
+              </SimpleNavItem>
+            </SimpleNav>
+          </Box>
+        </Box>
+        <Box as="article" id="endIcon" flex="1">
+          <Typography as="h2" variant="delta">
+            &quot;endIcon&quot;
+          </Typography>
+          <Box marginTop={2}>
+            <SimpleNav>
+              <SimpleNavItem href="#" endIcon={<IconChevronRight />}>
+                &quot;endIcon&quot; example #1
+              </SimpleNavItem>
+              <SimpleNavItem href="#" endIcon={<IconArrowRight />} withError>
+                &quot;endIcon&quot; example #2
+              </SimpleNavItem>
+            </SimpleNav>
+          </Box>
+        </Box>
+      </Flex>
+    </SimpleNav>
+  </Story>
+</Canvas>
+
+### Usage with other routing libraries
+
+To use the Strapi design system SimpleNavItem component with a routing library (e.g. react-router-dom), you'll need to pass the react-router-dom `NavLink` component to the `as` prop in order to replace the default HTML anchor `<a>`.
+You'll now be able to pass all `NavLink` props.
+
+```jsx
+import { SimpleNav, SimpleNavItem } from '@strapi/design-system/SimpleNav';
+import { NavLink } from 'react-router-dom';
+
+<SimpleNav>
+  <SimpleNavItem as={NavLink} to="/home">
+    Home
+  </SimpleNavItem>
+</SimpleNav>;
+```
+
+## `SimpleNav` Props
+
+The `SimpleNav` component wraps all its children in the [Flex](https://design-system-git-main-strapijs.vercel.app/?path=/docs/design-system-technical-components-flex--base) component, which it's derivated from [Box](https://design-system-git-main-strapijs.vercel.app/?path=/docs/design-system-technical-components-box--base) component, so you can pass all Flex and Box props to change `SimpleNav` styles.
+
+<ArgsTable of={SimpleNav} />
+
+## `SimpleNavItem` Props
+
+The `SimpleNavItem` component wraps all its children in the [Box](https://design-system-git-main-strapijs.vercel.app/?path=/docs/design-system-technical-components-box--base) component, so you can pass all Box props to change its style.
+
+<ArgsTable of={SimpleNavItem} />

--- a/packages/strapi-design-system/src/SimpleNav/SimpleNavItem.js
+++ b/packages/strapi-design-system/src/SimpleNav/SimpleNavItem.js
@@ -1,0 +1,94 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { BaseLink } from '../BaseLink';
+import { Box } from '../Box';
+import { Flex } from '../Flex';
+import { Typography } from '../Typography';
+import { buttonFocusStyle } from '../themes/utils';
+
+const SimpleNavItemWrapper = styled(Box)`
+  text-decoration: none;
+  background: ${({ background, theme }) => theme.colors[background] || background};
+  color: ${({ textColor, theme, withError }) => theme.colors[withError ? 'danger600' : textColor]};
+
+  &.active,
+  &:active,
+  &[aria-current='page'] {
+    background: ${({ theme, withError }) => theme.colors[withError ? 'danger100' : 'primary100']};
+    color: ${({ theme, withError }) => theme.colors[withError ? 'danger600' : 'primary700']};
+  }
+
+  &:not(.active):not(:active):not([aria-current='page']) {
+    &:hover {
+      background: ${({ theme, withError }) => theme.colors[withError ? 'danger100' : 'neutral150']};
+      color: ${({ theme, withError }) => theme.colors[withError ? 'danger600' : 'neutral800']};
+    }
+  }
+
+  svg,
+  svg * {
+    fill: currentColor;
+  }
+
+  ${buttonFocusStyle}
+`;
+
+const SimpleNavItemIconWrapper = (props) => <Flex as="span" alignItems="center" aria-hidden="true" {...props} />;
+
+export const SimpleNavItem = ({
+  children,
+  className,
+  endIcon,
+  gap,
+  isActive,
+  startIcon,
+  textVariant,
+  withError,
+  ...rest
+}) => {
+  return (
+    <SimpleNavItemWrapper className={`${className}${!isActive ? '' : ' active'}`} withError={withError} {...rest}>
+      <Typography variant={textVariant} textColor="currentColor">
+        <Flex as="span" display="flex" alignItems="center" justifyContent="space-around" gap={gap} width="100%">
+          {startIcon && <SimpleNavItemIconWrapper>{startIcon}</SimpleNavItemIconWrapper>}
+          <Flex as="span" flex="1 auto">
+            {children}
+          </Flex>
+          {endIcon && <SimpleNavItemIconWrapper>{endIcon}</SimpleNavItemIconWrapper>}
+        </Flex>
+      </Typography>
+    </SimpleNavItemWrapper>
+  );
+};
+
+SimpleNavItem.defaultProps = {
+  ...Box.defaultProps,
+  as: BaseLink,
+  endIcon: undefined,
+  background: 'transparent',
+  cursor: 'pointer',
+  flex: '1 1 0%',
+  gap: 2,
+  hasRadius: true,
+  isActive: false,
+  kind: undefined,
+  paddingTop: 2,
+  paddingRight: 4,
+  paddingBottom: 2,
+  paddingLeft: 4,
+  startIcon: undefined,
+  textColor: 'neutral600',
+  textVariant: 'omega',
+  transition: 'all 0.2s linear',
+  withError: false,
+};
+
+SimpleNavItem.propTypes = {
+  ...Box.propTypes,
+  endIcon: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
+  isActive: PropTypes.bool,
+  kind: PropTypes.oneOf(['active', 'error']),
+  startIcon: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
+  withError: PropTypes.bool,
+};

--- a/packages/strapi-design-system/src/SimpleNav/__tests__/SimpleNav.e2e.js
+++ b/packages/strapi-design-system/src/SimpleNav/__tests__/SimpleNav.e2e.js
@@ -1,0 +1,23 @@
+import { injectAxe, checkA11y } from 'axe-playwright';
+
+import { test } from '@playwright/test';
+
+test.describe.parallel('SimpleNav', () => {
+  test.describe('light mode', () => {
+    test('triggers axe on the document', async ({ page }) => {
+      // This is the URL of the Storybook Iframe
+      await page.goto('/iframe.html?id=design-system-components-simplenav--base&viewMode=story');
+      await injectAxe(page);
+      await checkA11y(page);
+    });
+  });
+
+  test.describe('dark mode', () => {
+    test('triggers axe on the document', async ({ page }) => {
+      // This is the URL of the Storybook Iframe
+      await page.goto('/iframe.html?id=design-system-components-simplenav--base&viewMode=story&theme=dark');
+      await injectAxe(page);
+      await checkA11y(page);
+    });
+  });
+});

--- a/packages/strapi-design-system/src/SimpleNav/index.js
+++ b/packages/strapi-design-system/src/SimpleNav/index.js
@@ -1,0 +1,2 @@
+export * from './SimpleNav';
+export * from './SimpleNavItem';

--- a/packages/strapi-design-system/src/index.js
+++ b/packages/strapi-design-system/src/index.js
@@ -43,6 +43,7 @@ export * from './Flex';
 export * from './Searchbar';
 export * from './Select';
 export * from './SimpleMenu';
+export * from './SimpleNav';
 export * from './Stack';
 export * from './Status';
 export * from './SubNav';


### PR DESCRIPTION
## What does it do?

### Feature
Adds two new components for simple navigation:
- `SimpleNav`, derivated from `Flex` and `Box`
- `SimpleNavItem`, derivated from `Box` as `BaseLink`

### Chore
Few modifications on `Box` component styling props:
- Accepts one more possible-prop `gap` 
- Re-group the `fontSize` prop with the Text properties
- Removes `cursor` duplicate from styles

## Why is it needed?
Will help on Strapi Cloud Dashboard.

### Considerations
Strapi Design System already have similar components, like `MainNav` and it's scope components.
But the existents ones of `MainNav` are little different from the designed to Strapi Cloud Dashboard.
Those differences maybe could be worked to `MainNav`, but I assume that is risky considering the Strapi CMS Dashboard.
Then I decided to add this one here in behalf of not `MainNav` not having an "error" state, which it's necessary on Strapi Cloud.

## Related issue(s)/PR(s)
Strapi Cloud it's a private repository, but will be used on Project Settings page as sidebar navigation and that will be available for our community and customers soon.

## Preview
| ~ | ~ |
| --- | --- |
| <img width="612" alt="Screenshot 2022-11-06 at 10 06 54 PM" src="https://user-images.githubusercontent.com/4141420/200206761-a8de0074-2f24-4aab-9361-f62debdbc85e.png"> | <img width="612" alt="Screenshot 2022-11-06 at 10 07 17 PM" src="https://user-images.githubusercontent.com/4141420/200206774-f6e3386f-7661-4493-ac95-5b360c43d022.png"> |

