### PR TITLE
[fix] Bold & BulletList svg viewbox

### DIFF
--- a/packages/strapi-icons/assets/icons/Bold.svg
+++ b/packages/strapi-icons/assets/icons/Bold.svg
@@ -1,3 +1,3 @@
-<svg width="24" height="24" viewBox="0 0 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path fill-rule="evenodd" clip-rule="evenodd" d="M7.4 1.2H4.2v21.6h3.2V1.2Zm11.6 6a6 6 0 0 1-1.5 4 6.4 6.4 0 0 1-3.8 11.6H7.4v-3.2h6.3c1.8 0 3.3-1.4 3.3-3.2 0-1.8-1.5-3.2-3.3-3.2H7.4V10H13a2.8 2.8 0 0 0 0-5.6H7.4V1.2H13a6 6 0 0 1 6 6Z" fill="#32324D"/>
 </svg>

--- a/packages/strapi-icons/assets/icons/BulletList.svg
+++ b/packages/strapi-icons/assets/icons/BulletList.svg
@@ -1,3 +1,3 @@
-<svg width="24" height="24" viewBox="0 0 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path fill-rule="evenodd" clip-rule="evenodd" d="M3.64 7.23a2.14 2.14 0 1 1 0-4.27 2.14 2.14 0 0 1 0 4.27Zm4.98-3.25H22.5v2.37H8.62V3.98Zm-7.12 8.1a2.14 2.14 0 1 0 4.27 0 2.14 2.14 0 0 0-4.27 0Zm2.14 9.04a2.14 2.14 0 1 1 0-4.27 2.14 2.14 0 0 1 0 4.27ZM22.5 10.87H8.62v2.37H22.5v-2.37Zm-13.88 6.9H22.5v2.37H8.62v-2.37Z" fill="#32324D"/>
 </svg>


### PR DESCRIPTION
## What

`Bold` and `BulletList` svgs had broken `viewBox` 

| before  | after  |  
|---|---|
| <img width="103" alt="image" src="https://user-images.githubusercontent.com/71838159/209797212-841f3f32-aaa6-46dc-93e9-a902325a398a.png"> | <img width="100" alt="image" src="https://user-images.githubusercontent.com/71838159/209797268-a588484e-a8ac-42f9-9da0-cc1a2ad7c5e1.png"> |  
