### PR TITLE
close popover when clicking away

### DIFF
--- a/packages/strapi-design-system/src/Popover/Popover.tsx
+++ b/packages/strapi-design-system/src/Popover/Popover.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { useFloating, flip, shift, offset, autoUpdate, Placement } from '@floating-ui/react-dom';
 import styled from 'styled-components';
 
+import useClickAway from './useClickAway';
 import { Box, BoxProps } from '../Box';
 import { useIntersection } from '../hooks/useIntersection';
 import { Portal } from '../Portal';
@@ -47,7 +48,7 @@ export const Content = ({
   ...props
 }: ContentProps) => {
   const [width, setWidth] = React.useState<number | undefined>(undefined);
-  const { x, y, reference, floating, strategy } = useFloating({
+  const { x, y, reference, floating, strategy, refs } = useFloating({
     strategy: 'fixed',
     placement: centered ? 'bottom' : placement,
     middleware: [
@@ -69,6 +70,12 @@ export const Content = ({
       setWidth(source.current.offsetWidth);
     }
   }, [fullWidth, source]);
+
+  useClickAway(refs.floating, (event: Event) => {
+    if (!source.current.contains(event.target as any)) {
+      source.current.click();
+    }
+  });
 
   return (
     <PopoverWrapper

--- a/packages/strapi-design-system/src/Popover/useClickAway.ts
+++ b/packages/strapi-design-system/src/Popover/useClickAway.ts
@@ -1,0 +1,39 @@
+import { RefObject, useEffect, useRef } from 'react';
+
+import { off, on } from './utils';
+
+const defaultEvents = ['mousedown', 'touchstart'];
+
+const useClickAway = <E extends Event = Event>(
+  ref: RefObject<HTMLElement | null>,
+  onClickAway: (event: E) => void,
+  events: string[] = defaultEvents,
+) => {
+  const savedCallback = useRef(onClickAway);
+  useEffect(() => {
+    savedCallback.current = onClickAway;
+  }, [onClickAway]);
+  useEffect(() => {
+    const handler = (event) => {
+      const { current: el } = ref;
+
+      if (el && !el.contains(event.target)) {
+        savedCallback.current(event);
+      }
+    };
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const eventName of events) {
+      on(document, eventName, handler);
+    }
+
+    return () => {
+      // eslint-disable-next-line no-restricted-syntax
+      for (const eventName of events) {
+        off(document, eventName, handler);
+      }
+    };
+  }, [events, ref]);
+};
+
+export default useClickAway;

--- a/packages/strapi-design-system/src/Popover/utils.ts
+++ b/packages/strapi-design-system/src/Popover/utils.ts
@@ -1,0 +1,17 @@
+export function on<T extends Window | Document | HTMLElement | EventTarget>(
+  obj: T | null,
+  ...args: Parameters<T['addEventListener']> | [string, Function | null, ...any]
+): void {
+  if (obj && obj.addEventListener) {
+    obj.addEventListener(...(args as Parameters<HTMLElement['addEventListener']>));
+  }
+}
+
+export function off<T extends Window | Document | HTMLElement | EventTarget>(
+  obj: T | null,
+  ...args: Parameters<T['removeEventListener']> | [string, Function | null, ...any]
+): void {
+  if (obj && obj.removeEventListener) {
+    obj.removeEventListener(...(args as Parameters<HTMLElement['removeEventListener']>));
+  }
+}


### PR DESCRIPTION
### What does it do?

I think it would be better if we can close the `Popover` when clicking away.
But it didn't work and then I made it working in that way.


https://user-images.githubusercontent.com/61251512/234651605-6835eb5d-9c70-4990-8ef2-c2e416f43349.mp4



### Related issue(s)/PR(s)
#955
This issue is not about this pull request, but it's a similar one.

I have checked #955, but `DatePicker` is different a bit, and I have found a solution.
But The solution depends on this PR.
So if this PR is approved, then I can make another PR for #955.
