### PR TITLE
[fix] Focus the editor when clicking the label

### DIFF
--- a/packages/strapi-design-system/src/JSONInput/JSONInput.js
+++ b/packages/strapi-design-system/src/JSONInput/JSONInput.js
@@ -97,6 +97,13 @@ export const JSONInput = ({ label, value, error, hint, required, onChange, disab
     },
   });
 
+  const focusInput = () => {
+    if (!disabled) {
+      // Focus the element with focus styles (JSONInputContainer > .cm-editor > .cm-scroller)
+      editor.current.children[0].children[1].focus();
+    }
+  };
+
   useEffect(() => {
     const currentEditor = editor.current;
 
@@ -108,7 +115,11 @@ export const JSONInput = ({ label, value, error, hint, required, onChange, disab
   return (
     <Field error={error} hint={hint} required={required}>
       <Stack spacing={1}>
-        {label && <FieldLabel action={labelAction}>{label}</FieldLabel>}
+        {label && (
+          <FieldLabel onClick={focusInput} action={labelAction}>
+            {label}
+          </FieldLabel>
+        )}
         <JSONInputContainer
           ref={editor}
           hasError={hasError}

--- a/packages/strapi-design-system/src/JSONInput/JSONInput.js
+++ b/packages/strapi-design-system/src/JSONInput/JSONInput.js
@@ -99,8 +99,8 @@ export const JSONInput = ({ label, value, error, hint, required, onChange, disab
 
   const focusInput = () => {
     if (!disabled) {
-      // Focus the element with focus styles (JSONInputContainer > .cm-editor > .cm-scroller)
-      editor.current.children[0].children[1].focus();
+      // Focus the content editable element nested in the JSONInputContainer ref
+      editor.current.children[0].children[1].children[1].focus();
     }
   };
 


### PR DESCRIPTION
### What does it do?

Focuses the JSONInput when clicking the label and it is not disabled

### How to test it?

- Go to the editable input and click the label, it should focus the editor and apply the focus styles, you should be able to type
- Go to a disabled input and add a label, click the label, it shouldn't do anything

### Related issue(s)/PR(s)

resolves https://github.com/strapi/design-system/issues/862
