### PR TITLE
Badge: Update colors and height according to the UI kit

### DIFF
--- a/packages/strapi-design-system/src/Badge/Badge.js
+++ b/packages/strapi-design-system/src/Badge/Badge.js
@@ -6,20 +6,23 @@ import { Flex } from '../Flex';
 import { Typography } from '../Typography';
 
 const Base = styled(Flex)`
-  border-radius: 2px;
-  height: ${16 / 16}rem;
+  border-radius: ${({ theme, size }) => (size === 'S' ? '2px' : theme.borderRadius)};
+  height: ${({ size, theme }) => theme.sizes.badge[size]};
 `;
 
-export const Badge = ({ active, textColor, backgroundColor, children, minWidth, ...props }) => {
+export const Badge = ({ active, size, textColor, backgroundColor, children, minWidth, ...props }) => {
+  const paddingX = size === 'S' ? 1 : 2;
+
   return (
     <Base
       inline
       alignItem="center"
       justifyContent="center"
       minWidth={minWidth}
-      paddingLeft={1}
-      paddingRight={1}
+      paddingLeft={paddingX}
+      paddingRight={paddingX}
       background={active ? 'primary200' : backgroundColor}
+      size={size}
       {...props}
     >
       <Typography variant="sigma" textColor={active ? 'primary600' : textColor}>
@@ -33,6 +36,7 @@ Badge.defaultProps = {
   active: false,
   backgroundColor: 'neutral150',
   minWidth: 5,
+  size: 'M',
   textColor: 'neutral600',
 };
 
@@ -44,5 +48,6 @@ Badge.propTypes = {
   backgroundColor: PropTypes.string,
   children: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
   minWidth: PropTypes.number,
+  size: PropTypes.oneOf(['S', 'M']),
   textColor: PropTypes.string,
 };

--- a/packages/strapi-design-system/src/Badge/Badge.js
+++ b/packages/strapi-design-system/src/Badge/Badge.js
@@ -1,37 +1,44 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
 import { Flex } from '../Flex';
 import { Typography } from '../Typography';
 
+const Base = styled(Flex)`
+  border-radius: 2px;
+  height: ${16 / 16}rem;
+`;
+
 export const Badge = ({ active, textColor, backgroundColor, children, minWidth, ...props }) => {
   return (
-    <Flex
+    <Base
       inline
       alignItem="center"
       justifyContent="center"
       minWidth={minWidth}
-      padding={1}
-      background={active ? 'primary100' : backgroundColor}
-      hasRadius
+      paddingLeft={1}
+      paddingRight={1}
+      background={active ? 'primary200' : backgroundColor}
       {...props}
     >
       <Typography variant="sigma" textColor={active ? 'primary600' : textColor}>
         {children}
       </Typography>
-    </Flex>
+    </Base>
   );
 };
 
 Badge.defaultProps = {
   active: false,
-  backgroundColor: 'neutral100',
+  backgroundColor: 'neutral150',
   minWidth: 5,
   textColor: 'neutral600',
 };
 
 Badge.propTypes = {
   /**
-   * If `true`, it changes the `backgroundColor` to `primary100` and the `textColor` to `primary600`
+   * If `true`, it changes the `backgroundColor` to `primary200` and the `textColor` to `primary600`
    */
   active: PropTypes.bool,
   backgroundColor: PropTypes.string,

--- a/packages/strapi-design-system/src/Badge/Badge.stories.mdx
+++ b/packages/strapi-design-system/src/Badge/Badge.stories.mdx
@@ -33,21 +33,39 @@ Badges are used to give a quick and short scannable information to the users. Th
 <Canvas>
   <Story name="base">
     <Stack spacing={2}>
-      <div>
-        <Badge>Doc</Badge>
-      </div>
-      <div>
-        <Badge>1</Badge>
-      </div>
-      <div>
-        <Badge>5</Badge>
-      </div>
-      <div>
-        <Badge>Video</Badge>
-      </div>
-      <div>
-        <Badge active>Image</Badge>
-      </div>
+      <Stack horizontal spacing={1}>
+        <Badge>Badge</Badge>
+      </Stack>
+    </Stack>
+  </Story>
+</Canvas>
+
+## Active
+
+Badges can be displayed as active:
+
+<Canvas>
+  <Story name="active">
+    <Stack spacing={2}>
+      <Stack horizontal spacing={1}>
+        <Badge size="S" active>Small Badge</Badge>
+        <Badge size="M" active>Medium Badge</Badge>
+      </Stack>
+    </Stack>
+  </Story>
+</Canvas>
+
+## Size
+
+Badges can be displayed in two sizes: S and M:
+
+<Canvas>
+  <Story name="size">
+    <Stack spacing={2}>
+      <Stack horizontal spacing={1}>
+        <Badge size="S">Small Badge</Badge>
+        <Badge size="M">Medium Badge</Badge>
+      </Stack>
     </Stack>
   </Story>
 </Canvas>

--- a/packages/strapi-design-system/src/themes/sizes.js
+++ b/packages/strapi-design-system/src/themes/sizes.js
@@ -7,6 +7,10 @@ export const sizes = {
     S: `${48 / 16}rem`,
     M: `${88 / 16}rem`,
   },
+  badge: {
+    S: `${16 / 16}rem`,
+    M: `${24 / 16}rem`,
+  },
   button: {
     S: `${32 / 16}rem`,
     M: `${36 / 16}rem`,


### PR DESCRIPTION
### What does it do?

- Updates the height of the `Badge` to match the UI Kit

| Before | After |
|-|-|
| <img width="89" alt="Screenshot 2022-11-14 at 12 08 29" src="https://user-images.githubusercontent.com/2244375/201645342-0ff30c6f-1f9f-4d69-9018-9ba82f4b3dd0.png"> | <img width="89" alt="Screenshot 2022-11-14 at 12 08 35" src="https://user-images.githubusercontent.com/2244375/201645350-349e10d4-68d6-4c5d-b7b4-c92f7dcd28d2.png"> |

- Updates the colors
- Updates the `border-radius` from `4px` to `2px`

### Why is it needed?

Match the UI Kit

### Related issue(s)/PR(s)

- https://strapi-inc.atlassian.net/browse/CONTENT-220
