### PR TITLE
Restore theme storybook

### DIFF
--- a/packages/strapi-design-system/src/themes/Theme.stories.mdx
+++ b/packages/strapi-design-system/src/themes/Theme.stories.mdx
@@ -72,7 +72,6 @@ This is the dark colors used for the dark mode
       let ruptureKey;
       for (const colorKey of Object.keys(color)) {
         const prefix = colorKey.substr(0, 2);
-
         if (ruptureKey !== prefix) {
           colors.push([]);
           ruptureKey = prefix;
@@ -171,7 +170,6 @@ Navigation, Action, Notification, and illustrations.
           if (!value) {
             return true;
           }
-
           return icon.toLowerCase().includes(value.toLowerCase());
         })
         .sort();


### PR DESCRIPTION
### What does it do?

Fix the issue we have with the Theme storybook

### Why is it needed?

Because we can't see the theme storybook

### How to test it?

check https://design-system-aw9pd8kew-strapijs.vercel.app/?path=/story/design-system-components-theme--light-colors

