### PR TITLE
[imports]: don't use duplicate imports as the application breaks

### DIFF
--- a/packages/strapi-design-system/src/index.js
+++ b/packages/strapi-design-system/src/index.js
@@ -1,6 +1,3 @@
-/* eslint-disable import/export */
-// TODO: the import error will be fixed in a different PR
-
 export * from './Accordion';
 export * from './Alert';
 export * from './Avatar';
@@ -8,7 +5,7 @@ export * from './Badge';
 export * from './BaseButton';
 export * from './BaseCheckbox';
 export * from './BaseLink';
-export * from './BaseRadio';
+export { BaseRadio } from './BaseRadio';
 export * from './Box';
 export * from './Breadcrumbs';
 export * from './Button';
@@ -63,5 +60,4 @@ export * from './ToggleInput';
 export * from './Tooltip';
 export * from './Typography';
 export * from './VisuallyHidden';
-export * from './v2';
 export * from './themes';


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* Removes `v2` from the exports list
* Doesn't export RadioGroup twice as well

### Why is it needed?

* As discussed in the DS sync we're removing the `v2` exports from the `index` as it breaks the package, they'll only be exported from `@strapi/design-system/v2`

### Related issue(s)/PR(s)

* resolves #781 
