### PR TITLE
chore: use esnext

### DIFF
--- a/packages/strapi-design-system/vite.config.js
+++ b/packages/strapi-design-system/vite.config.js
@@ -11,7 +11,7 @@ export default glob('./src/**/!(*.spec|*.e2e).{js,svg}').then(async (paths) => {
       exclude: [],
     },
     build: {
-      target: 'es2015',
+      target: 'esnext',
       lib: {
         entry: {},
         formats: ['cjs', 'es'],

--- a/packages/strapi-icons/vite.config.js
+++ b/packages/strapi-icons/vite.config.js
@@ -9,7 +9,7 @@ export default defineConfig({
     exclude: [],
   },
   build: {
-    target: 'es2015',
+    target: 'esnext',
     lib: {
       entry: resolve(__dirname, './src/index.js'),
       formats: ['cjs', 'es'],


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* changes the target to `esnext`

### Why is it needed?

* Originally i had it at this or es2020 but then webpack caused issues in the admin app when trying to convert it down to 2015 🤔 Now this – https://github.com/strapi/strapi/pull/15369 is open, we can go back to being _super flexible_
* `esnext` performs as little transpilation as possible, this is perfect for a library because some people may want to support 2018 but if we compile to 2015, we're making life difficult for them – https://vitejs.dev/config/build-options.html#build-target

