### PR TITLE
Button: Unify component height with the UI Kit

### DIFF
--- a/packages/strapi-design-system/src/Button/Button.js
+++ b/packages/strapi-design-system/src/Button/Button.js
@@ -27,19 +27,33 @@ const BoxFullHeight = styled(Box)`
   height: 100%;
 `;
 
-// TODO: Check the L size button with Maeva
 export const ButtonWrapper = styled(BaseButton)`
   align-items: center;
-  padding: ${({ theme, size }) => `${size === 'S' ? theme.spaces[2] : '10px'} ${theme.spaces[4]}`};
-  background: ${({ theme }) => theme.colors.buttonPrimary600};
+  background-color: ${({ theme }) => theme.colors.buttonPrimary600};
   border: 1px solid ${({ theme }) => theme.colors.buttonPrimary600};
+  height: ${({ size }) => {
+    let height = 32;
+
+    if (size === 'M') {
+      height = 36;
+    } else if (size === 'L') {
+      height = 40;
+    }
+
+    return `${height / 16}rem`;
+  }};
+  padding-left: ${({ theme }) => theme.spaces[4]};
+  padding-right: ${({ theme }) => theme.spaces[4]};
+
   ${Box} {
     display: flex;
     align-items: center;
   }
+
   ${Typography} {
     color: ${({ theme }) => theme.colors.buttonNeutral0};
   }
+
   &[aria-disabled='true'] {
     ${getDisabledStyle}
     &:active {
@@ -95,13 +109,9 @@ export const Button = React.forwardRef(
           </BoxFullHeight>
         )}
 
-        {size === 'S' ? (
-          <Typography variant="pi" fontWeight="bold">
-            {children}
-          </Typography>
-        ) : (
-          <Typography fontWeight="bold">{children}</Typography>
-        )}
+        <Typography variant={size === 'S' ? 'pi' : undefined} fontWeight="bold" lineHeight={0}>
+          {children}
+        </Typography>
 
         {endIcon && (
           <Box aria-hidden={true} paddingLeft={2}>

--- a/packages/strapi-design-system/src/Button/Button.js
+++ b/packages/strapi-design-system/src/Button/Button.js
@@ -31,17 +31,7 @@ export const ButtonWrapper = styled(BaseButton)`
   align-items: center;
   background-color: ${({ theme }) => theme.colors.buttonPrimary600};
   border: 1px solid ${({ theme }) => theme.colors.buttonPrimary600};
-  height: ${({ size }) => {
-    let height = 32;
-
-    if (size === 'M') {
-      height = 36;
-    } else if (size === 'L') {
-      height = 40;
-    }
-
-    return `${height / 16}rem`;
-  }};
+  height: ${({ theme, size }) => theme.sizes.button[size]};
   padding-left: ${({ theme }) => theme.spaces[4]};
   padding-right: ${({ theme }) => theme.spaces[4]};
 
@@ -135,6 +125,7 @@ Button.defaultProps = {
   startIcon: undefined,
   variant: 'default',
 };
+
 Button.propTypes = {
   children: PropTypes.node.isRequired,
   disabled: PropTypes.bool,

--- a/packages/strapi-design-system/src/Button/Button.stories.mdx
+++ b/packages/strapi-design-system/src/Button/Button.stories.mdx
@@ -38,9 +38,7 @@ The most common button component used in the interface (primary action). It can 
 
 <Canvas withSource="open">
   <Story name="base" parameters={{ docs: { source: { code: '<Button>Default button</Button>' } } }}>
-    <Box paddingBottom={2}>
-      <Button variant="default">Default</Button>
-    </Box>
+    <Button variant="default">Default</Button>
   </Story>
 </Canvas>
 
@@ -64,12 +62,11 @@ Use the size prop to change the size of the button. You can set the value to `S`
       },
     }}
   >
-    <Flex>
-      <Box paddingRight={1}>
-        <Button size="S">Small</Button>
-      </Box>
+    <Stack spacing={1} horizontal>
+      <Button size="S">Small</Button>
+      <Button size="M">Medium</Button>
       <Button size="L">Large</Button>
-    </Flex>
+    </Stack>
   </Story>
 </Canvas>
 

--- a/packages/strapi-design-system/src/Button/Button.stories.mdx
+++ b/packages/strapi-design-system/src/Button/Button.stories.mdx
@@ -7,7 +7,6 @@ import Plus from '@strapi/icons/Plus';
 import Write from '@strapi/icons/Write';
 import { Button } from './Button';
 import { Box } from '../Box';
-import { Flex } from '../Flex';
 import { Stack } from '../Stack';
 
 <Meta title="Design System/Components/Button" component={Button} />

--- a/packages/strapi-design-system/src/Button/constants.js
+++ b/packages/strapi-design-system/src/Button/constants.js
@@ -9,4 +9,4 @@ export const GHOST = 'ghost';
 
 export const LIGHT_VARIANTS = [SUCCESS_LIGHT, DANGER_LIGHT];
 export const VARIANTS = [DEFAULT, TERTIARY, SECONDARY, DANGER, SUCCESS, GHOST, ...LIGHT_VARIANTS];
-export const BUTTON_SIZES = ['S', 'L'];
+export const BUTTON_SIZES = ['S', 'M', 'L'];

--- a/packages/strapi-design-system/src/ModalLayout/__tests__/ModalLayout.spec.js
+++ b/packages/strapi-design-system/src/ModalLayout/__tests__/ModalLayout.spec.js
@@ -44,6 +44,7 @@ describe('ModalLayout', () => {
 
       .c17 {
         font-weight: 600;
+        line-height: 1.14;
         color: #32324d;
         font-size: 0.75rem;
         line-height: 1.33;
@@ -130,9 +131,11 @@ describe('ModalLayout', () => {
         -webkit-box-align: center;
         -ms-flex-align: center;
         align-items: center;
-        padding: 8px 16px;
-        background: #4945ff;
+        background-color: #4945ff;
         border: 1px solid #4945ff;
+        height: 2rem;
+        padding-left: 16px;
+        padding-right: 16px;
         border: 1px solid #dcdce4;
         background: #ffffff;
       }
@@ -200,9 +203,11 @@ describe('ModalLayout', () => {
         -webkit-box-align: center;
         -ms-flex-align: center;
         align-items: center;
-        padding: 8px 16px;
-        background: #4945ff;
+        background-color: #4945ff;
         border: 1px solid #4945ff;
+        height: 2rem;
+        padding-left: 16px;
+        padding-right: 16px;
         border: 1px solid #d9d8ff;
         background: #f0f0ff;
       }
@@ -280,9 +285,11 @@ describe('ModalLayout', () => {
         -webkit-box-align: center;
         -ms-flex-align: center;
         align-items: center;
-        padding: 8px 16px;
-        background: #4945ff;
+        background-color: #4945ff;
         border: 1px solid #4945ff;
+        height: 2rem;
+        padding-left: 16px;
+        padding-right: 16px;
       }
 
       .c19 .c2 {

--- a/packages/strapi-design-system/src/themes/sizes.js
+++ b/packages/strapi-design-system/src/themes/sizes.js
@@ -7,4 +7,9 @@ export const sizes = {
     S: `${48 / 16}rem`,
     M: `${88 / 16}rem`,
   },
+  button: {
+    S: `${32 / 16}rem`,
+    M: `${36 / 16}rem`,
+    L: `${40 / 16}rem`,
+  },
 };


### PR DESCRIPTION
### What does it do?

Updates the buttons to use the heights defined in the [UI Kit](https://www.figma.com/file/PICiE8O4NLrHO1lhJftLdE/Strapi---UI-Kit-%F0%9F%A7%A9?node-id=9974%3A117504):

- `S`: 32px
- `M`: 36px
- `L`: 40px

### Why is it needed?

1. Currently the different sizes look messed up:

| Before | After |
|-|-|
| <img width="316" alt="Screenshot 2022-11-08 at 17 05 29" src="https://user-images.githubusercontent.com/2244375/200616417-44974f91-6de2-433c-855f-066b985f322e.png"> | <img width="316" alt="Screenshot 2022-11-08 at 17 20 57" src="https://user-images.githubusercontent.com/2244375/200619343-78db43ea-6807-404f-88f9-d0eecc3318b4.png"> |

➡️ [Preview](https://design-system-git-fix-button-height-strapijs.vercel.app/?path=/story/design-system-components-button--sizes)

I did my best to compose the height out of `line-height` and `padding` but neither combination worked and we always ended up using sub-pixel values. Therefore I've decided to make the heights fixed, which follows what has been done in `IconButton`.

2. The height of the `IconButton` doesn't align with the `Button[size=S]`: we have to shown `IconButton` in a row with `Buttons` and therefore they should have the same height.

### How to test it?

 Preview: https://design-system-git-fix-button-height-strapijs.vercel.app/?path=/story/design-system-components-button--sizes

