### PR TITLE
Remove z-index causing navbar overlap in the CMS

### DIFF
--- a/packages/strapi-design-system/src/Layout/HeaderLayout.js
+++ b/packages/strapi-design-system/src/Layout/HeaderLayout.js
@@ -56,6 +56,7 @@ HeaderLayout.displayName = 'HeaderLayout';
 
 const StickyBox = styled(Box)`
   width: ${(props) => props.width}px;
+  z-index: ${({ theme }) => theme.zIndices[1]};
 `;
 
 export const BaseHeaderLayout = React.forwardRef(
@@ -75,7 +76,6 @@ export const BaseHeaderLayout = React.forwardRef(
           background="neutral0"
           shadow="tableShadow"
           width={width}
-          zIndex={4}
           data-strapi-header-sticky
         >
           <Flex justifyContent="space-between">

--- a/packages/strapi-design-system/src/Popover/Popover.tsx
+++ b/packages/strapi-design-system/src/Popover/Popover.tsx
@@ -24,7 +24,6 @@ export const POPOVER_PLACEMENTS = [
 
 const PopoverWrapper = styled(Box)`
   box-shadow: ${({ theme }) => theme.shadows.filterShadow};
-  z-index: 4;
   border: 1px solid ${({ theme }) => theme.colors.neutral150};
   background: ${({ theme }) => theme.colors.neutral0};
 `;

--- a/packages/strapi-design-system/src/Popover/Popover.tsx
+++ b/packages/strapi-design-system/src/Popover/Popover.tsx
@@ -24,6 +24,7 @@ export const POPOVER_PLACEMENTS = [
 
 const PopoverWrapper = styled(Box)`
   box-shadow: ${({ theme }) => theme.shadows.filterShadow};
+  z-index: ${({ theme }) => theme.zIndices[0]};
   border: 1px solid ${({ theme }) => theme.colors.neutral150};
   background: ${({ theme }) => theme.colors.neutral0};
 `;

--- a/packages/strapi-design-system/src/Popover/__tests__/Popover.spec.tsx
+++ b/packages/strapi-design-system/src/Popover/__tests__/Popover.spec.tsx
@@ -49,7 +49,6 @@ describe('Popover', () => {
 
       .c2 {
         box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
-        z-index: 4;
         border: 1px solid #eaeaef;
         background: #ffffff;
       }

--- a/packages/strapi-design-system/src/Popover/__tests__/Popover.spec.tsx
+++ b/packages/strapi-design-system/src/Popover/__tests__/Popover.spec.tsx
@@ -49,6 +49,7 @@ describe('Popover', () => {
 
       .c2 {
         box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
+        z-index: 5;
         border: 1px solid #eaeaef;
         background: #ffffff;
       }


### PR DESCRIPTION
### What does it do?

Removes the z-index which is apparently unnecessary.

### Why is it needed?

The z-index causes the popover to overlap a navbar in the CMS
Berfore:
![Screenshot 2023-04-20 at 17 44 11](https://user-images.githubusercontent.com/26598053/233418454-87a8b8b4-cc41-44fd-aa0b-4b4257e1e3a9.png)
After:
![Screenshot 2023-04-20 at 17 37 16](https://user-images.githubusercontent.com/26598053/233417474-747ae5a9-a2e7-4644-a97c-aae8fcf1e3d3.png)


### How to test it?

Run yarn build in the DS
Head to the CMS and from the root run

```
yarn link -r ../<relative-path-to-strapi-design-system>
```
In examples getstarted yarn build && yarn develop
Go to the CM or Audit Logs or the Marketplace, make sure you have enough content to be scrollable, and scroll down the page.

(I'll update the strapi docs since it seem yarn link works differently now)
