### PR TITLE
workflows not running but are required

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,12 +3,11 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, reopened]
-    paths:
-      - 'packages/**'
-      - '!docs/**'
-      - '!website/**'
+  pull_request: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   typecheck:


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* removes the path filtering for PR workflows

### Why is it needed?

* tests are "required" but then they don't run so PRs are left in limbo

### Related issue(s)/PR(s)

* #836
