### PR TITLE
[Fix] MainNav overflow auto

### DIFF
--- a/packages/strapi-design-system/src/MainNav/NavSections.js
+++ b/packages/strapi-design-system/src/MainNav/NavSections.js
@@ -6,7 +6,7 @@ import { Box } from '../Box';
 
 const BoxGrow = styled(Box)`
   flex-grow: 1;
-  overflow-y: scroll;
+  overflow-y: auto;
 `;
 
 export const NavSections = ({ children, ...props }) => {

--- a/packages/strapi-design-system/src/v2/MainNav/NavSections.js
+++ b/packages/strapi-design-system/src/v2/MainNav/NavSections.js
@@ -6,7 +6,7 @@ import { Box } from '../../Box';
 
 const BoxGrow = styled(Box)`
   flex-grow: 1;
-  overflow-y: scroll;
+  overflow-y: auto;
 `;
 
 export const NavSections = ({ children, ...props }) => {


### PR DESCRIPTION
## What

Replace `overflow: scroll` with `overflow: auto` for `NavSections` as it would force scrollbar being displayed even when not needed