### PR TITLE
Add experimental release workflow

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -1,0 +1,25 @@
+name: 'Experimental Releases'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  publish:
+    name: 'Publish'
+    runs-on: ubuntu-latest
+    if: github.repository == 'strapi/strapi'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup npmrc
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: yarn setup
+      - run: ./scripts/pre-publish.sh --yes
+        env:
+          VERSION: '0.0.0-${{ github.sha }}'
+          DIST_TAG: experimental

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:snapshots": "lerna --scope @strapi/design-system exec -- yarn test -u",
     "release": "yarn vers && yarn setup && git commit -am \"Releasing\" && yarn pub",
     "pub": "lerna publish from-package",
-    "vers": "lerna version --no-push --no-git-tag-version --no-private"
+    "vers": "lerna version --no-push --no-git-tag-version --no-private --force-publish"
   },
   "devDependencies": {
     "@babel/preset-react": "^7.18.6",

--- a/scripts/pre-publish.sh
+++ b/scripts/pre-publish.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Force start from root folder
+cd "$(dirname "$0")/.."
+
+set -e
+
+version=$VERSION
+distTag=$DIST_TAG
+
+if [[ -z "$version" ]]; then
+  echo "Please enter the version you want to publish"
+  read -r version
+fi
+
+if [[ -z "$distTag" ]]; then
+  echo "Please enter the dist-tag you want to publish with"
+  read -r distTag
+fi
+
+# publish packages
+./node_modules/.bin/lerna publish "$version" --no-push --no-git-tag-version --force-publish --dist-tag "$distTag" $@


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* Adds Github action for people to make their own experimental releases exactly the same as Strapi

### Why is it needed?

* Will give more autonomy to squads

### Note

@alexandrebodin what's the best way to handle the NPM token? Should I add my own or would it make more sense to add a more generic user? I'm not sure what we use for the main Strapi repo.
