### PR TITLE
[enh] Avatar video support

### DIFF
--- a/packages/strapi-design-system/src/Avatar/Avatar.js
+++ b/packages/strapi-design-system/src/Avatar/Avatar.js
@@ -74,7 +74,7 @@ export const Avatar = ({ src, alt, preview, type, mime }) => {
             height={`${previewSize / 16}rem`}
             as="figure"
           >
-            <video muted src={src} crossOrigin="anonymous">
+            <video muted src={preview === true ? src : preview} crossOrigin="anonymous">
               <source type={mime} />
             </video>
           </VideoPreviewWrapper>
@@ -175,6 +175,7 @@ Avatar.propTypes = {
   mime: throwPropErrorRequiredIf({ type: 'video' }, 'string'),
   /**
    * Image src of the image preview (displayed on `Avatar` hover).
+   * if preview is a boolean, src will be used as preview
    */
   preview: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   /**

--- a/packages/strapi-design-system/src/Avatar/Avatar.stories.mdx
+++ b/packages/strapi-design-system/src/Avatar/Avatar.stories.mdx
@@ -57,11 +57,27 @@ The avatar has a feature to display a preview of its thumbnail.
 <Canvas>
   <Story name="initials">
     <Box padding={11}>
-      <Initials>MF</Initials>
+      <Initials>mf</Initials>
+      <Initials background="secondary100" textColor="secondary600">pdf</Initials>
     </Box>
   </Story>
 </Canvas>
 
+### Video
+
+```jsx
+import { Avatar } from '@strapi/design-system';
+
+<Avatar 
+  src="/my-sleepy-cat-video.mp4" 
+  mime="video/mp4"
+  alt="sleepy cat" 
+  type="video" 
+  preview
+/>
+```
+
 ## Props
 
 <ArgsTable of={Avatar} />
+<ArgsTable of={Initials} />

--- a/packages/strapi-design-system/src/IconButton/IconButton.js
+++ b/packages/strapi-design-system/src/IconButton/IconButton.js
@@ -5,6 +5,7 @@ import { Tooltip } from '../Tooltip';
 import { BaseButton } from '../BaseButton';
 import { Flex } from '../Flex';
 import { VisuallyHidden } from '../VisuallyHidden';
+import { throwPropErrorIfNoneAreDefined } from '../helpers/throwPropError';
 
 const IconButtonWrapper = styled(BaseButton)`
   display: flex;
@@ -142,17 +143,6 @@ IconButton.defaultProps = {
   label: undefined,
   noBorder: false,
   onClick: undefined,
-};
-
-/**
- * @type {(otherProps: string[]) => (props: Record<string, unknown>, propName: string) => Error | undefined}
- */
-const throwPropErrorIfNoneAreDefined = (otherProps, propType) => (props, propName) => {
-  if (!props[propName] && otherProps.every((otherProp) => !props[otherProp])) {
-    return new Error(`One of the following props is required: ${propName}, ${otherProps.join(', ')}`);
-  }
-
-  return PropTypes.checkPropTypes({ [propName]: PropTypes[propType] }, props, 'prop', 'IconButton');
 };
 
 IconButton.propTypes = {

--- a/packages/strapi-design-system/src/helpers/throwPropError.js
+++ b/packages/strapi-design-system/src/helpers/throwPropError.js
@@ -1,0 +1,25 @@
+import PropTypes from 'prop-types';
+
+/**
+ * @type {(otherProps: string[]) => (props: Record<string, unknown>, propName: string) => Error | undefined}
+ */
+
+export const throwPropErrorIfNoneAreDefined = (otherProps, propType) => (props, propName, componentName) => {
+  if (!props[propName] && otherProps.every((otherProp) => !props[otherProp])) {
+    return new Error(`One of the following props is required: ${propName}, ${otherProps.join(', ')}`);
+  }
+
+  return PropTypes.checkPropTypes({ [propName]: PropTypes[propType] }, props, 'prop', componentName);
+};
+
+/**
+ * @type {(otherProps: any{}) => (props: Record<string, unknown>, propName: string) => Error | undefined}
+ */
+
+export const throwPropErrorRequiredIf = (otherProps, propType) => (props, propName, componentName) => {
+  if (props[propName] === undefined && Object.entries(otherProps).every(([key, value]) => props[key] === value)) {
+    return new Error(`${propName} is required`);
+  }
+
+  return PropTypes.checkPropTypes({ [propName]: PropTypes[propType] }, props, 'prop', componentName);
+};


### PR DESCRIPTION
## What

- Adds video support for `Avatar`
- Allows `background` and `textColor` customization for `Initials`

## Test

- Use local video files and test `Avatar` component 