### PR TITLE
Add 'Warning' variant to the 'Alert' component

### DIFF
--- a/packages/strapi-design-system/src/Alert/Alert.js
+++ b/packages/strapi-design-system/src/Alert/Alert.js
@@ -47,7 +47,7 @@ const AlertIcon = ({ variant, ...props }) => {
     return <CheckCircle {...props} />;
   }
 
-  if (variant === 'danger') {
+  if (variant === 'danger' || variant === 'warning') {
     return <ExclamationMarkCircle {...props} />;
   }
 
@@ -136,7 +136,7 @@ Alert.propTypes = {
   /**
    * `Alert` color variant.
    */
-  variant: PropTypes.oneOf(['danger', 'success', 'default']),
+  variant: PropTypes.oneOf(['danger', 'success', 'default', 'warning']),
 };
 
 AlertIcon.propTypes = {

--- a/packages/strapi-design-system/src/Alert/Alert.stories.mdx
+++ b/packages/strapi-design-system/src/Alert/Alert.stories.mdx
@@ -57,8 +57,8 @@ one is aimed to give a small piece of text.
 
 ### Alert variants
 
-Use the variant prop to change the visual style of the Button. You can set the value to `default`, `success`, or
-`danger`.
+Use the variant prop to change the visual style of the Button. You can set the value to `default`, `success`,
+`danger` or `warning`.
 
 <Canvas withSource="open">
   <Story
@@ -82,6 +82,9 @@ Use the variant prop to change the visual style of the Button. You can set the v
         <Alert onClose={() => {}} closeLabel="Close" title="Title" variant="danger">
           This is the danger variant.
         </Alert>
+        <Alert onClose={() => {}} closeLabel="Close" title="Title" variant="warning">
+          This is the warning variant.
+        </Alert>
       </Stack>
     </Box>
   </Story>
@@ -92,6 +95,8 @@ Use the variant prop to change the visual style of the Button. You can set the v
 | Default/Information | Use a default alert for an informational purpose. Examples: Latest update, a specific mode, ...                       |
 | Success             | Use a success alert to indicate a successful action. Examples: Content has been saved, the locale has been added, ... |
 | Danger              | Examples: Content has been saved, the locale has been added, ...                                                      |
+| Warning              | Examples: A condition has occured that the user needs to be warned about, ...                                                      |
+
 
 ### Alert with action
 

--- a/packages/strapi-design-system/src/Alert/utils.js
+++ b/packages/strapi-design-system/src/Alert/utils.js
@@ -7,6 +7,10 @@ export const handleBackgroundColor = ({ theme, variant }) => {
     return theme.colors.success100;
   }
 
+  if (variant === 'warning') {
+    return theme.colors.warning100;
+  }
+
   return theme.colors.primary100;
 };
 
@@ -19,6 +23,10 @@ export const handleBorderColor = ({ theme, variant }) => {
     return theme.colors.success200;
   }
 
+  if (variant === 'warning') {
+    return theme.colors.warning200;
+  }
+
   return theme.colors.primary200;
 };
 
@@ -29,6 +37,10 @@ export const handleIconColor = ({ theme, variant }) => {
 
   if (variant === 'success') {
     return theme.colors.success700;
+  }
+
+  if (variant === 'warning') {
+    return theme.colors.warning700;
   }
 
   return theme.colors.primary700;


### PR DESCRIPTION
### What does it do?

This PR adds `Warning` variant to the `Alert` component.

### Why is it needed?

Needed for product licensing business logic. 

### How to test it?

Pass the `warning` variant to the `Alert` component

