### PR TITLE
Box: Extend transient props

### DIFF
--- a/packages/strapi-design-system/src/Avatar/__tests__/Avatar.spec.tsx
+++ b/packages/strapi-design-system/src/Avatar/__tests__/Avatar.spec.tsx
@@ -63,13 +63,9 @@ describe('Avatar', () => {
         />
         <div
           class="c1"
-          height="32px"
-          width="32px"
         >
           <div
             class="c2 c3"
-            height="32px"
-            width="32px"
           />
           <img
             alt="marvin frachet"
@@ -145,13 +141,9 @@ describe('Avatar', () => {
         />
         <div
           class="c1"
-          height="32px"
-          width="32px"
         >
           <div
             class="c2 c3"
-            height="32px"
-            width="32px"
           />
           <img
             alt="marvin frachet"

--- a/packages/strapi-design-system/src/Box/Box.tsx
+++ b/packages/strapi-design-system/src/Box/Box.tsx
@@ -125,6 +125,7 @@ export type BoxProps<TElement extends HTMLElement = HTMLDivElement> = Pick<
  */
 const transientProps: Partial<Record<keyof BoxProps, boolean>> = {
   color: true,
+  cursor: true,
 };
 
 export const Box = styled.div.withConfig<BoxProps>({

--- a/packages/strapi-design-system/src/Box/Box.tsx
+++ b/packages/strapi-design-system/src/Box/Box.tsx
@@ -126,6 +126,8 @@ export type BoxProps<TElement extends HTMLElement = HTMLDivElement> = Pick<
 const transientProps: Partial<Record<keyof BoxProps, boolean>> = {
   color: true,
   cursor: true,
+  height: true,
+  width: true,
 };
 
 export const Box = styled.div.withConfig<BoxProps>({

--- a/packages/strapi-design-system/src/Box/__tests__/Box.spec.tsx
+++ b/packages/strapi-design-system/src/Box/__tests__/Box.spec.tsx
@@ -24,9 +24,11 @@ describe('Box', () => {
     },
   );
 
-  it.each(['color', 'cursor'])('does not render color or cursor props as HTML attributes', (prop) => {
-    const { container } = setup({ [prop]: 'something' });
-    expect(container).not.toHaveAttribute('color');
-    expect(container.children[0]).not.toHaveAttribute('color');
-  });
+  it.each(['color', 'cursor', 'height', 'width'])(
+    'does not render color or cursor props as HTML attributes',
+    (prop) => {
+      const { container } = setup({ [prop]: 'something' });
+      expect(container.children[0]).not.toHaveAttribute(prop);
+    },
+  );
 });

--- a/packages/strapi-design-system/src/Box/__tests__/Box.spec.tsx
+++ b/packages/strapi-design-system/src/Box/__tests__/Box.spec.tsx
@@ -1,36 +1,32 @@
-import * as React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 import { Box } from '../Box';
 import { lightTheme } from '../../themes';
 
+const setup = (props = {}) =>
+  render(
+    <ThemeProvider theme={lightTheme}>
+      <Box {...props} />
+    </ThemeProvider>,
+  );
+
 describe('Box', () => {
   it.each(['color', 'background'])('retrieves the theme value corresponding to the %s props', (colorProp) => {
-    const props = { [colorProp]: 'primary500' };
-
-    render(
-      <ThemeProvider theme={lightTheme}>
-        <Box {...props}>Hello world</Box>
-      </ThemeProvider>,
-    );
-
-    const el = screen.getByText('Hello world');
-    expect(el).toHaveStyle(`${colorProp}: #7b79ff`);
+    const { container } = setup({ [colorProp]: 'primary500' });
+    expect(container.children[0]).toHaveStyle(`${colorProp}: #7b79ff`);
   });
 
   it.each(['padding', 'paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft'])(
     'retrieves the theme value corresponding to the %s props',
     (spacingProp) => {
-      const props = { [spacingProp]: 4 };
-
-      render(
-        <ThemeProvider theme={lightTheme}>
-          <Box {...props}>Hello world</Box>
-        </ThemeProvider>,
-      );
-
-      const el = screen.getByText('Hello world');
-      expect(el).toHaveStyle(`${spacingProp}: 16px`);
+      const { container } = setup({ [spacingProp]: 4 });
+      expect(container.children[0]).toHaveStyle(`${spacingProp}: 16px`);
     },
   );
+
+  it.each(['color', 'cursor'])('does not render color or cursor props as HTML attributes', (prop) => {
+    const { container } = setup({ [prop]: 'something' });
+    expect(container).not.toHaveAttribute('color');
+    expect(container.children[0]).not.toHaveAttribute('color');
+  });
 });


### PR DESCRIPTION
### What does it do?

Ensures the `Box` component does not render the following props as HTML attributes:

- `width`
- `height`
- `cursor`
- `color`

### Why is it needed?

Became evident in https://github.com/strapi/design-system/pull/878.

### How to test it?

Follow the 🐇 automated tests.
