### PR TITLE
GitHub: Run bundle-size reporter on every PR

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,9 +1,7 @@
 name: Bundle-size
 
 on:
-  pull_request:
-    branches:
-      - main
+  pull_request: {}
 
 jobs:
   size:


### PR DESCRIPTION
### What does it do?

Enables the bundle-size action on all PRs.

### Why is it needed?

With the introduction of release branches it is not sufficient any longer to run the bundle-size action when merging into main.

