### PR TITLE
BaseButton: Merge background prop with falsy values

### DIFF
--- a/docs/stories/IconButton.stories.mdx
+++ b/docs/stories/IconButton.stories.mdx
@@ -43,7 +43,7 @@ minimal and by so, efficient in small areas. Icon Buttons should be associated w
           <Box paddingBottom={3}>
             <Typography>{currentAction}</Typography>
           </Box>
-          <Flex>
+          <Flex background="neutral100" gap={1} padding={2}>
             <IconButton onClick={() => setCurrentAction('edit')} label="Edit" icon={<Pencil />} />
             <IconButton onClick={() => setCurrentAction('Create')} label="Create" icon={<Plus />} />
             <IconButton onClick={() => setCurrentAction('Delete')} label="Delete" icon={<Trash />} />
@@ -68,7 +68,7 @@ Depending on the status of an action or the permissions, an IconButton can be un
           <Box paddingBottom={3}>
             <Typography>{currentAction}</Typography>
           </Box>
-          <Flex>
+          <Flex background="neutral100" gap={1} padding={2}>
             <IconButton disabled onClick={() => setCurrentAction('edit')} label="Edit" icon={<Pencil />} />
             <IconButton disabled onClick={() => setCurrentAction('Create')} label="Create" icon={<Plus />} />
             <IconButton disabled onClick={() => setCurrentAction('Delete')} label="Delete" icon={<Trash />} />
@@ -89,7 +89,9 @@ the button.**
 <Canvas>
   <Story name="without tooltip">
     <Box padding={7}>
-      <IconButton onClick={() => console.log('edit')} aria-label="Edit" icon={<Pencil />} />
+      <Flex background="neutral100" gap={1} padding={2}>
+        <IconButton onClick={() => console.log('edit')} aria-label="Edit" icon={<Pencil />} />
+      </Flex>
     </Box>
   </Story>
 </Canvas>
@@ -101,12 +103,14 @@ IconButtons can be used within another component is a Group shape.
 <Canvas>
   <Story name="group">
     <Box padding={7}>
-      <IconButtonGroup>
-        <IconButton onClick={() => console.log('edit')} label="Edit" icon={<Pencil />} />
-        <IconButton onClick={() => console.log('Create')} label="Create" icon={<Plus />} />
-        <IconButton onClick={() => console.log('Delete')} label="Delete" icon={<Trash />} />
-        <IconButton onClick={() => console.log('Publish')} label="Publish" icon={<Play />} />
-      </IconButtonGroup>
+      <Flex background="neutral100" gap={1} padding={2}>
+        <IconButtonGroup>
+          <IconButton onClick={() => console.log('edit')} label="Edit" icon={<Pencil />} />
+          <IconButton onClick={() => console.log('Create')} label="Create" icon={<Plus />} />
+          <IconButton onClick={() => console.log('Delete')} label="Delete" icon={<Trash />} />
+          <IconButton onClick={() => console.log('Publish')} label="Publish" icon={<Play />} />
+        </IconButtonGroup>
+      </Flex>
     </Box>
   </Story>
 </Canvas>
@@ -124,7 +128,7 @@ IconButtons can take Icons as their children and can be fully accessible without
           <Box paddingBottom={3}>
             <Typography>{currentAction}</Typography>
           </Box>
-          <Flex>
+          <Flex background="neutral100" gap={1} padding={2}>
             <IconButton onClick={() => setCurrentAction('Edit')} aria-label="Edit">
               <Pencil />
             </IconButton>

--- a/packages/strapi-design-system/src/BaseButton/BaseButton.tsx
+++ b/packages/strapi-design-system/src/BaseButton/BaseButton.tsx
@@ -28,7 +28,7 @@ export interface BaseButtonProps<TElement extends HTMLElement = HTMLButtonElemen
 }
 
 export const BaseButton = React.forwardRef<HTMLButtonElement, BaseButtonProps>(
-  ({ disabled, children, ...props }, ref) => {
+  ({ disabled, children, background = 'neutral0', ...props }, ref) => {
     return (
       <BaseButtonWrapper
         ref={ref}
@@ -38,7 +38,7 @@ export const BaseButton = React.forwardRef<HTMLButtonElement, BaseButtonProps>(
         disabled={disabled}
         padding={2}
         hasRadius
-        background="neutral0"
+        background={background}
         borderColor="neutral200"
         cursor="pointer"
         {...props}

--- a/packages/strapi-design-system/src/ModalLayout/__tests__/ModalLayout.spec.js
+++ b/packages/strapi-design-system/src/ModalLayout/__tests__/ModalLayout.spec.js
@@ -61,6 +61,7 @@ describe('ModalLayout', () => {
       }
 
       .c9 {
+        background: #ffffff;
         padding: 8px;
         border-radius: 4px;
         border-color: #dcdce4;


### PR DESCRIPTION
### What does it do?

- Updates the `IconButton` stories to use a background-color, which is never used in the button itself to make the background-color of the button itself visible. Before they were the same which made me miss they are now transparent instead of white.
- Merges the `background` prop in `BaseButton`

### Why is it needed?

Components inheriting from `BaseButton` may set `background=undefined` if they don't want to set a background-color explicitly (e.g. for a ternary). Merging props with `background=undefined` leads to the original value being overwritten. This PR prevents that by checking for a fasly value.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

- Broke in https://github.com/strapi/design-system/pull/878
