### PR TITLE
IconButton: Allow passing background and borderWidth as props

### DIFF
--- a/packages/strapi-design-system/src/IconButton/IconButton.tsx
+++ b/packages/strapi-design-system/src/IconButton/IconButton.tsx
@@ -42,7 +42,18 @@ type IconButtonProps = ChildrenWithLabel | ChildrenWithAriaLabel | IconWithLabel
 
 export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
   (
-    { label, noBorder = false, children, icon, disabled = false, onClick, 'aria-label': ariaLabel, ...restProps },
+    {
+      label,
+      background,
+      borderWidth,
+      noBorder = false,
+      children,
+      icon,
+      disabled = false,
+      onClick,
+      'aria-label': ariaLabel,
+      ...restProps
+    },
     ref,
   ) => {
     const handleClick: React.MouseEventHandler<HTMLButtonElement> = (e) => {
@@ -54,8 +65,8 @@ export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
     const component = (
       <IconButtonWrapper
         aria-disabled={disabled}
-        background={disabled ? 'neutral150' : undefined}
-        borderWidth={noBorder ? 0 : undefined}
+        background={disabled ? 'neutral150' : background}
+        borderWidth={noBorder ? 0 : borderWidth}
         justifyContent="center"
         height={`${32 / 16}rem`}
         width={`${32 / 16}rem`}


### PR DESCRIPTION
### What does it do?

I've made a mistake in https://github.com/strapi/design-system/pull/878 which made it impossible to pass `background` and `borderWidth` to `IconButton`. With this PR it is finally possible.

### Why is it needed?

To support all `Box` props properly and apply sensible defaults.

