### PR TITLE
[fix][IconButton]: use `icon` if it's passed over children

### DIFF
--- a/packages/strapi-design-system/src/IconButton/IconButton.js
+++ b/packages/strapi-design-system/src/IconButton/IconButton.js
@@ -110,7 +110,7 @@ export const IconButton = React.forwardRef(
       return (
         <IconButtonWrapper {...restProps} ref={ref} noBorder={noBorder} onClick={handleClick} aria-disabled={disabled}>
           <VisuallyHidden as="span">{ariaLabel}</VisuallyHidden>
-          {cloneElement(children ?? icon, {
+          {cloneElement(icon ? icon : children, {
             'aria-hidden': true,
             focusable: false, // See: https://allyjs.io/tutorials/focusing-in-svg.html#making-svg-elements-focusable
           })}
@@ -122,7 +122,7 @@ export const IconButton = React.forwardRef(
       <Tooltip label={label}>
         <IconButtonWrapper {...restProps} ref={ref} noBorder={noBorder} onClick={handleClick} aria-disabled={disabled}>
           <VisuallyHidden as="span">{label}</VisuallyHidden>
-          {cloneElement(children ?? icon, {
+          {cloneElement(icon ? icon : children, {
             'aria-hidden': true,
             focusable: false, // See: https://allyjs.io/tutorials/focusing-in-svg.html#making-svg-elements-focusable
           })}


### PR DESCRIPTION


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* if `icon` is present we use that over `children`

### Why is it needed?

* for backwards compatibility 

### Related issue(s)/PR(s)

* raised internally
