### PR TITLE
[fix] minDate not working for DatePicker component

### DIFF
--- a/packages/strapi-design-system/src/DatePicker/DatePicker.js
+++ b/packages/strapi-design-system/src/DatePicker/DatePicker.js
@@ -22,6 +22,8 @@ export const DatePicker = ({
   clearLabel,
   disabled,
   id,
+  minDate,
+  maxDate,
   ...props
 }) => {
   const generatedId = useId('datepicker', id);
@@ -94,6 +96,8 @@ export const DatePicker = ({
           onEscape={handleEscape}
           popoverSource={inputRef.current.inputWrapperRef}
           label={label || ariaLabel}
+          minDate={minDate}
+          maxDate={maxDate}
         />
       )}
     </DatePickerWrapper>
@@ -108,6 +112,8 @@ DatePicker.defaultProps = {
   label: undefined,
   locale: undefined,
   initialDate: new Date(),
+  minDate: undefined,
+  maxDate: undefined,
   onClear: undefined,
   placeholder: undefined,
   selectedDate: undefined,
@@ -122,6 +128,8 @@ DatePicker.propTypes = {
   initialDate: PropTypes.instanceOf(Date),
   label: PropTypes.string,
   locale: PropTypes.string,
+  maxDate: PropTypes.instanceOf(Date),
+  minDate: PropTypes.instanceOf(Date),
   onChange: PropTypes.func.isRequired,
   onClear: PropTypes.func,
   placeholder: PropTypes.string,

--- a/packages/strapi-design-system/src/DatePicker/__tests__/DatePicker.e2e.js
+++ b/packages/strapi-design-system/src/DatePicker/__tests__/DatePicker.e2e.js
@@ -142,11 +142,7 @@ test.describe.parallel('DatePicker', () => {
 
       const value = await page.$eval('input', (el) => el.value);
 
-      if (yearElement) {
-        expect(value).toBe('1/14/1999');
-      } else {
-        expect(value).not.toBe('1/14/1999');
-      }
+      expect(value).not.toBe('1/14/1999');
       expect(await page.$('[role="dialog"]')).toBeFalsy();
     });
     test('selects a value bigger than the maximum value is not possible', async ({ page }) => {
@@ -168,11 +164,7 @@ test.describe.parallel('DatePicker', () => {
 
       const value = await page.$eval('input', (el) => el.value);
 
-      if (yearElement) {
-        expect(value).toBe('1/1/2041');
-      } else {
-        expect(value).not.toBe('1/1/2041');
-      }
+      expect(value).not.toBe('1/1/2041');
 
       expect(await page.$('[role="dialog"]')).toBeFalsy();
     });

--- a/packages/strapi-design-system/src/DatePicker/__tests__/DatePicker.e2e.js
+++ b/packages/strapi-design-system/src/DatePicker/__tests__/DatePicker.e2e.js
@@ -119,4 +119,62 @@ test.describe.parallel('DatePicker', () => {
       await checkA11y(page);
     });
   });
+  test.describe('max and min date', () => {
+    test.beforeEach(async ({ page }) => {
+      // This is the URL of the Storybook Iframe
+      await page.goto('/iframe.html?id=design-system-components-datepicker--min-max-date&viewMode=story');
+    });
+    test('selects a value less than the minumum value is not possible', async ({ page }) => {
+      await page.click('input');
+      expect(await page.$('[role="dialog"]')).toBeTruthy();
+
+      await page.click(':nth-match(button[aria-haspopup], 1)');
+      await page.click('text="January"');
+
+      await page.click(':nth-match(button[aria-haspopup], 2)');
+      const yearElement = await page.$('text="2041"');
+
+      await page.click('text="14"');
+
+      if (yearElement) {
+        await page.evaluate('text="1999"');
+      }
+
+      const value = await page.$eval('input', (el) => el.value);
+
+      if (yearElement) {
+        expect(value).toBe('1/14/1999');
+      } else {
+        expect(value).not.toBe('1/14/1999');
+      }
+      expect(await page.$('[role="dialog"]')).toBeFalsy();
+    });
+    test('selects a value bigger than the maximum value is not possible', async ({ page }) => {
+      await page.click('input');
+      expect(await page.$('[role="dialog"]')).toBeTruthy();
+
+      await page.click(':nth-match(button[aria-haspopup], 1)');
+      await page.click('text="January"');
+
+      await page.click(':nth-match(button[aria-haspopup], 2)');
+
+      const yearElement = await page.$('text="2041"');
+
+      await page.click('text="1"');
+
+      if (yearElement) {
+        await page.evaluate('text="2040"');
+      }
+
+      const value = await page.$eval('input', (el) => el.value);
+
+      if (yearElement) {
+        expect(value).toBe('1/1/2041');
+      } else {
+        expect(value).not.toBe('1/1/2041');
+      }
+
+      expect(await page.$('[role="dialog"]')).toBeFalsy();
+    });
+  });
 });


### PR DESCRIPTION
### What does it do?

Revert back the minDate and maxDate props in the DatePicker

### Why is it needed?

Because it is not still possible to add some limits to the DatePicker component.

### How to test it?

Run the storybook and check the minDate and maxDate component to see if it is possible to select value minor than 2000 and bigger than 2040

### Related issue(s)/PR(s)

Fix [#822](https://github.com/strapi/design-system/issues/822)
