### PR TITLE
[fix] borderRadius on json input

### DIFF
--- a/packages/strapi-design-system/src/JSONInput/JSONInputContainer.js
+++ b/packages/strapi-design-system/src/JSONInput/JSONInputContainer.js
@@ -13,6 +13,9 @@ export const JSONInputContainer = styled(Flex)`
     background-color: #32324d;
     width: 100%;
     outline: none;
+  }
+
+  .cm-scroller {
     border: 1px solid ${({ theme, hasError }) => (hasError ? theme.colors.danger600 : theme.colors.neutral200)};
     /* inputFocusStyle will receive hasError prop */
     ${inputFocusStyle()}


### PR DESCRIPTION
### What does it do?

- Fixes a small gap between the editor and the border

before

<img width="59" alt="json-before" src="https://user-images.githubusercontent.com/26598053/216080728-96b53217-08d0-4100-96c8-2206cd20b91c.png">

after

![Screenshot 2023-02-01 at 16 09 39](https://user-images.githubusercontent.com/26598053/216081329-dfbaa039-64ee-498c-a0cb-1a98eae9dfe8.png)


### How to test it?

Check if there is a gap 

