### PR TITLE
Fixes issue with date picker icon not being visible in dark mode

### DIFF
--- a/packages/strapi-design-system/src/DatePicker/DatePicker.tsx
+++ b/packages/strapi-design-system/src/DatePicker/DatePicker.tsx
@@ -7,6 +7,7 @@ import { DatePickerWrapper } from './components';
 import { DatePickerCalendar, DatePickerCalendarProps } from './DatePickerCalendar';
 import { formatDate } from './utils/formatDate';
 import { FieldAction } from '../Field';
+import { Flex } from '../Flex';
 import { getDefaultLocale } from '../helpers/getDefaultLocale';
 import { TextInput, TextInputProps } from '../TextInput';
 
@@ -90,7 +91,11 @@ export const DatePicker = ({
         // Prevent input from changing for now
         onChange={() => {}}
         value={formattedDate}
-        startAction={<CalendarIcon aria-hidden />}
+        startAction={
+          <CalendarIconWrapper>
+            <CalendarIcon aria-hidden />
+          </CalendarIconWrapper>
+        }
         endAction={
           onClear && formattedDate ? (
             <FieldAction label={clearLabel} onClick={handleClear} aria-disabled={disabled || undefined}>
@@ -127,5 +132,16 @@ const StyledCross = styled(Cross)`
 
   path {
     fill: ${({ theme }) => theme.colors.neutral600};
+  }
+`;
+
+const CalendarIconWrapper = styled(Flex)`
+  & > svg {
+    height: 1rem;
+    width: 1rem;
+  }
+
+  & > svg path {
+    fill: ${({ theme }) => theme.colors.neutral500};
   }
 `;

--- a/packages/strapi-design-system/src/DatePicker/DatePicker.tsx
+++ b/packages/strapi-design-system/src/DatePicker/DatePicker.tsx
@@ -7,7 +7,6 @@ import { DatePickerWrapper } from './components';
 import { DatePickerCalendar, DatePickerCalendarProps } from './DatePickerCalendar';
 import { formatDate } from './utils/formatDate';
 import { FieldAction } from '../Field';
-import { Flex } from '../Flex';
 import { getDefaultLocale } from '../helpers/getDefaultLocale';
 import { TextInput, TextInputProps } from '../TextInput';
 
@@ -91,11 +90,7 @@ export const DatePicker = ({
         // Prevent input from changing for now
         onChange={() => {}}
         value={formattedDate}
-        startAction={
-          <CalendarIconWrapper>
-            <CalendarIcon aria-hidden />
-          </CalendarIconWrapper>
-        }
+        startAction={<StyledCalendarIcon aria-hidden />}
         endAction={
           onClear && formattedDate ? (
             <FieldAction label={clearLabel} onClick={handleClear} aria-disabled={disabled || undefined}>
@@ -135,13 +130,8 @@ const StyledCross = styled(Cross)`
   }
 `;
 
-const CalendarIconWrapper = styled(Flex)`
-  & > svg {
-    height: 1rem;
-    width: 1rem;
-  }
-
-  & > svg path {
+const StyledCalendarIcon = styled(CalendarIcon)`
+  & > path {
     fill: ${({ theme }) => theme.colors.neutral500};
   }
 `;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Fixes issue with date picker icon not being visible in dark mode

### Why is it needed?

The icon for date picker was only visible in light mode

### How to test it?

1. Go to storybook for design system and go to DatePicker or DateTimePicker components. 
2. Toggle between light and dark mode
3. The icon on date picker should be visible on both modes and should be the same colour as the icon for time picker

### Related issue(s)/PR(s)

Haven't created an issue for this. Let me know if I should create one
