### PR TITLE
Add `@preserve` to JSDOCs

### DIFF
--- a/packages/strapi-design-system/src/Accordion/Accordion.tsx
+++ b/packages/strapi-design-system/src/Accordion/Accordion.tsx
@@ -96,6 +96,7 @@ export interface AccordionProps {
    */
   shadow?: keyof DefaultTheme['shadows'];
   /**
+   * @preserve
    * @deprecated use `onToggle` instead
    * The callback invoked after a click event on the `AccordionToggle`.
    */

--- a/packages/strapi-design-system/src/Combobox/ComboboxList.tsx
+++ b/packages/strapi-design-system/src/Combobox/ComboboxList.tsx
@@ -3,6 +3,7 @@ interface ComboboxListProps {
 }
 
 /**
+ * @preserve
  * @deprecated
  * This component was deprecated in 1.6.2. It will be removed in the next major release 2.0.0.
  */

--- a/packages/strapi-design-system/src/DatePicker/DatePicker.tsx
+++ b/packages/strapi-design-system/src/DatePicker/DatePicker.tsx
@@ -22,6 +22,7 @@ export interface DatePickerProps
   clearLabel?: string;
   onClear?: () => void;
   /**
+   * @preserve
    * @deprecated This is no longer used.
    */
   selectedDateLabel?: (date: string) => string;

--- a/packages/strapi-design-system/src/DatePicker/components.ts
+++ b/packages/strapi-design-system/src/DatePicker/components.ts
@@ -10,6 +10,7 @@ export const DatePickerPopover = styled(Popover)`
 `;
 
 /**
+ * @preserve
  * @deprecated This component will be removed in the next major version
  */
 export const DatePickerButton = styled.button`
@@ -35,6 +36,7 @@ export const DatePickerWrapper = styled.div<{ bold?: boolean }>`
 `;
 
 /**
+ * @preserve
  * @deprecated This component will be removed in the next major version
  */
 export const IconBox = styled(Box)`

--- a/packages/strapi-design-system/src/Field/FieldLabel.tsx
+++ b/packages/strapi-design-system/src/Field/FieldLabel.tsx
@@ -10,6 +10,7 @@ import { Typography, TypographyProps } from '../Typography';
 export interface FieldLabelProps extends TypographyProps<HTMLLabelElement> {
   action?: ReactNode;
   /**
+   * @preserve
    * @deprecated "required" should be given to Field component to share the value across components
    */
   required?: boolean;

--- a/packages/strapi-design-system/src/Select/MultiSelect.tsx
+++ b/packages/strapi-design-system/src/Select/MultiSelect.tsx
@@ -28,6 +28,7 @@ export type MultiSelectProps = Omit<SelectParts.MultiSelectProps, 'value' | 'mul
     onChange?: (value: string[]) => void;
     onReachEnd?: (entry: IntersectionObserverEntry) => void;
     /**
+     * @preserve
      * @deprecated This prop is no longer required and will be removed in v2 of the DS.
      * It has no effect on the component.
      */

--- a/packages/strapi-design-system/src/Select/OptGroup.ts
+++ b/packages/strapi-design-system/src/Select/OptGroup.ts
@@ -1,6 +1,7 @@
 import { MultiSelectGroup, MultiSelectGroupProps } from './MultiSelect';
 
 /**
+ * @preserve
  * @deprecated This component is only fit for the MultiSelect component.
  * Therefore, you should import the MultiSelectGroup component instead.
  */

--- a/packages/strapi-design-system/src/Select/Option.tsx
+++ b/packages/strapi-design-system/src/Select/Option.tsx
@@ -4,6 +4,7 @@ import { SingleSelectOption, SingleSelectOptionProps } from './SingleSelect';
 export type OptionProps = (SingleSelectOptionProps & { multi?: never }) | (MultiSelectOptionProps & { multi: true });
 
 /**
+ * @preserve
  * @deprecated You should import the specific type of option you want to render,
  * e.g. `import { MultiSelectOption } from '@strapi/design-system';`
  */

--- a/packages/strapi-design-system/src/Select/Select.tsx
+++ b/packages/strapi-design-system/src/Select/Select.tsx
@@ -6,6 +6,7 @@ export type SelectProps =
   | (MultiSelectProps & { multi: true });
 
 /**
+ * @preserve
  * @deprecated You should import the specific type of select you want to render
  *
  * e.g. `import { MultiSelect } from '@strapi/design-system';`

--- a/packages/strapi-design-system/src/Select/SelectList.tsx
+++ b/packages/strapi-design-system/src/Select/SelectList.tsx
@@ -24,6 +24,7 @@ export interface SelectListProps {
 }
 
 /**
+ * @preserve
  * @deprecated This component will be removed in the next major release.
  * If you need a custom listbox I would recommend opening a new issue.
  */

--- a/packages/strapi-design-system/src/Select/SingleSelect.tsx
+++ b/packages/strapi-design-system/src/Select/SingleSelect.tsx
@@ -22,6 +22,7 @@ export type SingleSelectProps = Omit<SelectParts.SingleSelectProps, 'value'> &
     onChange?: (value: string | number) => void;
     onReachEnd?: (entry: IntersectionObserverEntry) => void;
     /**
+     * @preserve
      * @deprecated This prop is no longer required and will be removed in v2 of the DS.
      * It has no effect on the component.
      */

--- a/packages/strapi-design-system/src/Stack/Stack.tsx
+++ b/packages/strapi-design-system/src/Stack/Stack.tsx
@@ -45,6 +45,7 @@ export interface StackProps extends FlexProps {
    */
   horizontal?: boolean;
   /**
+   * @preserve
    * @deprecated use `spacing` instead
    * The space between stack item.
    */

--- a/packages/strapi-design-system/src/helpers/useElementOnScreen.ts
+++ b/packages/strapi-design-system/src/helpers/useElementOnScreen.ts
@@ -4,6 +4,7 @@ import { useElementOnScreen as actualUseElementOnScreen } from '../hooks/useElem
 const warnDeprecated = once(console.warn);
 
 /**
+ * @preserve
  * @deprecated useElementOnScreen has moved. Please import it from "@strapi/design-system/hooks/useElementOnScreen"
  */
 export const useElementOnScreen: typeof actualUseElementOnScreen = (...args) => {

--- a/packages/strapi-design-system/src/helpers/useId.ts
+++ b/packages/strapi-design-system/src/helpers/useId.ts
@@ -4,6 +4,7 @@ import { useId as actualUseId } from '../hooks/useId';
 const warnDeprecated = once(console.warn);
 
 /**
+ * @preserve
  * @deprecated useId has moved. Please import it from "@strapi/design-system/hooks/useId"
  */
 export const useId: typeof actualUseId = (...args) => {

--- a/packages/strapi-design-system/src/helpers/useIntersection.ts
+++ b/packages/strapi-design-system/src/helpers/useIntersection.ts
@@ -4,6 +4,7 @@ import { useIntersection as actualUseIntersection } from '../hooks/useIntersecti
 const warnDeprecated = once(console.warn);
 
 /**
+ * @preserve
  * @deprecated useId has moved. Please import it from "@strapi/design-system/hooks/useId"
  */
 export const useIntersection: typeof actualUseIntersection = (...args) => {

--- a/packages/strapi-design-system/src/helpers/useLockScroll.ts
+++ b/packages/strapi-design-system/src/helpers/useLockScroll.ts
@@ -4,6 +4,7 @@ import actualUseLockScroll from '../hooks/useLockScroll';
 const warnDeprecated = once(console.warn);
 
 /**
+ * @preserve
  * @deprecated useLockScroll has moved. Please import it from "@strapi/design-system/hooks/useLockScroll"
  */
 const useLockScroll: typeof actualUseLockScroll = (...args) => {

--- a/packages/strapi-design-system/src/helpers/usePrevious.ts
+++ b/packages/strapi-design-system/src/helpers/usePrevious.ts
@@ -4,6 +4,7 @@ import { usePrevious as actualUsePrevious } from '../hooks/usePrevious';
 const warnDeprecated = once(console.warn);
 
 /**
+ * @preserve
  * @deprecated usePrevious has moved. Please import it from "@strapi/design-system/hooks/usePrevious"
  */
 export const usePrevious: typeof actualUsePrevious = (...args) => {

--- a/packages/strapi-design-system/src/helpers/useResizeObserver.ts
+++ b/packages/strapi-design-system/src/helpers/useResizeObserver.ts
@@ -4,6 +4,7 @@ import { useResizeObserver as actualUseResizeObserver } from '../hooks/useResize
 const warnDeprecated = once(console.warn);
 
 /**
+ * @preserve
  * @deprecated useResizeObserver has moved. Please import it from "@strapi/design-system/hooks/useResizeObserver"
  */
 export const useResizeObserver: typeof actualUseResizeObserver = (...args) => {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* adds `@preserve` to JSDOCs

### Why is it needed?

* Turns out JSDOCs are normally stripped by the bundler, this ensures they're not so people can see the deprecation notices
