### PR TITLE
Infer the `multi` prop on `Option` based on the value passed to `Select`

### DIFF
--- a/packages/strapi-design-system/src/Select/Option.tsx
+++ b/packages/strapi-design-system/src/Select/Option.tsx
@@ -1,4 +1,5 @@
 import { MultiSelectOption, MultiSelectOptionProps } from './MultiSelect';
+import { useSelectContext } from './Select';
 import { SingleSelectOption, SingleSelectOptionProps } from './SingleSelect';
 
 export type OptionProps = (SingleSelectOptionProps & { multi?: never }) | (MultiSelectOptionProps & { multi: true });
@@ -8,5 +9,8 @@ export type OptionProps = (SingleSelectOptionProps & { multi?: never }) | (Multi
  * @deprecated You should import the specific type of option you want to render,
  * e.g. `import { MultiSelectOption } from '@strapi/design-system';`
  */
-export const Option = ({ multi, ...restProps }: OptionProps) =>
-  multi ? <MultiSelectOption {...restProps} /> : <SingleSelectOption {...restProps} />;
+export const Option = ({ multi, ...restProps }: OptionProps) => {
+  const context = useSelectContext();
+
+  return multi || context.multi ? <MultiSelectOption {...restProps} /> : <SingleSelectOption {...restProps} />;
+};

--- a/packages/strapi-design-system/src/Select/Select.tsx
+++ b/packages/strapi-design-system/src/Select/Select.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import { MultiSelect, MultiSelectProps } from './MultiSelect';
 import { SingleSelect, SingleSelectProps } from './SingleSelect';
 
@@ -5,11 +7,25 @@ export type SelectProps =
   | (SingleSelectProps & { multi?: never; withTags?: never })
   | (MultiSelectProps & { multi: true });
 
+const SelectContext = React.createContext<{ multi: boolean }>({ multi: false });
+
+export const useSelectContext = () => React.useContext(SelectContext);
+
 /**
  * @preserve
  * @deprecated You should import the specific type of select you want to render
  *
  * e.g. `import { MultiSelect } from '@strapi/design-system';`
  */
-export const Select = (props: SelectProps) =>
-  props.multi || props.withTags ? <MultiSelect {...props} /> : <SingleSelect {...props} />;
+export const Select = (props: SelectProps) => {
+  const contextValue = React.useMemo(
+    () => ({ multi: Boolean(props.multi || props.withTags) }),
+    [props.multi, props.withTags],
+  );
+
+  return (
+    <SelectContext.Provider value={contextValue}>
+      {props.multi || props.withTags ? <MultiSelect {...props} /> : <SingleSelect {...props} />}
+    </SelectContext.Provider>
+  );
+};

--- a/packages/strapi-design-system/src/Select/__tests__/Select.spec.tsx
+++ b/packages/strapi-design-system/src/Select/__tests__/Select.spec.tsx
@@ -1,0 +1,134 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ThemeProvider } from '../../ThemeProvider';
+import { darkTheme } from '../../themes';
+import { Option } from '../Option';
+import { Select } from '../Select';
+
+interface RenderProps {
+  options?: Array<{ value: string; label: string }>;
+}
+
+const defaultOpts = [
+  { value: 'Option 1', label: 'Option 1' },
+  { value: 'Option 2', label: 'Option 2' },
+  { value: 'Option 3', label: 'Option 3' },
+];
+
+const Component = ({ options = defaultOpts, ...restProps }: RenderProps) => (
+  <ThemeProvider theme={darkTheme}>
+    <Select label="Pick Options" placeholder="Your option" {...restProps}>
+      {options.map((opt) => (
+        <Option key={opt.label} value={opt.value}>
+          {opt.label}
+        </Option>
+      ))}
+    </Select>
+  </ThemeProvider>
+);
+
+const renderComponent = (props: RenderProps = {}) => render(<Component {...props} />);
+
+describe('Select', () => {
+  it('should infer the multi prop on the options when set to true on the Select component', async () => {
+    // @ts-expect-error We are testing the the inference of the multi prop for a deprecated component
+    const { getByRole } = renderComponent({ multi: true });
+
+    await userEvent.click(getByRole('combobox', { name: 'Pick Options' }));
+
+    /**
+     * Because we're only testing the visuals here, we're expecting a checkbox div element to be rendered
+     * so we're using a snapshot for that.
+     */
+    expect(getByRole('option', { name: 'Option 1' })).toMatchInlineSnapshot(`
+      .c1 {
+        border-radius: 4px;
+        position: relative;
+        z-index: 1;
+        overflow: hidden;
+        width: 18px;
+        height: 18px;
+      }
+
+      .c4 {
+        font-size: 0.875rem;
+        line-height: 1.43;
+        color: #ffffff;
+      }
+
+      .c0 {
+        width: 100%;
+        border: none;
+        text-align: left;
+        outline-offset: -3px;
+        border-radius: 4px;
+        padding: 8px 16px;
+        padding-left: 16px;
+        background-color: #212134;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-align-items: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+        gap: 8px;
+        white-space: nowrap;
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
+      }
+
+      .c0:focus-visible {
+        outline: none;
+        background-color: #181826;
+      }
+
+      .c0:hover {
+        background-color: #181826;
+      }
+
+      .c0[data-state='checked'] .c3 {
+        font-weight: bold;
+        color: #7b79ff;
+      }
+
+      .c2 {
+        border: 1px solid #666687;
+        background-color: #212134;
+      }
+
+      <div
+        aria-checked="false"
+        aria-labelledby="radix-:r6:"
+        class="c0"
+        data-highlighted=""
+        data-radix-collection-item=""
+        data-state="unchecked"
+        role="option"
+        tabindex="-1"
+      >
+        <span
+          aria-hidden="true"
+        >
+          <div
+            class="c1 c2"
+            overflow="hidden"
+          />
+        </span>
+        <span
+          class="c3 c4"
+        >
+          <span
+            id="radix-:r6:"
+          >
+            Option 1
+          </span>
+        </span>
+      </div>
+    `);
+  });
+});


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* Uses a small context to enable multi inference for the `Option` component

### Why is it needed?

* because cloneElement is evil and must be stopped
