### PR TITLE
Select/Combobox improvements

### DIFF
--- a/packages/strapi-design-system/src/Combobox/Combobox.tsx
+++ b/packages/strapi-design-system/src/Combobox/Combobox.tsx
@@ -19,6 +19,7 @@ export interface ComboboxProps {
   clearLabel?: string;
   creatable?: boolean;
   createMessage?: (inputValue: string) => string;
+  defaultTextValue?: string;
   disabled?: boolean;
   error?: string;
   hasMoreItems?: boolean;
@@ -36,7 +37,7 @@ export interface ComboboxProps {
   onLoadMore?: (entry: IntersectionObserverEntry) => void;
   placeholder?: string;
   required?: boolean;
-  defaultTextValue?: string;
+  startIcon?: React.ReactNode;
   textValue?: string;
   value?: string;
 }
@@ -46,6 +47,7 @@ export const Combobox = ({
   clearLabel = 'clear',
   creatable = false,
   createMessage = (value) => `Create "${value}"`,
+  defaultTextValue,
   disabled = false,
   error,
   hasMoreItems = false,
@@ -63,7 +65,7 @@ export const Combobox = ({
   onLoadMore,
   placeholder = 'Select or enter a value',
   required = false,
-  defaultTextValue,
+  startIcon,
   textValue,
   value,
 }: ComboboxProps) => {
@@ -163,14 +165,21 @@ export const Combobox = ({
           onFilterValueChange={handleFilterValueChange}
         >
           <Trigger $hasError={Boolean(error)}>
-            <TextInput
-              placeholder={placeholder}
-              id={generatedId}
-              aria-invalid={Boolean(error)}
-              aria-labelledby={`${hintId} ${errorId}`}
-              onChange={handleInputChange}
-              ref={triggerRef}
-            />
+            <Flex flex="1" as="span" gap={3}>
+              {startIcon ? (
+                <Box as="span" aria-hidden>
+                  {startIcon}
+                </Box>
+              ) : null}
+              <TextInput
+                placeholder={placeholder}
+                id={generatedId}
+                aria-invalid={Boolean(error)}
+                aria-labelledby={`${hintId} ${errorId}`}
+                onChange={handleInputChange}
+                ref={triggerRef}
+              />
+            </Flex>
             <Flex as="span" gap={3}>
               {internalTextValue && onClear ? (
                 <IconBox

--- a/packages/strapi-design-system/src/Select/SelectParts.tsx
+++ b/packages/strapi-design-system/src/Select/SelectParts.tsx
@@ -62,7 +62,7 @@ const SelectTrigger = React.forwardRef<HTMLSpanElement, TriggerProps>(
           width="100%"
           {...restProps}
         >
-          <Flex flex="1" as="span" gap={4}>
+          <Flex flex="1" as="span" gap={3}>
             {/* TODO: make this composable in v2 – <Select.Icon /> */}
             {startIcon && (
               <Box as="span" aria-hidden>

--- a/packages/strapi-design-system/src/Select/SelectParts.tsx
+++ b/packages/strapi-design-system/src/Select/SelectParts.tsx
@@ -14,14 +14,14 @@ import { Typography, TypographyProps } from '../Typography';
  * SelectTrigger
  * -----------------------------------------------------------------------------------------------*/
 
-interface TriggerProps extends BoxProps<HTMLButtonElement> {
+interface TriggerProps extends BoxProps<HTMLSpanElement> {
   /**
    * @default "Clear"
    */
   clearLabel?: string;
   disabled?: boolean;
   hasError?: boolean;
-  onClear?: (e: React.MouseEvent<HTMLButtonElement | HTMLDivElement>) => void;
+  onClear?: (e: React.MouseEvent<HTMLButtonElement | HTMLSpanElement>) => void;
   startIcon?: React.ReactElement;
   /**
    * @default "M"
@@ -29,11 +29,11 @@ interface TriggerProps extends BoxProps<HTMLButtonElement> {
   size?: 'S' | 'M';
 }
 
-const SelectTrigger = React.forwardRef<HTMLDivElement, TriggerProps>(
+const SelectTrigger = React.forwardRef<HTMLSpanElement, TriggerProps>(
   ({ onClear, clearLabel = 'Clear', startIcon, disabled, hasError, size = 'M', children, ...restProps }, ref) => {
-    const triggerRef = React.useRef<HTMLDivElement>(null!);
+    const triggerRef = React.useRef<HTMLSpanElement>(null!);
 
-    const handleClearClick = (e: React.MouseEvent<HTMLButtonElement | HTMLDivElement>) => {
+    const handleClearClick = (e: React.MouseEvent<HTMLButtonElement | HTMLSpanElement>) => {
       if (onClear && !disabled) {
         onClear(e);
         triggerRef.current.focus();
@@ -59,9 +59,10 @@ const SelectTrigger = React.forwardRef<HTMLDivElement, TriggerProps>(
           paddingRight={3}
           gap={4}
           cursor="default"
+          width="100%"
           {...restProps}
         >
-          <Flex as="span" gap={4}>
+          <Flex flex="1" as="span" gap={4}>
             {/* TODO: make this composable in v2 – <Select.Icon /> */}
             {startIcon && (
               <Box as="span" aria-hidden>
@@ -152,10 +153,14 @@ interface ValueProps
 }
 
 const SelectValue = React.forwardRef<HTMLSpanElement, ValueProps>(({ children, placeholder, ...restProps }, ref) => (
-  <Typography ref={ref} ellipsis {...restProps}>
+  <ValueType ref={ref} ellipsis {...restProps}>
     <StyledValue placeholder={placeholder}>{children}</StyledValue>
-  </Typography>
+  </ValueType>
 ));
+
+const ValueType = styled(Typography)`
+  flex: 1;
+`;
 
 const StyledValue = styled(Select.Value)`
   display: flex;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* Makes sure the `Select.Value` & `Select.Trigger` is full width so `customiseContent` is easier to do
* Adds `startIcon` to the `Combobox` Trigger space

### Why is it needed?

* Needed as part of replacing `react-select` in the CMS
