### PR TITLE
Stack: Prevent `spacing` prop to be rendered on DOM nodes as attribute

### DIFF
--- a/packages/strapi-design-system/src/DateTimePicker/__tests__/__snapshots__/DateTimePicker.spec.js.snap
+++ b/packages/strapi-design-system/src/DateTimePicker/__tests__/__snapshots__/DateTimePicker.spec.js.snap
@@ -277,7 +277,6 @@ exports[`DateTimePicker snapshots the component 1`] = `
 >
   <div
     class="c0 c1"
-    spacing="1"
   >
     <label
       class="c2"
@@ -291,7 +290,6 @@ exports[`DateTimePicker snapshots the component 1`] = `
     </label>
     <div
       class="c3 c4"
-      spacing="2"
     >
       <div
         class=""
@@ -300,7 +298,6 @@ exports[`DateTimePicker snapshots the component 1`] = `
           <div>
             <div
               class="c0 c1"
-              spacing="1"
             >
               <div
                 class="c5 c6"

--- a/packages/strapi-design-system/src/Select/__tests__/Select.spec.js
+++ b/packages/strapi-design-system/src/Select/__tests__/Select.spec.js
@@ -280,7 +280,6 @@ describe('Select', () => {
         <div>
           <div
             class="c0 c1"
-            spacing="1"
           >
             <label
               class="c2"
@@ -403,7 +402,6 @@ describe('Select', () => {
                 aria-multiselectable="false"
                 class="c0 c1"
                 role="listbox"
-                spacing="1"
                 tabindex="-1"
               >
                 <li
@@ -772,7 +770,6 @@ describe('Select', () => {
         <div>
           <div
             class="c0 c1"
-            spacing="1"
           >
             <label
               class="c2"
@@ -892,7 +889,6 @@ describe('Select', () => {
                 aria-multiselectable="true"
                 class="c0 c1"
                 role="listbox"
-                spacing="1"
                 tabindex="-1"
               >
                 <li

--- a/packages/strapi-design-system/src/Stack/Stack.tsx
+++ b/packages/strapi-design-system/src/Stack/Stack.tsx
@@ -9,6 +9,7 @@ import { extractStyleFromTheme } from '../helpers/theme';
  */
 const transientProps: Partial<Record<keyof StackProps, boolean>> = {
   size: true,
+  spacing: true,
 };
 
 const StackV = styled(Flex).withConfig<Omit<StackProps, 'size' | 'horizontal'>>({

--- a/packages/strapi-design-system/src/TimePicker/__tests__/TimePicker.spec.js
+++ b/packages/strapi-design-system/src/TimePicker/__tests__/TimePicker.spec.js
@@ -295,7 +295,6 @@ describe('TimePicker', () => {
         <div>
           <div
             class="c0 c1"
-            spacing="1"
           >
             <label
               class="c2"
@@ -453,7 +452,6 @@ describe('TimePicker', () => {
                 aria-multiselectable="false"
                 class="c0 c1"
                 role="listbox"
-                spacing="1"
                 tabindex="-1"
               >
                 <li


### PR DESCRIPTION
### What does it do?

Prevents the `spacing` prop of the `Stack` component to be rendered as attribute on DOM nodes.

### Why is it needed?

It is not a valid HTML attribute nor expected the attribute is rendered.

### How to test it?

Check the generated HTML for https://design-system-git-chore-stack-dom-attrs-spacing-strapijs.vercel.app/iframe.html?args=&id=design-system-technical-components-stack--base&viewMode=story

### Related issue(s)/PR(s)

- Fixes https://github.com/strapi/design-system/issues/846
