### PR TITLE
Fix missing proptype validation

### DIFF
--- a/packages/strapi-design-system/src/Field/Field.js
+++ b/packages/strapi-design-system/src/Field/Field.js
@@ -24,7 +24,7 @@ Field.defaultProps = {
 Field.propTypes = {
   children: PropTypes.node.isRequired,
   error: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
-  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
+  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
   id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   name: PropTypes.string,
   required: PropTypes.bool,

--- a/packages/strapi-design-system/src/Select/Select.js
+++ b/packages/strapi-design-system/src/Select/Select.js
@@ -299,7 +299,7 @@ Select.propTypes = {
   customizeContent: PropTypes.func,
   disabled: PropTypes.bool,
   error: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
-  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
+  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
   id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   label: PropTypes.string,
   labelAction: PropTypes.element,

--- a/packages/strapi-design-system/src/TextInput/TextInput.js
+++ b/packages/strapi-design-system/src/TextInput/TextInput.js
@@ -52,7 +52,7 @@ TextInput.propTypes = {
   'aria-label': PropTypes.string,
   endAction: PropTypes.element,
   error: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
-  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
+  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
   id: PropTypes.string,
   label: PropTypes.string,
   labelAction: PropTypes.element,

--- a/packages/strapi-design-system/src/TimePicker/TimePicker.js
+++ b/packages/strapi-design-system/src/TimePicker/TimePicker.js
@@ -119,7 +119,7 @@ TimePicker.propTypes = {
   clearLabel: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   error: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
-  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
+  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
   id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   label: PropTypes.string,
   onChange: PropTypes.func.isRequired,


### PR DESCRIPTION
### What does it do?

Fixes a missing boolean proptype validation

### Why is it needed?

It throws an error in the console and is breaking tests in the CMS

### How to test it?

The only way I found was to:

vite build this branch then copy the dist folder to replace the one in the node_modules in Strapi on this branch https://github.com/strapi/strapi/pull/15706#pullrequestreview-1283236627, run the tests over there for DateTimePicker:

```
yarn test:front packages/core/helper-plugin/lib/src/components/DateTimePicker/tests/index.test.js --updateSnapshot
```

or run all the tests

### Related issue(s)/PR(s)
- https://github.com/strapi/design-system/pull/864
- https://github.com/strapi/strapi/pull/15706#pullrequestreview-1283236627
