### PR TITLE
fix: only use a span on the placeholder text

### DIFF
--- a/packages/primitives/src/components/Select/Select.tsx
+++ b/packages/primitives/src/components/Select/Select.tsx
@@ -429,7 +429,7 @@ const SelectValue = React.forwardRef<SelectValueElement, SelectValueProps>(
     let renderValue = children;
 
     if ((context.value === undefined || context.value.length === 0) && placeholder !== undefined) {
-      renderValue = placeholder;
+      renderValue = <span>{placeholder}</span>;
     } else if (typeof children === 'function') {
       if (Array.isArray(context.value)) {
         const childrenArray = context.value.map((value) => {
@@ -454,7 +454,7 @@ const SelectValue = React.forwardRef<SelectValueElement, SelectValueProps>(
      */
     return (
       <Primitive.span {...valueProps} ref={composedRefs}>
-        {renderValue ? <span>{renderValue}</span> : null}
+        {renderValue ? renderValue : null}
       </Primitive.span>
     );
   },

--- a/packages/primitives/src/components/Select/Select.tsx
+++ b/packages/primitives/src/components/Select/Select.tsx
@@ -454,7 +454,7 @@ const SelectValue = React.forwardRef<SelectValueElement, SelectValueProps>(
      */
     return (
       <Primitive.span {...valueProps} ref={composedRefs}>
-        {renderValue ? renderValue : null}
+        {renderValue || null}
       </Primitive.span>
     );
   },


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* wraps only the placeholder in a span

### Why is it needed?

* ensure styling is used and the placeholder re-renders after portals
