### PR TITLE
Fix/add ts declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ test-results
 playwright-report
 packages/strapi-icons/src
 coverage
+types

--- a/packages/strapi-design-system/.eslintignore
+++ b/packages/strapi-design-system/.eslintignore
@@ -1,2 +1,3 @@
 **/node_modules/**
 **/dist/**
+**/types/**

--- a/packages/strapi-design-system/package.json
+++ b/packages/strapi-design-system/package.json
@@ -62,7 +62,7 @@
     "develop": "vite build --watch",
     "build": "yarn build:prod && yarn generate:types",
     "build:prod": "vite build",
-    "clean": "rm -rf dist node_modules",
+    "clean": "rm -rf dist node_modules types",
     "generate:types": "tsc --noEmit false --emitDeclarationOnly --declaration --declarationDir types",
     "lint": "eslint . --ext .js,.jsx,.tsx,.ts",
     "format": "yarn lint --fix",

--- a/packages/strapi-design-system/package.json
+++ b/packages/strapi-design-system/package.json
@@ -6,7 +6,7 @@
   "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "types": "./types/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/index.js",
@@ -60,10 +60,10 @@
   },
   "scripts": {
     "develop": "vite build --watch",
-    "build": "yarn build:prod",
+    "build": "yarn build:prod && yarn generate:types",
     "build:prod": "vite build",
     "clean": "rm -rf dist node_modules",
-    "generate:types": "tsc --noEmit false --emitDeclarationOnly --declarationDir dist",
+    "generate:types": "tsc --noEmit false --emitDeclarationOnly --declaration --declarationDir types",
     "lint": "eslint . --ext .js,.jsx,.tsx,.ts",
     "format": "yarn lint --fix",
     "test": "jest -c jest.config.js",

--- a/packages/strapi-design-system/src/Popover/Popover.tsx
+++ b/packages/strapi-design-system/src/Popover/Popover.tsx
@@ -29,7 +29,7 @@ const PopoverWrapper = styled(Box)`
   background: ${({ theme }) => theme.colors.neutral0};
 `;
 
-interface ContentProps extends BoxProps<HTMLDivElement> {
+export interface ContentProps extends BoxProps<HTMLDivElement> {
   source: React.MutableRefObject<HTMLElement>;
   placement?: Placement;
   fullWidth?: boolean;

--- a/packages/strapi-icons/package.json
+++ b/packages/strapi-icons/package.json
@@ -13,9 +13,10 @@
     },
     "./*": "./dist/*"
   },
-  "types": "./dist/index.d.ts",
+  "types": "./types/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "types"
   ],
   "devDependencies": {
     "@svgr/cli": "6.5.1",
@@ -33,7 +34,7 @@
     "build:prod": "vite build",
     "clean": "rm -rf src dist node_modules",
     "generate:icons": "svgr -- ./assets/icons",
-    "generate:types": "tsc --noEmit false --emitDeclarationOnly --declarationDir dist"
+    "generate:types": "tsc --noEmit false --emitDeclarationOnly --declaration --declarationDir ./types"
   },
   "gitHead": "c74900b0ee3525510d266dc83c9743cb24dafced"
 }

--- a/packages/strapi-icons/package.json
+++ b/packages/strapi-icons/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "build": "yarn generate:icons && yarn build:prod && yarn generate:types",
     "build:prod": "vite build",
-    "clean": "rm -rf src dist node_modules",
+    "clean": "rm -rf src dist node_modules types",
     "generate:icons": "svgr -- ./assets/icons",
     "generate:types": "tsc --noEmit false --emitDeclarationOnly --declaration --declarationDir ./types"
   },

--- a/packages/strapi-icons/tsconfig.json
+++ b/packages/strapi-icons/tsconfig.json
@@ -16,7 +16,6 @@
     "isolatedModules": true,
     "noEmit": true,
     "outDir": "dist",
-    "declaration": true,
     "jsx": "react-jsx",
     "types": ["vite/client"]
   },


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

This PR builds the design-system and icons ts declaration files into a separate folder and adds them to the package.json

### Why is it needed?

Whenever creating a new strapi plugin, I am having to work around the missing types by declaring the module, removing the benefits of using typescript for a consumer of the package

### How to test it?

You can verify that the ./types folder exists after running `yarn build` within the repository

### Related issue(s)/PR(s)

Related to #633 