### PR TITLE
Remove field hint type check for string

### DIFF
--- a/packages/strapi-design-system/src/Field/FieldHint.tsx
+++ b/packages/strapi-design-system/src/Field/FieldHint.tsx
@@ -4,7 +4,7 @@ import { Typography } from '../Typography';
 export const FieldHint = () => {
   const { id, hint, error } = useField();
 
-  if (!hint || typeof hint !== 'string' || error) {
+  if (!hint || error) {
     return null;
   }
 

--- a/packages/strapi-design-system/src/Field/__tests__/Field.spec.tsx
+++ b/packages/strapi-design-system/src/Field/__tests__/Field.spec.tsx
@@ -48,6 +48,13 @@ describe('Field', () => {
       expect(getByRole('textbox')).toHaveAttribute('aria-describedby', expect.stringContaining('hint'));
     });
 
+    it('should render a ReactNode hint if passed', () => {
+      const { getByText, getByRole } = render({ hint: <>field hint</> });
+
+      expect(getByText('field hint')).toBeInTheDocument();
+      expect(getByRole('textbox')).toHaveAttribute('aria-describedby', expect.stringContaining('hint'));
+    });
+
     it('should render the error if passed and if the hint is passed, it should not render that', () => {
       const { getByRole, getByText, queryByText, rerender } = render({ error: 'field error' });
 
@@ -56,6 +63,21 @@ describe('Field', () => {
       expect(getByRole('textbox')).toHaveAttribute('aria-invalid', 'true');
 
       rerender(<Component error="field error" hint="field hint" />);
+
+      expect(queryByText('field hint')).not.toBeInTheDocument();
+      expect(getByText('field error')).toBeInTheDocument();
+      expect(getByRole('textbox')).toHaveAttribute('aria-describedby', expect.stringContaining('error'));
+      expect(getByRole('textbox')).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('should render the error if passed and if the ReactNode hint is passed, it should not render that', () => {
+      const { getByRole, getByText, queryByText, rerender } = render({ error: 'field error' });
+
+      expect(getByText('field error')).toBeInTheDocument();
+      expect(getByRole('textbox')).toHaveAttribute('aria-describedby', expect.stringContaining('error'));
+      expect(getByRole('textbox')).toHaveAttribute('aria-invalid', 'true');
+
+      rerender(<Component error="field error" hint={<>field hint</>} />);
 
       expect(queryByText('field hint')).not.toBeInTheDocument();
       expect(getByText('field error')).toBeInTheDocument();


### PR DESCRIPTION
### What does it do?

Removed `typeof hint !== 'string'` check in `FieldHint.tsx`

### Why is it needed?

ReactNodes won't go through the check. This input
```javascript
<TextInput
  label="Key"
  hint={
    <>
      Do this{" "}
      <Link href="https://strapi.io/" isExternal>
        here
      </Link>
    </>
  }
  required
/>
```

wouldn't display a hint due to it not being a string.

### How to test it?

Not sure, whether additional tests are needed.

### Related issue(s)/PR(s)

—
