### PR TITLE
Use specific intersection ids

### DIFF
--- a/packages/strapi-design-system/src/Combobox/Combobox.tsx
+++ b/packages/strapi-design-system/src/Combobox/Combobox.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 import { Box } from '../Box';
 import { Field, FieldError, FieldHint, FieldLabel } from '../Field';
 import { Flex } from '../Flex';
+import { stripReactIdOfColon } from '../helpers/strings';
 import { useControllableState } from '../hooks/useControllableState';
 import { useId } from '../hooks/useId';
 import { useIntersection } from '../hooks/useIntersection';
@@ -144,7 +145,8 @@ export const Combobox = ({
     }
   };
 
-  const intersectionId = `intersection-${CSS.escape(generatedId)}`;
+  const generatedIntersectionId = useId();
+  const intersectionId = `intersection-${stripReactIdOfColon(generatedIntersectionId)}`;
 
   const handleReachEnd = (entry: IntersectionObserverEntry) => {
     if (onLoadMore && hasMoreItems && !loading) {

--- a/packages/strapi-design-system/src/Popover/Popover.tsx
+++ b/packages/strapi-design-system/src/Popover/Popover.tsx
@@ -4,6 +4,8 @@ import { useFloating, flip, shift, offset, autoUpdate, Placement } from '@floati
 import styled from 'styled-components';
 
 import { Box, BoxProps } from '../Box';
+import { stripReactIdOfColon } from '../helpers/strings';
+import { useId } from '../hooks/useId';
 import { useIntersection } from '../hooks/useIntersection';
 import { Portal } from '../Portal';
 
@@ -97,15 +99,18 @@ export interface ScrollingProps extends BoxProps<HTMLDivElement> {
 export const Scrolling = ({ children, intersectionId, onReachEnd, ...props }: ScrollingProps) => {
   const popoverRef = React.useRef<HTMLDivElement>(null!);
 
+  const generatedIntersectionId = useId();
   useIntersection(popoverRef, onReachEnd ?? (() => {}), {
-    selectorToWatch: `#${CSS.escape(intersectionId ?? '')}`,
+    selectorToWatch: `#${stripReactIdOfColon(generatedIntersectionId)}`,
     skipWhen: !intersectionId || !onReachEnd,
   });
 
   return (
     <PopoverScrollable ref={popoverRef} {...props}>
       {children}
-      {intersectionId && onReachEnd && <Box id={CSS.escape(intersectionId)} width="100%" height="1px" />}
+      {intersectionId && onReachEnd && (
+        <Box id={stripReactIdOfColon(generatedIntersectionId)} width="100%" height="1px" />
+      )}
     </PopoverScrollable>
   );
 };

--- a/packages/strapi-design-system/src/Select/MultiSelect.tsx
+++ b/packages/strapi-design-system/src/Select/MultiSelect.tsx
@@ -9,6 +9,7 @@ import checkmarkIcon from '../BaseCheckbox/assets/checkmark.svg';
 import { Box } from '../Box';
 import { Field, FieldError, FieldHint, FieldLabel } from '../Field';
 import { Flex } from '../Flex';
+import { stripReactIdOfColon } from '../helpers/strings';
 import { useId } from '../hooks/useId';
 import { useIntersection } from '../hooks/useIntersection';
 import { Tag } from '../Tag';
@@ -114,7 +115,8 @@ export const MultiSelect = ({
     triggerRef.current.focus();
   };
 
-  const intersectionId = `intersection-${CSS.escape(generatedId)}`;
+  const generatedIntersectionId = useId();
+  const intersectionId = `intersection-${stripReactIdOfColon(generatedIntersectionId)}`;
 
   const handleReachEnd = (entry: IntersectionObserverEntry) => {
     if (onReachEnd) {

--- a/packages/strapi-design-system/src/Select/SingleSelect.tsx
+++ b/packages/strapi-design-system/src/Select/SingleSelect.tsx
@@ -4,6 +4,7 @@ import * as SelectParts from './SelectParts';
 import { Box } from '../Box';
 import { Field, FieldError, FieldHint, FieldLabel } from '../Field';
 import { Flex } from '../Flex';
+import { stripReactIdOfColon } from '../helpers/strings';
 import { useId } from '../hooks/useId';
 import { useIntersection } from '../hooks/useIntersection';
 import { Typography } from '../Typography';
@@ -101,7 +102,8 @@ export const SingleSelect = ({
   };
 
   const viewportRef = React.useRef<HTMLDivElement>(null);
-  const intersectionId = `intersection-${CSS.escape(generatedId)}`;
+  const generatedIntersectionId = useId();
+  const intersectionId = `intersection-${stripReactIdOfColon(generatedIntersectionId)}`;
 
   const handleReachEnd = (entry: IntersectionObserverEntry) => {
     if (onReachEnd) {

--- a/packages/strapi-design-system/src/Select/__tests__/Select.spec.tsx
+++ b/packages/strapi-design-system/src/Select/__tests__/Select.spec.tsx
@@ -103,7 +103,7 @@ describe('Select', () => {
 
       <div
         aria-checked="false"
-        aria-labelledby="radix-:r6:"
+        aria-labelledby="radix-:r7:"
         class="c0"
         data-highlighted=""
         data-radix-collection-item=""
@@ -123,7 +123,7 @@ describe('Select', () => {
           class="c3 c4"
         >
           <span
-            id="radix-:r6:"
+            id="radix-:r7:"
           >
             Option 1
           </span>

--- a/packages/strapi-design-system/src/helpers/__tests__/strings.test.ts
+++ b/packages/strapi-design-system/src/helpers/__tests__/strings.test.ts
@@ -1,0 +1,17 @@
+import * as StringHelpers from '../strings';
+
+describe('String helpers', () => {
+  describe('stripReactIdOfColon', () => {
+    it('should remove all colons from a string', () => {
+      expect(StringHelpers.stripReactIdOfColon(':r18:')).toEqual('r18');
+    });
+
+    it('should remove all colons from a string', () => {
+      expect(StringHelpers.stripReactIdOfColon(':r1:8:')).toEqual('r18');
+    });
+
+    it('should return the same string assuming there are no colons in the passed string', () => {
+      expect(StringHelpers.stripReactIdOfColon('r18')).toEqual('r18');
+    });
+  });
+});

--- a/packages/strapi-design-system/src/helpers/escapeSelector.ts
+++ b/packages/strapi-design-system/src/helpers/escapeSelector.ts
@@ -1,1 +1,0 @@
-export const escapeSelector = (selector: string) => selector.replace(':', '-');

--- a/packages/strapi-design-system/src/helpers/strings.ts
+++ b/packages/strapi-design-system/src/helpers/strings.ts
@@ -1,0 +1,1 @@
+export const stripReactIdOfColon = (str: string): string => str.replaceAll(':', '');

--- a/packages/strapi-design-system/src/v2/SimpleMenu/SimpleMenu.tsx
+++ b/packages/strapi-design-system/src/v2/SimpleMenu/SimpleMenu.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react';
 
 import * as Menu from './Menu';
+import { stripReactIdOfColon } from '../../helpers/strings';
 import { useId } from '../../hooks/useId';
 import { useIntersection } from '../../hooks/useIntersection';
 
@@ -12,7 +13,6 @@ interface SimpleMenuProps
   extends Omit<Menu.TriggerProps, 'children'>,
     Pick<Menu.ContentProps, 'popoverPlacement' | 'intersectionId'> {
   children?: React.ReactNode;
-  id?: string;
   label?: React.ReactNode;
   onOpen?: () => void;
   onClose?: () => void;
@@ -22,7 +22,7 @@ interface SimpleMenuProps
   onReachEnd?: (entry: IntersectionObserverEntry) => void;
 }
 
-const SimpleMenu = ({ children, id, onOpen, onClose, popoverPlacement, onReachEnd, ...props }: SimpleMenuProps) => {
+const SimpleMenu = ({ children, onOpen, onClose, popoverPlacement, onReachEnd, ...props }: SimpleMenuProps) => {
   /**
    * Used for the intersection observer
    */
@@ -46,9 +46,8 @@ const SimpleMenu = ({ children, id, onOpen, onClose, popoverPlacement, onReachEn
     setInternalIsOpen(isOpen);
   };
 
-  const generatedId = useId(id);
-
-  const intersectionId = `intersection-${CSS.escape(generatedId)}`;
+  const generatedId = useId();
+  const intersectionId = `intersection-${stripReactIdOfColon(generatedId)}`;
 
   useIntersection(contentRef, handleReachEnd, {
     selectorToWatch: `#${intersectionId}`,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* generate a unique intersection id instead of trying to use part of the input's id

### Why is it needed?

* r18's id hook generates `:r18` which is invalid so you need to escape the CSS, this becomes an issue in instances where we pass strange ids e.g. the RelationInput where the input name is the id. It's easier just to generate an id we know will be a number or `:r18:` so we can just strip `:`.
