### PR TITLE
Accordion: forward shadow prop

### DIFF
--- a/packages/strapi-design-system/src/Accordion/Accordion.tsx
+++ b/packages/strapi-design-system/src/Accordion/Accordion.tsx
@@ -91,6 +91,10 @@ export interface AccordionProps {
    */
   onToggle?: () => void;
   /**
+   * Shadow name (see `theme.shadows`)
+   */
+  shadow?: keyof DefaultTheme['shadows'];
+  /**
    * @deprecated use `onToggle` instead
    * The callback invoked after a click event on the `AccordionToggle`.
    */
@@ -117,6 +121,7 @@ export const Accordion = ({
   toggle,
   size = 'M',
   variant = 'primary',
+  shadow,
 }: AccordionProps) => {
   const generatedId = useId('accordion', id);
 
@@ -130,6 +135,7 @@ export const Accordion = ({
         hasRadius
         variant={variant}
         error={error}
+        shadow={shadow}
       >
         {children}
       </AccordionWrapper>


### PR DESCRIPTION
### What does it do?

It forwards the `shadow` prop on the `Accordion` component to the underlying `Box`.

### Why is it needed?

It allows us to render the Accordion with a shadow:

<img width="1208" alt="Screenshot 2023-01-24 at 16 20 01" src="https://user-images.githubusercontent.com/2244375/214334615-f2f7da9d-1fae-4e13-961a-b8a1810d9518.png">

<img width="1208" alt="Screenshot 2023-01-24 at 16 20 07" src="https://user-images.githubusercontent.com/2244375/214334611-a3a34448-f17c-423f-8703-fd687b6ad4c3.png">

This is a design-requirement for review workflows. We can make use out of this for dynamic-zones too, which are currently using a style override:

```js
const StyledBox = styled(Box)`
  > div:first-child {
    box-shadow: ${({ theme }) => theme.shadows.tableShadow};
  }
`;
```

