### PR TITLE
[fix] DateTimePicker and Select accessibility

### DIFF
--- a/packages/strapi-design-system/src/DatePicker/DatePicker.js
+++ b/packages/strapi-design-system/src/DatePicker/DatePicker.js
@@ -12,6 +12,7 @@ import { getDefaultLocale } from '../helpers/getDefaultLocale';
 
 export const DatePicker = ({
   ariaLabel,
+  parentFieldId,
   initialDate,
   selectedDate,
   onChange,
@@ -24,7 +25,10 @@ export const DatePicker = ({
   id,
   ...props
 }) => {
-  const generatedId = useId('datepicker', id);
+  const internalGeneratedId = useId('datepicker', id);
+  // when used in a DateTimePicker, we want DatePicker input to use DateTimePicker id
+  // it allows accessibility feature as focusing the input when clicking on the label
+  const generatedId = parentFieldId ?? internalGeneratedId;
   const [visible, setVisible] = useState(false);
   const inputRef = useRef(null);
   const datePickerButtonRef = useRef(null);
@@ -109,6 +113,7 @@ DatePicker.defaultProps = {
   locale: undefined,
   initialDate: new Date(),
   onClear: undefined,
+  parentFieldId: undefined,
   placeholder: undefined,
   selectedDate: undefined,
   size: 'M',
@@ -124,6 +129,7 @@ DatePicker.propTypes = {
   locale: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   onClear: PropTypes.func,
+  parentFieldId: PropTypes.string,
   placeholder: PropTypes.string,
   selectedDate: PropTypes.instanceOf(Date),
   selectedDateLabel: PropTypes.func.isRequired,

--- a/packages/strapi-design-system/src/DateTimePicker/DateTimePicker.js
+++ b/packages/strapi-design-system/src/DateTimePicker/DateTimePicker.js
@@ -118,6 +118,8 @@ export const DateTimePicker = ({
         <Stack horizontal spacing={2}>
           <DatePicker
             data-testid="datetimepicker-date"
+            // DateTimePicker sharing its Field id to DatePicker component
+            parentFieldId={generatedId}
             name={name}
             ariaLabel={label || ariaLabel}
             error={typeof error === 'string'}

--- a/packages/strapi-design-system/src/DateTimePicker/__tests__/__snapshots__/DateTimePicker.spec.js.snap
+++ b/packages/strapi-design-system/src/DateTimePicker/__tests__/__snapshots__/DateTimePicker.spec.js.snap
@@ -339,7 +339,7 @@ exports[`DateTimePicker snapshots the component 1`] = `
                   aria-required="false"
                   class="c9"
                   data-testid="datetimepicker-date"
-                  id="datepicker-3"
+                  id="datetime-label-1"
                   name="datetimepicker"
                   value="10/13/2021"
                 />
@@ -360,7 +360,7 @@ exports[`DateTimePicker snapshots the component 1`] = `
               aria-expanded="false"
               aria-haspopup="listbox"
               aria-label="Date time picker"
-              aria-labelledby="timepicker-4-label timepicker-4-content"
+              aria-labelledby="timepicker-4 timepicker-4-label timepicker-4-content"
               class="c12"
               data-testid="datetimepicker-time"
               id="timepicker-4"

--- a/packages/strapi-design-system/src/Select/Select.js
+++ b/packages/strapi-design-system/src/Select/Select.js
@@ -162,16 +162,12 @@ export const Select = ({
   return (
     <Field hint={hint} error={error} id={generatedId} required={required}>
       <Stack spacing={label || hint || hasStringError ? 1 : 0}>
-        {label && (
-          <FieldLabel as="span" action={labelAction}>
-            {label}
-          </FieldLabel>
-        )}
+        {label && <FieldLabel action={labelAction}>{label}</FieldLabel>}
 
         <SelectButtonWrapper size={size} hasError={Boolean(error)} disabled={disabled} ref={containerRef}>
           <SelectButton
             ref={buttonRef}
-            labelledBy={`${labelId} ${contentId}`}
+            labelledBy={`${generatedId} ${labelId} ${contentId}`}
             aria-describedby={ariaDescribedBy}
             expanded={Boolean(expanded)}
             onTrigger={setExpanded}

--- a/packages/strapi-design-system/src/Select/__tests__/Select.spec.js
+++ b/packages/strapi-design-system/src/Select/__tests__/Select.spec.js
@@ -282,7 +282,7 @@ describe('Select', () => {
             class="c0 c1"
             spacing="1"
           >
-            <span
+            <label
               class="c2"
               for="select-1"
             >
@@ -291,7 +291,7 @@ describe('Select', () => {
               >
                 Choose your meal
               </div>
-            </span>
+            </label>
             <div
               class="c3 c4"
             >
@@ -300,7 +300,7 @@ describe('Select', () => {
                 aria-disabled="false"
                 aria-expanded="true"
                 aria-haspopup="listbox"
-                aria-labelledby="select-1-label select-1-content"
+                aria-labelledby="select-1 select-1-label select-1-content"
                 class="c5"
                 id="select-1"
                 type="button"
@@ -775,7 +775,7 @@ describe('Select', () => {
             class="c0 c1"
             spacing="1"
           >
-            <span
+            <label
               class="c2"
               for="select-3"
             >
@@ -784,7 +784,7 @@ describe('Select', () => {
               >
                 Choose your meal
               </div>
-            </span>
+            </label>
             <div
               class="c3 c4"
             >
@@ -793,7 +793,7 @@ describe('Select', () => {
                 aria-disabled="false"
                 aria-expanded="true"
                 aria-haspopup="listbox"
-                aria-labelledby="select-3-label select-3-content"
+                aria-labelledby="select-3 select-3-label select-3-content"
                 class="c5"
                 id="select-3"
                 type="button"

--- a/packages/strapi-design-system/src/TimePicker/__tests__/TimePicker.spec.js
+++ b/packages/strapi-design-system/src/TimePicker/__tests__/TimePicker.spec.js
@@ -297,7 +297,7 @@ describe('TimePicker', () => {
             class="c0 c1"
             spacing="1"
           >
-            <span
+            <label
               class="c2"
               for="timepicker-1"
             >
@@ -306,7 +306,7 @@ describe('TimePicker', () => {
               >
                 Choose a time
               </div>
-            </span>
+            </label>
             <div
               class="c3 c4"
             >
@@ -315,7 +315,7 @@ describe('TimePicker', () => {
                 aria-disabled="false"
                 aria-expanded="true"
                 aria-haspopup="listbox"
-                aria-labelledby="timepicker-1-label timepicker-1-content"
+                aria-labelledby="timepicker-1 timepicker-1-label timepicker-1-content"
                 class="c5"
                 id="timepicker-1"
                 type="button"


### PR DESCRIPTION
## What

### DateTimePicker

- proposition to fix `DateTimePicker` accessibility issue:
  - when clicking on the label, it should focus on `DatePicker` component
  - for that we need `DatePicker` `input` to have an `id` corresponding to the `htmlFor` / `for` used by the `DateTimePicker` label
  - since by default `DatePicker` generates its own id, I passed a `parentFieldId` (⚠️ open to suggestion / ideas, not 100% comfortable with this solution)


https://user-images.githubusercontent.com/71838159/208694028-9ac33793-97a2-4ab6-bcea-0f903248516e.mov


### Select

- removing `as="span"` as it was breaking the link between the label and the button (e.g. clicking on the label wouldn't focus the button)
- proposition to improve `Select` accessibility by adding the `generatedId` used by the `Field` to button's aria-labelledby attribute
  -  allows to read the `Select` label when focusing on the `Select` button

https://user-images.githubusercontent.com/71838159/208694012-8549a6a6-50e4-4be1-87bd-c7c2b70ba34b.mov


## Questions

- would there be a better solution / refactor than passing a `parentFieldId`prop to `DatePicker` to ensure the link between the `DateTimePicker` label and the `DatePicker` input?
- any idea why `Select` label would be treated as a `span` and if removing that would cause any other issue?
- any issue possible that you could see/imagine with this fix?
