### PR TITLE
chore: Improve SimpleMenu component

### DIFF
--- a/packages/strapi-design-system/src/SimpleMenu/SimpleMenu.js
+++ b/packages/strapi-design-system/src/SimpleMenu/SimpleMenu.js
@@ -98,6 +98,7 @@ export const SimpleMenu = ({
   onClose = () => {},
   size,
   popoverPlacement,
+  onReachEnd,
   ...props
 }) => {
   const menuButtonRef = useRef();
@@ -108,6 +109,7 @@ export const SimpleMenu = ({
   const childrenArray = Children.toArray(children);
   const DefaultComponent = size === 'S' ? StyledButtonSmall : Button;
   const Component = asComp || DefaultComponent;
+  const shouldHandleReachEnd = !!onReachEnd && typeof onReachEnd === 'function';
 
   useEffect(() => {
     if (['string', 'number'].includes(typeof label)) {
@@ -177,6 +179,12 @@ export const SimpleMenu = ({
     setVisible((prevVisible) => !prevVisible);
   };
 
+  const handleReachEnd = () => {
+    if (shouldHandleReachEnd) {
+      onReachEnd();
+    }
+  };
+
   const childrenClone = childrenArray.map((child, index) => (
     <Flex as="li" key={index} justifyContent="center" role="menuitem">
       {cloneElement(child, {
@@ -212,7 +220,14 @@ export const SimpleMenu = ({
         {label}
       </Component>
       {visible && (
-        <Popover onBlur={handleBlur} placement={popoverPlacement} source={menuButtonRef} spacing={4}>
+        <Popover
+          onBlur={handleBlur}
+          placement={popoverPlacement}
+          source={menuButtonRef}
+          onReachEnd={handleReachEnd}
+          intersectionId={shouldHandleReachEnd ? `popover-${menuId}` : undefined}
+          spacing={4}
+        >
           <Box role="menu" as="ul" padding={1} id={menuId}>
             {childrenClone}
           </Box>
@@ -240,8 +255,11 @@ SimpleMenu.propTypes = {
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.element]).isRequired,
   onClose: PropTypes.func,
   onOpen: PropTypes.func,
+  /**
+   * Callback function to be called when the popover reaches the end of the scrollable content
+   */
+  onReachEnd: PropTypes.func,
   popoverPlacement: PropTypes.oneOf(POPOVER_PLACEMENTS),
-
   /**
    * Size of the trigger button.
    * Note: in case a custom component is passed through the "as"


### PR DESCRIPTION
### What does it do?

Add the prop `onReachEnd` to the SimpleMenu popover

### Why is it needed?

Needed to append additional items when items are retrieved from a server.

### How to test it?

consume the prop from any `<SimpleMenu />` component in storybook

```
<SimpleMenu id="label" label={val} onReachEnd={() => console.log('END')}>
```

if enough items there should be a log in the console