### PR TITLE
ProgressBar: Refactor component to use Box as base

### DIFF
--- a/packages/strapi-design-system/src/ProgressBar/ProgressBar.js
+++ b/packages/strapi-design-system/src/ProgressBar/ProgressBar.js
@@ -2,43 +2,37 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-const ProgressBarSmall = styled.div`
-  background: ${({ theme }) => theme.colors.neutral600};
-  border-radius: ${({ theme }) => theme.borderRadius};
-  position: relative;
+import { Box } from '../Box';
 
-  width: 78px;
-  height: ${({ theme }) => theme.spaces[1]};
-
+const ProgressbarBase = styled(Box)`
   &:before {
+    background-color: ${({ theme }) => theme.colors.neutral0};
+    border-radius: ${({ theme }) => theme.borderRadius};
+    bottom: 0;
     content: '';
     position: absolute;
     top: 0;
-    bottom: 0;
-    border-radius: ${({ theme }) => theme.borderRadius};
     width: ${({ value }) => `${value}%`};
-    background: ${({ theme }) => theme.colors.neutral150};
   }
-`;
-
-const ProgressBarMedium = styled(ProgressBarSmall)`
-  width: 102px;
-  height: ${({ theme }) => theme.spaces[2]};
 `;
 
 export const ProgressBar = ({ min, max, value, children, size, ...props }) => {
-  const sharedProps = {
-    role: 'progressbar',
-    'aria-valuenow': value,
-    'aria-valuemin': min,
-    'aria-valuemax': max,
-  };
-
-  if (size === 'M') {
-    return <ProgressBarMedium {...sharedProps} value={value} aria-label={children} {...props} />;
-  }
-
-  return <ProgressBarSmall {...sharedProps} value={value} aria-label={children} {...props} />;
+  return (
+    <ProgressbarBase
+      background="neutral600"
+      hasRadius
+      aria-label={children}
+      aria-valuemax={max}
+      aria-valuemin={min}
+      aria-valuenow={value}
+      height={size === 'S' ? 1 : 2}
+      position="relative"
+      role="progressbar"
+      value={value}
+      width={size === 'S' ? '78px' : '102px'}
+      {...props}
+    />
+  );
 };
 
 ProgressBar.defaultProps = {

--- a/packages/strapi-design-system/src/ProgressBar/ProgressBar.stories.mdx
+++ b/packages/strapi-design-system/src/ProgressBar/ProgressBar.stories.mdx
@@ -36,8 +36,8 @@ The "S" progressbar
 
 <Canvas>
   <Story name="S">
-    <ProgressBar value={100} size="S">
-      100/200 plugins loaded
+    <ProgressBar value={90} size="S">
+      90/100 plugins loaded
     </ProgressBar>
   </Story>
 </Canvas>

--- a/packages/strapi-design-system/src/ProgressBar/ProgressBar.stories.mdx
+++ b/packages/strapi-design-system/src/ProgressBar/ProgressBar.stories.mdx
@@ -2,6 +2,7 @@
 
 import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { ArgsTable } from '@storybook/addon-docs';
+import { Box } from '../Box';
 import { ProgressBar } from './ProgressBar';
 
 <Meta title="Design System/Components/ProgressBar" component={ProgressBar} />
@@ -26,7 +27,9 @@ Default "M" progressbar
 
 <Canvas>
   <Story name="M">
-    <ProgressBar value={33}>33/100 plugins loaded</ProgressBar>
+    <Box background="neutral150" padding={2}>
+      <ProgressBar value={33}>33/100 plugins loaded</ProgressBar>
+    </Box>
   </Story>
 </Canvas>
 
@@ -36,9 +39,11 @@ The "S" progressbar
 
 <Canvas>
   <Story name="S">
-    <ProgressBar value={90} size="S">
-      90/100 plugins loaded
-    </ProgressBar>
+    <Box background="neutral150" padding={2}>
+      <ProgressBar value={90} size="S">
+        90/100 plugins loaded
+      </ProgressBar>
+    </Box>
   </Story>
 </Canvas>
 


### PR DESCRIPTION
### What does it do?

- Refactors the component to use `Box` as base component
- Update progress-color from `neutral150` to `neutral0`

➡️ [Preview](https://design-system-git-enhancement-progressbar-strapijs.vercel.app/?path=/story/design-system-components-progressbar--m)

### Why is it needed?

- Follow the UI Kit

### Related issue(s)/PR(s)

- https://strapi-inc.atlassian.net/browse/CONTENT-220
