### PR TITLE
[Fix] Remove alt as required in Avatar

### DIFF
--- a/packages/strapi-design-system/src/Avatar/Avatar.js
+++ b/packages/strapi-design-system/src/Avatar/Avatar.js
@@ -91,6 +91,7 @@ Initials.propTypes = {
 };
 
 Avatar.defaultProps = {
+  alt: undefined,
   preview: undefined,
 };
 
@@ -98,7 +99,7 @@ Avatar.propTypes = {
   /**
    * Alternative text
    */
-  alt: PropTypes.string.isRequired,
+  alt: PropTypes.string,
   /**
    * Image src of the image preview (displayed on `Avatar` hover).
    */


### PR DESCRIPTION
## What

Removing `required` for `alt` prop in Avatar component - decided after an alt fallback [discussion](https://github.com/strapi/strapi/pull/14880)
> Screenreaders will automatically read the filename if no alt attribute is provided.