### PR TITLE
[fix] IconButton no border

### DIFF
--- a/packages/strapi-design-system/src/Box/Box.tsx
+++ b/packages/strapi-design-system/src/Box/Box.tsx
@@ -163,7 +163,7 @@ export const Box = styled.div.withConfig<BoxProps>({
   border-color: ${({ borderColor, theme }) => extractStyleFromTheme(theme.colors, borderColor, undefined)};
   border: ${({ theme, borderColor, borderStyle, borderWidth }) => {
     // This condition prevents borderColor from override the border-color attribute when not passing borderStyle nor borderWidth
-    if (borderColor && !borderStyle && !borderWidth) {
+    if (borderColor && !borderStyle && typeof borderWidth === 'undefined') {
       return `1px solid ${theme.colors[borderColor]}`;
     }
 

--- a/packages/strapi-design-system/src/IconButton/IconButton.tsx
+++ b/packages/strapi-design-system/src/IconButton/IconButton.tsx
@@ -54,7 +54,7 @@ export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
       <IconButtonWrapper
         aria-disabled={disabled}
         background={disabled ? 'neutral150' : undefined}
-        borderWidth={noBorder ? '0px' : undefined}
+        borderWidth={noBorder ? 0 : undefined}
         justifyContent="center"
         height={`${32 / 16}rem`}
         width={`${32 / 16}rem`}

--- a/packages/strapi-design-system/src/IconButton/IconButton.tsx
+++ b/packages/strapi-design-system/src/IconButton/IconButton.tsx
@@ -54,7 +54,7 @@ export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
       <IconButtonWrapper
         aria-disabled={disabled}
         background={disabled ? 'neutral150' : undefined}
-        borderWidth={noBorder ? 0 : undefined}
+        borderWidth={noBorder ? '0px' : undefined}
         justifyContent="center"
         height={`${32 / 16}rem`}
         width={`${32 / 16}rem`}


### PR DESCRIPTION
## What

fixing no border application on `IconButton` 

| Before | After |
|-|-|
| <img width="577" alt="Screenshot 2023-02-14 at 10 05 15" src="https://user-images.githubusercontent.com/71838159/218689749-081e1015-15ce-4dc8-89d8-03671d878d81.png">  | <img width="535" alt="Screenshot 2023-02-14 at 10 04 29" src="https://user-images.githubusercontent.com/71838159/218689801-63392797-6cbc-41cc-969e-0b16f923c68e.png"> |


