### PR TITLE
Adds declaration to design system

### DIFF
--- a/packages/strapi-design-system/tsconfig.json
+++ b/packages/strapi-design-system/tsconfig.json
@@ -4,7 +4,11 @@
     "module": "ESNext",
     "moduleResolution": "node",
     "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ESNext"
+    ],
     "noImplicitAny": false,
     "skipLibCheck": true,
     "esModuleInterop": false,
@@ -15,9 +19,20 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["vite/client", "jest", "@testing-library/jest-dom"]
+    "types": [
+      "vite/client",
+      "jest",
+      "@testing-library/jest-dom"
+    ],
+    "outDir": "./dist",
+    "declarationMap": true,
+    "sourceMap": true,
+    "declaration": true,
   },
-  "include": ["src", "styled.d.ts"],
+  "include": [
+    "src",
+    "styled.d.ts"
+  ],
   "references": [
     {
       "path": "./tsconfig.node.json"


### PR DESCRIPTION
In the current state of the design system, the distribution folder doesn't include the index.d.ts file. While this could be either intentional or forgotten in either case this pull request adds declaration creation.