### PR TITLE
Update to react18 internally & allow in peer-deps

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -14,9 +14,9 @@
     "@strapi/icons": "^1.7.0-alpha.2",
     "@strapi/ui-primitives": "^1.7.0-alpha.2",
     "qs": "^6.11.1",
-    "react": "17.0.2",
+    "react": "18.2.0",
     "react-copy-to-clipboard": "^5.1.0",
-    "react-dom": "17.0.2",
+    "react-dom": "18.2.0",
     "react-router-dom": "5.3.4",
     "storybook-dark-mode": "^2.1.1",
     "styled-components": "^5.3.10"

--- a/package.json
+++ b/package.json
@@ -38,12 +38,12 @@
     "@swc/core": "^1.3.55",
     "@swc/jest": "^0.2.26",
     "@testing-library/jest-dom": "5.16.5",
-    "@testing-library/react": "12.1.5",
+    "@testing-library/react": "14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "@tsconfig/node16": "^1.0.3",
     "@types/jest": "^29.5.1",
-    "@types/react": "17.0.58",
-    "@types/react-dom": "17.0.19",
+    "@types/react": "18.2.0",
+    "@types/react-dom": "18.2.0",
     "@typescript-eslint/eslint-plugin": "^5.59.1",
     "@typescript-eslint/parser": "^5.59.1",
     "@vitejs/plugin-react": "^4.0.0",
@@ -69,16 +69,12 @@
     "lerna": "^6.6.1",
     "nx": "15.9.2",
     "prettier": "^2.8.8",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "rimraf": "^5.0.0",
     "tiny-glob": "^0.2.9",
     "typescript": "^5.0.4",
     "vite": "^4.3.2"
-  },
-  "resolutions": {
-    "@types/react": "17.0.2",
-    "@types/react-dom": "17.0.2"
   },
   "packageManager": "yarn@3.5.0"
 }

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -40,8 +40,8 @@
     "react-remove-scroll": "^2.5.5"
   },
   "peerDependencies": {
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "vite-plugin-dts": "^2.3.0"

--- a/packages/primitives/src/components/Select/Select.tsx
+++ b/packages/primitives/src/components/Select/Select.tsx
@@ -426,7 +426,7 @@ const SelectValue = React.forwardRef<SelectValueElement, SelectValueProps>(
       }
     }, [context.value, getItems, valuedItems]);
 
-    let renderValue = children;
+    let renderValue: React.ReactNode;
 
     if ((context.value === undefined || context.value.length === 0) && placeholder !== undefined) {
       renderValue = <span>{placeholder}</span>;
@@ -446,6 +446,8 @@ const SelectValue = React.forwardRef<SelectValueElement, SelectValueProps>(
       } else {
         renderValue = children(context.value);
       }
+    } else {
+      renderValue = children;
     }
 
     /**
@@ -1482,7 +1484,7 @@ interface SelectItemIndicatorProps extends Omit<PrimitiveSpanProps, 'children'> 
 
 const SelectItemIndicator = React.forwardRef<SelectItemIndicatorElement, SelectItemIndicatorProps>(
   (props: ScopedProps<SelectItemIndicatorProps>, forwardedRef) => {
-    const { __scopeSelect, ...itemIndicatorProps } = props;
+    const { __scopeSelect, children, ...itemIndicatorProps } = props;
     const itemContext = useSelectItemContext(ITEM_INDICATOR_NAME, __scopeSelect);
 
     /**
@@ -1494,10 +1496,10 @@ const SelectItemIndicator = React.forwardRef<SelectItemIndicatorElement, SelectI
      * to how isSelected is passed. So for "group parents", they can be correctly styled.
      */
 
-    if (typeof props.children === 'function') {
+    if (typeof children === 'function') {
       return (
         <Primitive.span aria-hidden {...itemIndicatorProps} ref={forwardedRef}>
-          {props.children({
+          {children({
             isSelected: itemContext.isSelected,
             isIntermediate: itemContext.isIntermediate,
           })}
@@ -1505,7 +1507,11 @@ const SelectItemIndicator = React.forwardRef<SelectItemIndicatorElement, SelectI
       );
     }
 
-    return itemContext.isSelected ? <Primitive.span aria-hidden {...itemIndicatorProps} ref={forwardedRef} /> : null;
+    return itemContext.isSelected ? (
+      <Primitive.span aria-hidden {...itemIndicatorProps} ref={forwardedRef}>
+        {children}
+      </Primitive.span>
+    ) : null;
   },
 );
 

--- a/packages/strapi-design-system/package.json
+++ b/packages/strapi-design-system/package.json
@@ -41,8 +41,8 @@
   },
   "peerDependencies": {
     "@strapi/icons": "^1.5.0",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1",
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0",
     "react-router-dom": "^5.2.0",
     "styled-components": "^5.2.1"
   },
@@ -61,10 +61,6 @@
     "test:e2e:ci": "cross-env CI=true playwright test",
     "test:e2e:watch": "chokidar '**/__tests__/*.e2e.js' -c 'npm run test:e2e -- --retries=0 {path}'",
     "test:e2e:debug": "cross-env PWDEBUG=1 playwright test"
-  },
-  "resolutions": {
-    "@types/react": "17.0.2",
-    "@types/react-dom": "17.0.2"
   },
   "gitHead": "c74900b0ee3525510d266dc83c9743cb24dafced"
 }

--- a/packages/strapi-design-system/src/Combobox/Combobox.tsx
+++ b/packages/strapi-design-system/src/Combobox/Combobox.tsx
@@ -119,7 +119,7 @@ export const Combobox = ({
     }
   };
 
-  const intersectionId = `intersection-${generatedId}`;
+  const intersectionId = `intersection-${CSS.escape(generatedId)}`;
 
   const handleReachEnd = (entry: IntersectionObserverEntry) => {
     if (onLoadMore && hasMoreItems && !loading) {

--- a/packages/strapi-design-system/src/Popover/Popover.tsx
+++ b/packages/strapi-design-system/src/Popover/Popover.tsx
@@ -98,14 +98,14 @@ export const Scrolling = ({ children, intersectionId, onReachEnd, ...props }: Sc
   const popoverRef = React.useRef<HTMLDivElement>(null!);
 
   useIntersection(popoverRef, onReachEnd ?? (() => {}), {
-    selectorToWatch: `#${intersectionId}`,
+    selectorToWatch: `#${CSS.escape(intersectionId ?? '')}`,
     skipWhen: !intersectionId || !onReachEnd,
   });
 
   return (
     <PopoverScrollable ref={popoverRef} {...props}>
       {children}
-      {intersectionId && onReachEnd && <Box id={intersectionId} width="100%" height="1px" />}
+      {intersectionId && onReachEnd && <Box id={CSS.escape(intersectionId)} width="100%" height="1px" />}
     </PopoverScrollable>
   );
 };

--- a/packages/strapi-design-system/src/Select/MultiSelect.tsx
+++ b/packages/strapi-design-system/src/Select/MultiSelect.tsx
@@ -113,7 +113,7 @@ export const MultiSelect = ({
     triggerRef.current.focus();
   };
 
-  const intersectionId = `intersection-${generatedId}`;
+  const intersectionId = `intersection-${CSS.escape(generatedId)}`;
 
   const handleReachEnd = (entry: IntersectionObserverEntry) => {
     if (onReachEnd) {
@@ -132,12 +132,16 @@ export const MultiSelect = ({
 
   const value = typeof passedValue !== 'undefined' ? passedValue : internalValue;
 
-  const renderTags = ({ value, textValue }: { value: string; textValue?: string }) => {
-    return (
-      <Tag tabIndex={-1} key={value} disabled={disabled} icon={<Cross />} onClick={handleTagClick(value)}>
-        {textValue}
-      </Tag>
-    );
+  const renderTags: SelectParts.ValueRenderFn = (arg?: { value?: string; textValue?: string } | string) => {
+    if (arg && typeof arg === 'object' && arg.value) {
+      return (
+        <Tag tabIndex={-1} key={arg.value} disabled={disabled} icon={<Cross />} onClick={handleTagClick(arg.value)}>
+          {arg.textValue}
+        </Tag>
+      );
+    }
+
+    return null;
   };
 
   return (

--- a/packages/strapi-design-system/src/Select/SelectParts.tsx
+++ b/packages/strapi-design-system/src/Select/SelectParts.tsx
@@ -145,7 +145,9 @@ const DownIcon = styled(Select.Icon)`
  * SelectValue
  * -----------------------------------------------------------------------------------------------*/
 
-interface ValueProps extends TypographyProps {
+interface ValueProps
+  extends Omit<TypographyProps, 'children' | 'placeholder'>,
+    Pick<Select.SelectValueProps, 'placeholder' | 'children'> {
   asChild?: boolean;
 }
 

--- a/packages/strapi-design-system/src/Select/SingleSelect.tsx
+++ b/packages/strapi-design-system/src/Select/SingleSelect.tsx
@@ -100,7 +100,7 @@ export const SingleSelect = ({
   };
 
   const viewportRef = React.useRef<HTMLDivElement>(null);
-  const intersectionId = `intersection-${generatedId}`;
+  const intersectionId = `intersection-${CSS.escape(generatedId)}`;
 
   const handleReachEnd = (entry: IntersectionObserverEntry) => {
     if (onReachEnd) {

--- a/packages/strapi-design-system/src/Tooltip/__tests__/Tooltip.spec.tsx
+++ b/packages/strapi-design-system/src/Tooltip/__tests__/Tooltip.spec.tsx
@@ -50,7 +50,7 @@ describe('Tooltip', () => {
         <div>
           <span>
             <button
-              aria-describedby="0"
+              aria-describedby=":r0:"
               tabindex="0"
               type="button"
             >
@@ -85,7 +85,7 @@ describe('Tooltip', () => {
         >
           <div
             class="c1 c2"
-            id="0"
+            id=":r0:"
             role="tooltip"
           >
             <p
@@ -146,7 +146,7 @@ describe('Tooltip', () => {
         <div>
           <span>
             <button
-              aria-describedby="2"
+              aria-describedby=":r2:"
               tabindex="0"
               type="button"
             >
@@ -181,13 +181,13 @@ describe('Tooltip', () => {
         >
           <div
             class="c1 c2"
-            id="2"
+            id=":r2:"
             role="tooltip"
             style="left: 0px; top: -8px;"
           >
             <div
               class="c0"
-              id="3"
+              id=":r3:"
             >
               Content of the tooltip fefe
             </div>
@@ -249,7 +249,7 @@ describe('Tooltip', () => {
         <div>
           <span>
             <button
-              aria-labelledby="4"
+              aria-labelledby=":r4:"
               tabindex="0"
               type="button"
             >
@@ -284,13 +284,13 @@ describe('Tooltip', () => {
         >
           <div
             class="c1 c2"
-            id="4"
+            id=":r4:"
             role="tooltip"
             style="left: 0px; top: -8px;"
           >
             <div
               class="c0"
-              id="5"
+              id=":r5:"
             />
             <p
               class="c3"

--- a/packages/strapi-design-system/src/hooks/__tests__/useId.spec.tsx
+++ b/packages/strapi-design-system/src/hooks/__tests__/useId.spec.tsx
@@ -14,7 +14,7 @@ describe('useId', () => {
     expect(container).toMatchInlineSnapshot(`
       <div>
         <div
-          id="0"
+          id=":r0:"
         />
       </div>
     `);

--- a/packages/strapi-design-system/src/hooks/useIntersection.ts
+++ b/packages/strapi-design-system/src/hooks/useIntersection.ts
@@ -33,6 +33,10 @@ export const useIntersection = (
     };
 
     const observer = new IntersectionObserver(onEnterZone, options);
+    /**
+     * @note We need to escape the selector because we use `React.useId` to generate our ids an
+     * they contain `:` which is not a valid selector because it's part of the CSS spec
+     */
     const target = scrollableAreaRef.current.querySelector(selectorToWatch);
 
     if (target) {

--- a/packages/strapi-design-system/src/v2/SimpleMenu/SimpleMenu.tsx
+++ b/packages/strapi-design-system/src/v2/SimpleMenu/SimpleMenu.tsx
@@ -48,7 +48,7 @@ const SimpleMenu = ({ children, id, onOpen, onClose, popoverPlacement, onReachEn
 
   const generatedId = useId(id);
 
-  const intersectionId = `intersection-${generatedId}`;
+  const intersectionId = `intersection-${CSS.escape(generatedId)}`;
 
   useIntersection(contentRef, handleReachEnd, {
     selectorToWatch: `#${intersectionId}`,

--- a/packages/strapi-icons/package.json
+++ b/packages/strapi-icons/package.json
@@ -21,8 +21,8 @@
     "@svgr/cli": "7.0.0"
   },
   "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   },
   "scripts": {
     "build": "yarn generate:icons && yarn build:prod && yarn generate:types",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5095,9 +5095,9 @@ __metadata:
     "@strapi/ui-primitives": ^1.7.0-alpha.2
     eslint-plugin-mdx: ^1.17.1
     qs: ^6.11.1
-    react: 17.0.2
+    react: 18.2.0
     react-copy-to-clipboard: ^5.1.0
-    react-dom: 17.0.2
+    react-dom: 18.2.0
     react-router-dom: 5.3.4
     storybook-dark-mode: ^2.1.1
     styled-components: ^5.3.10
@@ -5128,8 +5128,8 @@ __metadata:
     styled-components: ^5.3.10
   peerDependencies:
     "@strapi/icons": ^1.5.0
-    react: ^17.0.1
-    react-dom: ^17.0.1
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^5.2.0
     styled-components: ^5.2.1
   languageName: unknown
@@ -5167,8 +5167,8 @@ __metadata:
   dependencies:
     "@svgr/cli": 7.0.0
   peerDependencies:
-    react: ^17.0.2
-    react-dom: ^17.0.2
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
   languageName: unknown
   linkType: soft
 
@@ -5193,8 +5193,8 @@ __metadata:
     react-remove-scroll: ^2.5.5
     vite-plugin-dts: ^2.3.0
   peerDependencies:
-    react: ^17.0.1
-    react-dom: ^17.0.1
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
   languageName: unknown
   linkType: soft
 
@@ -5501,9 +5501,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/dom@npm:^8.0.0":
-  version: 8.20.0
-  resolution: "@testing-library/dom@npm:8.20.0"
+"@testing-library/dom@npm:^9.0.0":
+  version: 9.2.0
+  resolution: "@testing-library/dom@npm:9.2.0"
   dependencies:
     "@babel/code-frame": ^7.10.4
     "@babel/runtime": ^7.12.5
@@ -5511,9 +5511,9 @@ __metadata:
     aria-query: ^5.0.0
     chalk: ^4.1.0
     dom-accessibility-api: ^0.5.9
-    lz-string: ^1.4.4
+    lz-string: ^1.5.0
     pretty-format: ^27.0.2
-  checksum: 1e599129a2fe91959ce80900a0a4897232b89e2a8e22c1f5950c36d39c97629ea86b4986b60b173b5525a05de33fde1e35836ea597b03de78cc51b122835c6f0
+  checksum: b145f43cd06ff083012cf2503aff6ccba97ff80715fcb106fe64af690f5536557bf24d37b97e8d685bbe3803d7f71d685ce71426cb1b9e250c3611e4372dcfa9
   languageName: node
   linkType: hard
 
@@ -5534,17 +5534,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/react@npm:12.1.5":
-  version: 12.1.5
-  resolution: "@testing-library/react@npm:12.1.5"
+"@testing-library/react@npm:14.0.0":
+  version: 14.0.0
+  resolution: "@testing-library/react@npm:14.0.0"
   dependencies:
     "@babel/runtime": ^7.12.5
-    "@testing-library/dom": ^8.0.0
-    "@types/react-dom": <18.0.0
+    "@testing-library/dom": ^9.0.0
+    "@types/react-dom": ^18.0.0
   peerDependencies:
-    react: <18.0.0
-    react-dom: <18.0.0
-  checksum: 4abd0490405e709a7df584a0db604e508a4612398bb1326e8fa32dd9393b15badc826dcf6d2f7525437886d507871f719f127b9860ed69ddd204d1fa834f576a
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  checksum: 4a54c8f56cc4a39b50803205f84f06280bb76521d6d5d4b3b36651d760c7c7752ef142d857d52aaf4fad4848ed7a8be49afc793a5dda105955d2f8bef24901ac
   languageName: node
   linkType: hard
 
@@ -5949,12 +5949,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-dom@npm:17.0.2":
-  version: 17.0.2
-  resolution: "@types/react-dom@npm:17.0.2"
+"@types/react-dom@npm:18.2.0":
+  version: 18.2.0
+  resolution: "@types/react-dom@npm:18.2.0"
   dependencies:
     "@types/react": "*"
-  checksum: 1725928a1c3a0026044e6401e6b53729e1a88849034fc67138d7784ec44a5132fe2e9056a19b741ccb462ff0ec0d8c2c01ef316bda19be0e31f2ead9346f600b
+  checksum: 9212b3793707a763f10e2c608f6ccb5f729029da6cb84204f333634d3d7baafbc1b20b7faf7cf788a8fd385050a1fb579902031f9462473ef10607116f33f33c
+  languageName: node
+  linkType: hard
+
+"@types/react-dom@npm:^18.0.0":
+  version: 18.2.1
+  resolution: "@types/react-dom@npm:18.2.1"
+  dependencies:
+    "@types/react": "*"
+  checksum: 4e607a9d08f707ae2bd6b377f1da32989dcbe4e38ac39110423a1f6bc95dd53a5484f7f952b34e9d12b5f29a265d52a8c74c1a7d1d1e25be0fa69ccf9d64209f
   languageName: node
   linkType: hard
 
@@ -5979,13 +5988,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:17.0.2":
-  version: 17.0.2
-  resolution: "@types/react@npm:17.0.2"
+"@types/react@npm:*, @types/react@npm:18.2.0":
+  version: 18.2.0
+  resolution: "@types/react@npm:18.2.0"
   dependencies:
     "@types/prop-types": "*"
+    "@types/scheduler": "*"
     csstype: ^3.0.2
-  checksum: a5198857165feddcbfc7d33e3322460ac62b8894d702414496a825b0c82272911ec33a42ef7c9d623a59308070eef4dfee6ff834b0674aa3f87eeb644196ee3b
+  checksum: db3d92b423150222a666329f7aa3023e3e942044700557b8a7d161530847e621aec9f56c9e7f71761b06dd164c8a7b17ad52355863efe80963dffa5537e8e5fd
+  languageName: node
+  linkType: hard
+
+"@types/scheduler@npm:*":
+  version: 0.16.3
+  resolution: "@types/scheduler@npm:0.16.3"
+  checksum: 2b0aec39c24268e3ce938c5db2f2e77f5c3dd280e05c262d9c2fe7d890929e4632a6b8e94334017b66b45e4f92a5aa42ba3356640c2a1175fa37bef2f5200767
   languageName: node
   linkType: hard
 
@@ -9858,12 +9875,12 @@ __metadata:
     "@swc/core": ^1.3.55
     "@swc/jest": ^0.2.26
     "@testing-library/jest-dom": 5.16.5
-    "@testing-library/react": 12.1.5
+    "@testing-library/react": 14.0.0
     "@testing-library/user-event": ^14.4.3
     "@tsconfig/node16": ^1.0.3
     "@types/jest": ^29.5.1
-    "@types/react": 17.0.58
-    "@types/react-dom": 17.0.19
+    "@types/react": 18.2.0
+    "@types/react-dom": 18.2.0
     "@typescript-eslint/eslint-plugin": ^5.59.1
     "@typescript-eslint/parser": ^5.59.1
     "@vitejs/plugin-react": ^4.0.0
@@ -9889,8 +9906,8 @@ __metadata:
     lerna: ^6.6.1
     nx: 15.9.2
     prettier: ^2.8.8
-    react: ^17.0.2
-    react-dom: ^17.0.2
+    react: ^18.2.0
+    react-dom: ^18.2.0
     rimraf: ^5.0.0
     tiny-glob: ^0.2.9
     typescript: ^5.0.4
@@ -15264,7 +15281,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lz-string@npm:^1.4.4":
+"lz-string@npm:^1.5.0":
   version: 1.5.0
   resolution: "lz-string@npm:1.5.0"
   bin:
@@ -18374,16 +18391,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:17.0.2, react-dom@npm:^17.0.2":
-  version: 17.0.2
-  resolution: "react-dom@npm:17.0.2"
+"react-dom@npm:18.2.0, react-dom@npm:^18.2.0":
+  version: 18.2.0
+  resolution: "react-dom@npm:18.2.0"
   dependencies:
     loose-envify: ^1.1.0
-    object-assign: ^4.1.1
-    scheduler: ^0.20.2
+    scheduler: ^0.23.0
   peerDependencies:
-    react: 17.0.2
-  checksum: 1c1eaa3bca7c7228d24b70932e3d7c99e70d1d04e13bb0843bbf321582bc25d7961d6b8a6978a58a598af2af496d1cedcfb1bf65f6b0960a0a8161cb8dab743c
+    react: ^18.2.0
+  checksum: 7d323310bea3a91be2965f9468d552f201b1c27891e45ddc2d6b8f717680c95a75ae0bc1e3f5cf41472446a2589a75aed4483aee8169287909fcd59ad149e8cc
   languageName: node
   linkType: hard
 
@@ -18537,13 +18553,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:17.0.2, react@npm:^17.0.2":
-  version: 17.0.2
-  resolution: "react@npm:17.0.2"
+"react@npm:18.2.0, react@npm:^18.2.0":
+  version: 18.2.0
+  resolution: "react@npm:18.2.0"
   dependencies:
     loose-envify: ^1.1.0
-    object-assign: ^4.1.1
-  checksum: b254cc17ce3011788330f7bbf383ab653c6848902d7936a87b09d835d091e3f295f7e9dd1597c6daac5dc80f90e778c8230218ba8ad599f74adcc11e33b9d61b
+  checksum: 88e38092da8839b830cda6feef2e8505dec8ace60579e46aa5490fc3dc9bba0bd50336507dc166f43e3afc1c42939c09fe33b25fae889d6f402721dcd78fca1b
   languageName: node
   linkType: hard
 
@@ -19384,13 +19399,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:^0.20.2":
-  version: 0.20.2
-  resolution: "scheduler@npm:0.20.2"
+"scheduler@npm:^0.23.0":
+  version: 0.23.0
+  resolution: "scheduler@npm:0.23.0"
   dependencies:
     loose-envify: ^1.1.0
-    object-assign: ^4.1.1
-  checksum: c4b35cf967c8f0d3e65753252d0f260271f81a81e427241295c5a7b783abf4ea9e905f22f815ab66676f5313be0a25f47be582254db8f9241b259213e999b8fc
+  checksum: d79192eeaa12abef860c195ea45d37cbf2bbf5f66e3c4dcd16f54a7da53b17788a70d109ee3d3dde1a0fd50e6a8fc171f4300356c5aee4fc0171de526bf35f8a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* Moves the repo to use `react@18` for local development and allows it as a peer-dep
* Fixes some types that needed better narrowing with react@18
* escapes the ID used in `useIntersection` so `useId` can be used.

### Why is it needed?

* We know react18 works fine with this library and as we move to make the CMS use `react@18` this is a part of that migration

### Related issue(s)/PR(s)

* Should be merged after #962 
