### PR TITLE
No length limit on the name for the API token or transfer token 

### DIFF
--- a/packages/strapi-design-system/src/Layout/HeaderLayout.js
+++ b/packages/strapi-design-system/src/Layout/HeaderLayout.js
@@ -58,6 +58,10 @@ const StickyBox = styled(Box)`
   width: ${(props) => props.width}px;
 `;
 
+const TitleFlex = styled(Flex)`
+  min-width: 0;
+`;
+
 export const BaseHeaderLayout = React.forwardRef(
   ({ navigationAction, primaryAction, secondaryAction, subtitle, title, sticky, width, ...props }, ref) => {
     const isSubtitleString = typeof subtitle === 'string';
@@ -101,6 +105,8 @@ export const BaseHeaderLayout = React.forwardRef(
       );
     }
 
+    const FlexElement = props?.ellipsis ? TitleFlex : Flex;
+
     return (
       <Box
         ref={ref}
@@ -113,12 +119,12 @@ export const BaseHeaderLayout = React.forwardRef(
       >
         {navigationAction ? <Box paddingBottom={2}>{navigationAction}</Box> : null}
         <Flex justifyContent="space-between">
-          <Flex>
+          <FlexElement>
             <Typography as="h1" variant="alpha" {...props}>
               {title}
             </Typography>
             {secondaryAction ? <Box paddingLeft={4}>{secondaryAction}</Box> : null}
-          </Flex>
+          </FlexElement>
           {primaryAction}
         </Flex>
         {isSubtitleString ? (

--- a/packages/strapi-design-system/src/Layout/HeaderLayout.js
+++ b/packages/strapi-design-system/src/Layout/HeaderLayout.js
@@ -101,12 +101,6 @@ export const BaseHeaderLayout = React.forwardRef(
       );
     }
 
-    let flexProps = {};
-
-    if (props?.ellipsis) {
-      flexProps.minWidth = 0;
-    }
-
     return (
       <Box
         ref={ref}
@@ -119,7 +113,7 @@ export const BaseHeaderLayout = React.forwardRef(
       >
         {navigationAction ? <Box paddingBottom={2}>{navigationAction}</Box> : null}
         <Flex justifyContent="space-between">
-          <Flex {...flexProps}>
+          <Flex minWidth={0}>
             <Typography as="h1" variant="alpha" {...props}>
               {title}
             </Typography>

--- a/packages/strapi-design-system/src/Layout/HeaderLayout.js
+++ b/packages/strapi-design-system/src/Layout/HeaderLayout.js
@@ -58,10 +58,6 @@ const StickyBox = styled(Box)`
   width: ${(props) => props.width}px;
 `;
 
-const TitleFlex = styled(Flex)`
-  min-width: 0;
-`;
-
 export const BaseHeaderLayout = React.forwardRef(
   ({ navigationAction, primaryAction, secondaryAction, subtitle, title, sticky, width, ...props }, ref) => {
     const isSubtitleString = typeof subtitle === 'string';
@@ -105,7 +101,11 @@ export const BaseHeaderLayout = React.forwardRef(
       );
     }
 
-    const FlexElement = props?.ellipsis ? TitleFlex : Flex;
+    let flexProps = {};
+
+    if (props?.ellipsis) {
+      flexProps.minWidth = 0;
+    }
 
     return (
       <Box
@@ -119,12 +119,12 @@ export const BaseHeaderLayout = React.forwardRef(
       >
         {navigationAction ? <Box paddingBottom={2}>{navigationAction}</Box> : null}
         <Flex justifyContent="space-between">
-          <FlexElement>
+          <Flex {...flexProps}>
             <Typography as="h1" variant="alpha" {...props}>
               {title}
             </Typography>
             {secondaryAction ? <Box paddingLeft={4}>{secondaryAction}</Box> : null}
-          </FlexElement>
+          </Flex>
           {primaryAction}
         </Flex>
         {isSubtitleString ? (


### PR DESCRIPTION
### What does it do?

As a developer managing transfer tokens of API tokens, I want to have a limit on the maximum number of characters per tone name.

### Why is it needed?

Because we have some UI issues with long names
The activity must not be breaking change and so it must only affect the frontend validation

### How to test it?

 - As a developer with the permissions useful to create or edit a API tokens and transfer tokens
   - when I create an existing API token
     - then I want the validation on the Name field to limit the length of the field up to 100 characters
   - when I access the API tokens list
     - then I want the name trimmed as the description field
   - when I create an existing transfer token
     - then I want the validation on the Name field to limit the length of the field up to 100 characters
   - when I access the transfer tokens list
     - then I want the name trimmed as the description field
   - when I edit and save the edits on an existing token and the token has a length on the name longer than 100 characters
     - then I want the validation to highlight it and prevent the saving of the edits


### Related issue(s)/PR(s)

The ticket related to it is https://strapi-inc.atlassian.net/browse/DX-613 and the strapi Pr related to this is https://github.com/strapi/strapi/pull/15895
