### PR TITLE
Add the ability to manage the open state of the combobox externally

### DIFF
--- a/packages/strapi-design-system/src/Combobox/Combobox.tsx
+++ b/packages/strapi-design-system/src/Combobox/Combobox.tsx
@@ -20,6 +20,8 @@ export interface ComboboxProps {
   creatable?: boolean;
   createMessage?: (inputValue: string) => string;
   defaultTextValue?: string;
+  defaultOpen?: boolean;
+  open?: boolean;
   disabled?: boolean;
   error?: string;
   hasMoreItems?: boolean;
@@ -35,6 +37,7 @@ export interface ComboboxProps {
   onCreateOption?: (inputValue: string) => void;
   onInputChange?: React.ChangeEventHandler<HTMLInputElement>;
   onLoadMore?: (entry: IntersectionObserverEntry) => void;
+  onOpenChange?: (open?: boolean) => void;
   placeholder?: string;
   required?: boolean;
   startIcon?: React.ReactNode;
@@ -48,6 +51,9 @@ export const Combobox = ({
   creatable = false,
   createMessage = (value) => `Create "${value}"`,
   defaultTextValue,
+  defaultOpen = false,
+  open,
+  onOpenChange,
   disabled = false,
   error,
   hasMoreItems = false,
@@ -69,7 +75,11 @@ export const Combobox = ({
   textValue,
   value,
 }: ComboboxProps) => {
-  const [internalIsOpen, setInternalIsOpen] = React.useState(false);
+  const [internalIsOpen, setInternalIsOpen] = useControllableState({
+    prop: open,
+    defaultProp: defaultOpen,
+    onChange: onOpenChange,
+  });
   const [internalTextValue, setInternalTextValue] = useControllableState({
     prop: textValue,
     defaultProp: defaultTextValue,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* uses `useControllableState` to manage the open state of the combobox

### Why is it needed?

* Need it to call search for relations in the CMS
