### PR TITLE
create the useInternationalizedNumber hook

### DIFF
--- a/packages/strapi-design-system/src/NumberInput/NumberInput.js
+++ b/packages/strapi-design-system/src/NumberInput/NumberInput.js
@@ -1,17 +1,16 @@
 /* eslint-disable no-restricted-globals */
-import React, { useRef } from 'react';
+import React from 'react';
 
-import { NumberFormatter, NumberParser } from '@internationalized/number';
 import { CarretDown } from '@strapi/icons';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 import { Field, FieldLabel, FieldHint, FieldError, FieldInput } from '../Field';
 import { Flex } from '../Flex';
-import { getDefaultLocale } from '../helpers/getDefaultLocale';
 import { KeyboardKeys } from '../helpers/keyboardKeys';
 import { useControllableState } from '../hooks/useControllableState';
 import { useId } from '../hooks/useId';
+import { useInternationalizedNumber } from '../hooks/useInternationalizedNumber';
 import { Icon } from '../Icon';
 import { sizes } from '../themes/sizes';
 
@@ -53,9 +52,10 @@ export const NumberInput = React.forwardRef(
   ) => {
     const generatedId = useId(id);
 
-    const locale = defaultLocale || getDefaultLocale();
-    const numberParserRef = useRef(new NumberParser(locale, { style: 'decimal' }));
-    const numberFormaterRef = useRef(new NumberFormatter(locale, { maximumFractionDigits: 20 }));
+    const { parser, formatter } = useInternationalizedNumber(defaultLocale, {
+      parserParams: { style: 'decimal' },
+      formatParams: { maximumFractionDigits: 20 },
+    });
 
     const [inputValue, setInputValue] = useControllableState({
       prop(currentInputValue) {
@@ -78,7 +78,7 @@ export const NumberInput = React.forwardRef(
         /**
          * always return a
          */
-        const parsedValue = numberParserRef.current.parse(value);
+        const parsedValue = parser.parse(value);
         onValueChange(isNaN(parsedValue) ? undefined : parsedValue);
       },
     });
@@ -95,7 +95,7 @@ export const NumberInput = React.forwardRef(
      * @type {React.ChangeEventHandler<HTMLInputElement>}
      */
     const handelInputChange = ({ target: { value } }) => {
-      if (numberParserRef.current.isValidPartialNumber(value)) {
+      if (parser.isValidPartialNumber(value)) {
         formatNumberAndSetInput(value);
       }
     };
@@ -107,11 +107,11 @@ export const NumberInput = React.forwardRef(
         return;
       }
 
-      const parsedValue = numberParserRef.current.parse(inputValue);
+      const parsedValue = parser.parse(inputValue);
 
       const newValue = isNaN(parsedValue) ? step : parsedValue + step;
 
-      formatNumberAndSetInput(numberFormaterRef.current.format(newValue));
+      formatNumberAndSetInput(formatter.format(newValue));
     };
 
     const decrement = () => {
@@ -121,11 +121,11 @@ export const NumberInput = React.forwardRef(
         return;
       }
 
-      const parsedValue = numberParserRef.current.parse(inputValue);
+      const parsedValue = parser.parse(inputValue);
 
       const newValue = isNaN(parsedValue) ? -step : parsedValue - step;
 
-      formatNumberAndSetInput(numberFormaterRef.current.format(newValue));
+      formatNumberAndSetInput(formatter.format(newValue));
     };
 
     const handleKeyDown = (e) => {
@@ -155,8 +155,8 @@ export const NumberInput = React.forwardRef(
      */
     const handleBlur = () => {
       if (inputValue) {
-        const parsedValue = numberParserRef.current.parse(inputValue);
-        const formattedValue = isNaN(parsedValue) ? '' : numberFormaterRef.current.format(parsedValue);
+        const parsedValue = parser.parse(inputValue);
+        const formattedValue = isNaN(parsedValue) ? '' : formatter.format(parsedValue);
         formatNumberAndSetInput(formattedValue);
       }
     };

--- a/packages/strapi-design-system/src/hooks/useInternationalizedNumber.ts
+++ b/packages/strapi-design-system/src/hooks/useInternationalizedNumber.ts
@@ -1,0 +1,17 @@
+import { useRef } from 'react';
+
+import { NumberFormatter, NumberParser } from '@internationalized/number';
+
+import { getDefaultLocale } from '../helpers/getDefaultLocale';
+
+export const useInternationalizedNumber = (locale, { parserParams, formatParams }) => {
+  // define the locale or use the default one
+  const finalLocale = locale || getDefaultLocale();
+  const numberParserRef = useRef(new NumberParser(finalLocale, parserParams));
+  const numberFormaterRef = useRef(new NumberFormatter(finalLocale, formatParams));
+
+  return {
+    parser: numberParserRef.current,
+    formatter: numberFormaterRef.current,
+  };
+};


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Add a new hook `useInternationalizedNumber` to create a number formatter and a number parser using the `@internationalized/number` library.
And also we have replaced all the code with the new hook inside the NumberInput component

### Why is it needed?

Becuase it is useful if we want in future to use again the library, we need just to add the hook to configure the library, and also can be useful in the CMS where we have to show the number with a specific locale format

### How to test it?

Just take a look at the NumberInput component

