### PR TITLE
fix(Layout/HeaderLayout): Don't set height to 0

### DIFF
--- a/packages/strapi-design-system/src/Layout/HeaderLayout.js
+++ b/packages/strapi-design-system/src/Layout/HeaderLayout.js
@@ -42,7 +42,7 @@ export const HeaderLayout = (props) => {
 
   return (
     <>
-      <div style={{ height: headerSize?.height }} ref={containerRef}>
+      <div style={{ height: headerSize?.height || undefined }} ref={containerRef}>
         {isVisible && <BaseHeaderLayout ref={baseHeaderLayoutRef} {...props} />}
       </div>
       {!isVisible && <BaseHeaderLayout {...props} sticky width={headerSize?.width} />}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Avoids setting header layout container height to 0px by using undefined (so no height inline style) as fallback

### Why is it needed?

When the container renders while `isVisible` is `false`,  the div will get a height of `0px`.
When `isVisible` turns `true`, the inner `<BaseHeaderLayout />` renders, but the container cannot grow,
resulting in a missing header and a broken layout.

This mostly occures when a custom field gets rendered and needs some time to load asynchronous 


### How to test it?

* Create a customField that needs some time to load (in my case, a monaco editor)
* Go on the create page
* Keep hitting "Reload" while the dev tools are open and "disable cache" is checked
