### PR TITLE
feat: add DesignSystemProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,17 @@ $ npm i react react-dom @strapi/design-system @strapi/icons styled-components re
 
 ## Getting Started
 
-Wrap your application with the `ThemeProvider` and pass the default `lightTheme` or `darkTheme` provided by `@strapi/design-system`.
+Wrap your application with the `DesignSystemProvider`. You can additionally pass a theme and/or locale, although you don't have to as we have default values for both.
 
 ```jsx
-import { ThemeProvider, lightTheme } from '@strapi/design-system';
+import { DesignSystemProvider, lightTheme } from '@strapi/design-system';
 
 function MyApp({ children }) {
-  return <ThemeProvider theme={lightTheme}>{children}</ThemeProvider>;
+  return (
+    <DesignSystemProvider locale="en-GB" theme={lightTheme}>
+      {children}
+    </DesignSystemProvider>
+  );
 }
 
 export default App;

--- a/docs/.storybook/components/Theme.js
+++ b/docs/.storybook/components/Theme.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useDarkMode } from 'storybook-dark-mode';
 import { parse } from 'qs';
-import { ThemeProvider, Box, lightTheme, darkTheme } from '@strapi/design-system';
+import { DesignSystemProvider, Box, lightTheme, darkTheme } from '@strapi/design-system';
 
 const themeQueryURL = parse(document.location.search).theme;
 
@@ -16,11 +16,11 @@ const Theme = ({ children }) => {
   }, [isDarkAddon, isDark]);
 
   return (
-    <ThemeProvider theme={isDark ? darkTheme : lightTheme}>
+    <DesignSystemProvider locale="en-GB" theme={isDark ? darkTheme : lightTheme}>
       <Box padding={2} background="neutral0">
         {children}
       </Box>
-    </ThemeProvider>
+    </DesignSystemProvider>
   );
 };
 

--- a/docs/components/DeprecationNotice.js
+++ b/docs/components/DeprecationNotice.js
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 
-import { Flex, Typography, ThemeProvider, lightTheme } from '@strapi/design-system';
+import { Flex, Typography, DesignSystemProvider, lightTheme } from '@strapi/design-system';
 
 export const DeprecationNotice = ({ children, href }) => (
-  <ThemeProvider theme={lightTheme}>
+  <DesignSystemProvider theme={lightTheme}>
     <Flex padding={5} background="danger200" justifyContent="center" marginTop={4} marginBottom={4}>
       <Typography fontSize={4} fontWeight="bold" as="p">
         ⛔️
@@ -18,7 +18,7 @@ export const DeprecationNotice = ({ children, href }) => (
         ⛔️
       </Typography>
     </Flex>
-  </ThemeProvider>
+  </DesignSystemProvider>
 );
 
 DeprecationNotice.propTypes = {

--- a/docs/stories/DesignSystemProvider.stories.mdx
+++ b/docs/stories/DesignSystemProvider.stories.mdx
@@ -1,0 +1,48 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs';
+
+import { DesignSystemProvider } from '@strapi/design-system';
+
+<Meta title="Design System/Components/DesignSystemProvider" component={DesignSystemProvider} />
+
+# DesignSystemProvider
+
+The root provider for your DesignSystem components. An abstraction around `styled-component`'s `ThemeProvider`
+that also includes `GlobalStyles` as well as an unique provider supplying values to components.
+
+## Usage
+
+```ts
+import { DesignSystemProvider } from '@strapi/design-system';
+```
+
+### Provider
+
+Both locale & theme are optional, their default values are `en-GB` & `lightTheme` respectively also as seen below.
+
+```tsx
+import { DesignSystemProvider, lightTheme } from '@strapi/design-system';
+
+const MyApp = () => (
+  <DesignSystemProvider locale="en-GB" theme={lightTheme}>
+    <App />
+  </DesignSystemProvider>
+);
+```
+
+### Accessing the Context
+
+```tsx
+import { useDesignSystem } from '@strapi/design-system';
+
+const MyLocale = () => {
+  const { locale } = useDesignSystem();
+
+  return <p>{locale}</p>;
+};
+```
+
+## API Reference
+
+### DesignSystemProvider
+
+<ArgsTable of={DesignSystemProvider} />

--- a/packages/strapi-design-system/README.md
+++ b/packages/strapi-design-system/README.md
@@ -1,24 +1,12 @@
-<p align="center">
-  <a href="https://strapi.io">
-    <img src="./assets/logo.svg" width="318px" alt="Strapi logo" />
-  </a>
-</p>
-<p align="center">
-<a style='margin-right:10px' href="https://design-system.strapi.io/">Documentation</a>|<a style='margin-left:10px' href="https://design-system-git-main-strapijs.vercel.app/">Try components</a></p>
-<br />
+# Strapi Design System
 
 [![Version](https://img.shields.io/npm/v/@strapi/design-system?style=flat&colorA=4945ff&colorB=4945ff)](https://www.npmjs.com/package/@strapi/design-system)
 [![Downloads](https://img.shields.io/npm/dt/@strapi/design-system.svg?style=flat&colorA=4945ff&colorB=4945ff)](https://www.npmjs.com/package/@strapi/design-system)
 [![Discord Shield](https://img.shields.io/discord/811989166782021633?style=flat&colorA=4945ff&colorB=4945ff&label=discord&logo=discord&logoColor=f0f0ff)](https://discord.gg/strapi)
 
-# Welcome! 👋👋👋
-
-Strapi Design System provides guidelines and tools to help anyone make Strapi's contributions more cohesive and to build
-plugins more efficiently.
+<b>A UI component library for creating amazing Strapi extensions.</b>
 
 ## Installation
-
-Install Strapi Design System and its peer dependencies:
 
 ```sh
 $ yarn add react react-dom @strapi/design-system @strapi/icons styled-components react-router-dom
@@ -30,13 +18,17 @@ $ npm i react react-dom @strapi/design-system @strapi/icons styled-components re
 
 ## Getting Started
 
-Wrap your application with the `ThemeProvider` and pass the default `lightTheme` or `darkTheme` provided by `@strapi/design-system`.
+Wrap your application with the `DesignSystemProvider`. You can additionally pass a theme and/or locale, although you don't have to as we have default values for both.
 
 ```jsx
-import { ThemeProvider, lightTheme } from '@strapi/design-system';
+import { DesignSystemProvider, lightTheme } from '@strapi/design-system';
 
 function MyApp({ children }) {
-  return <ThemeProvider theme={lightTheme}>{children}</ThemeProvider>;
+  return (
+    <DesignSystemProvider locale="en-GB" theme={lightTheme}>
+      {children}
+    </DesignSystemProvider>
+  );
 }
 
 export default App;

--- a/packages/strapi-design-system/jest.config.js
+++ b/packages/strapi-design-system/jest.config.js
@@ -9,6 +9,10 @@ const __dirname = dirname(__filename);
 
 export default {
   ...jestBaseConfig,
+  moduleNameMapper: {
+    ...jestBaseConfig.moduleNameMapper,
+    '^@test/(.*)$': '<rootDir>/packages/strapi-design-system/test/$1',
+  },
   roots: [__dirname],
   displayName: '@strapi/design-system',
 };

--- a/packages/strapi-design-system/src/Avatar/__tests__/Avatar.spec.tsx
+++ b/packages/strapi-design-system/src/Avatar/__tests__/Avatar.spec.tsx
@@ -1,17 +1,11 @@
-import * as React from 'react';
+import { render, fireEvent } from '@test/utils';
 
-import { render, fireEvent } from '@testing-library/react';
-
-import { ThemeProvider } from '../../ThemeProvider';
-import { lightTheme } from '../../themes';
 import { Avatar } from '../Avatar';
 
 describe('Avatar', () => {
   it('snapshots the component with preview (boolean)', () => {
     const { container } = render(
-      <ThemeProvider theme={lightTheme}>
-        <Avatar src="https://avatars.githubusercontent.com/u/3874873?v=4" alt="marvin frachet" preview />
-      </ThemeProvider>,
+      <Avatar src="https://avatars.githubusercontent.com/u/3874873?v=4" alt="marvin frachet" preview />,
     );
 
     fireEvent.mouseEnter(container.querySelector('img')!);
@@ -83,13 +77,11 @@ describe('Avatar', () => {
 
   it('snapshots the component with preview (string)', () => {
     const { container } = render(
-      <ThemeProvider theme={lightTheme}>
-        <Avatar
-          src="https://avatars.githubusercontent.com/u/3874873?v=4"
-          alt="marvin frachet"
-          preview="https://some-unknown-photo/x.png"
-        />
-      </ThemeProvider>,
+      <Avatar
+        src="https://avatars.githubusercontent.com/u/3874873?v=4"
+        alt="marvin frachet"
+        preview="https://some-unknown-photo/x.png"
+      />,
     );
 
     fireEvent.mouseEnter(container.querySelector('img')!);

--- a/packages/strapi-design-system/src/BaseLink/__tests__/BaseLink.spec.tsx
+++ b/packages/strapi-design-system/src/BaseLink/__tests__/BaseLink.spec.tsx
@@ -1,18 +1,10 @@
-import * as React from 'react';
+import { render } from '@test/utils';
 
-import { render } from '@testing-library/react';
-
-import { ThemeProvider } from '../../ThemeProvider';
-import { lightTheme } from '../../themes';
 import { BaseLink } from '../BaseLink';
 
 describe('BaseLink', () => {
   it('snapshots the component', () => {
-    const { container } = render(
-      <ThemeProvider theme={lightTheme}>
-        <BaseLink />
-      </ThemeProvider>,
-    );
+    const { container } = render(<BaseLink />);
 
     expect(container.firstChild).toMatchInlineSnapshot(`
       .c0 {

--- a/packages/strapi-design-system/src/Box/__tests__/Box.spec.tsx
+++ b/packages/strapi-design-system/src/Box/__tests__/Box.spec.tsx
@@ -1,15 +1,8 @@
-import { render } from '@testing-library/react';
-import { ThemeProvider } from 'styled-components';
+import { render } from '@test/utils';
 
-import { lightTheme } from '../../themes';
 import { Box } from '../Box';
 
-const setup = (props = {}) =>
-  render(
-    <ThemeProvider theme={lightTheme}>
-      <Box {...props} />
-    </ThemeProvider>,
-  );
+const setup = (props = {}) => render(<Box {...props} />);
 
 describe('Box', () => {
   it.each(['color', 'background'])('retrieves the theme value corresponding to the %s props', (colorProp) => {

--- a/packages/strapi-design-system/src/Combobox/__tests__/Combobox.spec.tsx
+++ b/packages/strapi-design-system/src/Combobox/__tests__/Combobox.spec.tsx
@@ -1,21 +1,16 @@
-import { render as renderRTL } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render as renderRTL } from '@test/utils';
 
-import { ThemeProvider } from '../../ThemeProvider';
-import { lightTheme } from '../../themes';
 import { Combobox, Option, ComboboxProps } from '../Combobox';
 
 type ComponentProps = Omit<ComboboxProps, 'children'>;
 
 const Component = (props: ComponentProps) => (
-  <ThemeProvider theme={lightTheme}>
-    <Combobox label="Food" {...props}>
-      <Option value="hamburger">Hamburger</Option>
-      <Option value="bagel">Bagel</Option>
-      <Option value="tartuffo">Tartuffo</Option>
-      <Option value="carbonara">Carbonara</Option>
-    </Combobox>
-  </ThemeProvider>
+  <Combobox label="Food" {...props}>
+    <Option value="hamburger">Hamburger</Option>
+    <Option value="bagel">Bagel</Option>
+    <Option value="tartuffo">Tartuffo</Option>
+    <Option value="carbonara">Carbonara</Option>
+  </Combobox>
 );
 
 const render = (props?: ComponentProps) => renderRTL(<Component {...props} />);
@@ -36,9 +31,8 @@ describe('Combobox', () => {
 
   describe('callbacks', () => {
     it('should fire onChange only when the value is changed not when the input does', async () => {
-      const user = userEvent.setup();
       const onChange = jest.fn();
-      const { getByRole } = render({ onChange });
+      const { getByRole, user } = render({ onChange });
 
       await user.click(getByRole('combobox'));
 
@@ -53,9 +47,8 @@ describe('Combobox', () => {
     });
 
     it('should call onInputChange as the input changes', async () => {
-      const user = userEvent.setup();
       const onInputChange = jest.fn();
-      const { getByRole } = render({ onInputChange });
+      const { getByRole, user } = render({ onInputChange });
 
       await user.click(getByRole('combobox'));
 
@@ -85,8 +78,7 @@ describe('Combobox', () => {
     });
 
     it('should handle the loading prop correctly', async () => {
-      const user = userEvent.setup();
-      const { getByRole, queryByText } = render({ loading: true });
+      const { getByRole, queryByText, user } = render({ loading: true });
 
       expect(queryByText('Loading content...')).not.toBeInTheDocument();
 
@@ -102,8 +94,7 @@ describe('Combobox', () => {
     });
 
     it('should handle noOptionsMessage prop correctly', async () => {
-      const user = userEvent.setup();
-      const { getByRole, queryAllByRole, getByText } = render({
+      const { getByRole, queryAllByRole, getByText, user } = render({
         noOptionsMessage: (value) => `${value} is not an option`,
       });
 
@@ -118,8 +109,7 @@ describe('Combobox', () => {
 
   describe('clear props', () => {
     it('should only show the clear button if the user has started typing an onClear is passed', async () => {
-      const user = userEvent.setup();
-      const { getByRole, queryByRole } = render({
+      const { getByRole, queryByRole, user } = render({
         onClear: jest.fn(),
       });
 
@@ -133,8 +123,7 @@ describe('Combobox', () => {
     });
 
     it('should handle a custom label being passed', async () => {
-      const user = userEvent.setup();
-      const { getByRole } = render({
+      const { getByRole, user } = render({
         onClear: jest.fn(),
         clearLabel: 'Clear the field',
       });
@@ -147,9 +136,8 @@ describe('Combobox', () => {
     });
 
     it('should clear the field when the clear button is pressed', async () => {
-      const user = userEvent.setup();
       const onClear = jest.fn();
-      const { getByRole } = render({
+      const { getByRole, user } = render({
         onClear,
       });
 
@@ -166,8 +154,7 @@ describe('Combobox', () => {
 
   describe('createable props', () => {
     it('should show the creatable button only if the prop is true & when an option is typed that does not exist', async () => {
-      const user = userEvent.setup();
-      const { getByRole, queryByRole } = render({
+      const { getByRole, queryByRole, user } = render({
         creatable: true,
       });
 
@@ -185,8 +172,7 @@ describe('Combobox', () => {
     });
 
     it("should by default show the 'Create {value}' label", async () => {
-      const user = userEvent.setup();
-      const { getByRole } = render({
+      const { getByRole, user } = render({
         creatable: true,
       });
 
@@ -198,8 +184,7 @@ describe('Combobox', () => {
     });
 
     it('should handle a custom createMessage function passed', async () => {
-      const user = userEvent.setup();
-      const { getByRole } = render({
+      const { getByRole, user } = render({
         creatable: true,
         createMessage: (value) => `Create ${value} as an option`,
       });
@@ -213,9 +198,8 @@ describe('Combobox', () => {
     });
 
     it('should fire onCreateOption callback when the button is pressed', async () => {
-      const user = userEvent.setup();
       const onCreateOption = jest.fn();
-      const { getByRole } = render({
+      const { getByRole, user } = render({
         creatable: true,
         onCreateOption,
       });

--- a/packages/strapi-design-system/src/DatePicker/DatePicker.tsx
+++ b/packages/strapi-design-system/src/DatePicker/DatePicker.tsx
@@ -22,12 +22,12 @@ import { RemoveScroll } from 'react-remove-scroll';
 import styled, { ThemeColors } from 'styled-components';
 
 import { Box, BoxProps } from '../Box';
+import { useDesignSystem } from '../DesignSystemProvider';
 import { DismissibleLayer, DismissibleLayerProps } from '../DismissibleLayer';
 import * as Field from '../Field';
 import { FieldProps } from '../Field';
 import { Flex, FlexProps } from '../Flex';
 import { createContext } from '../helpers/context';
-import { getDefaultLocale } from '../helpers/getDefaultLocale';
 import { useComposedRefs } from '../hooks/useComposeRefs';
 import { useControllableState } from '../hooks/useControllableState';
 import { useDateFormatter } from '../hooks/useDateFormatter';
@@ -204,7 +204,9 @@ const DatePickerInput = ({
     }
   }, [selectedDate]);
 
-  const locale = defaultLocale ?? getDefaultLocale();
+  const designContext = useDesignSystem('DatePicker');
+
+  const locale = defaultLocale ?? designContext.locale;
 
   const contentId = useId();
 

--- a/packages/strapi-design-system/src/DatePicker/__tests__/DatePicker.spec.tsx
+++ b/packages/strapi-design-system/src/DatePicker/__tests__/DatePicker.spec.tsx
@@ -1,20 +1,10 @@
-import { render as renderRTL } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render as renderRTL } from '@test/utils';
 
-import { ThemeProvider } from '../../ThemeProvider';
-import { lightTheme } from '../../themes';
 import { DatePicker, DatePickerProps } from '../DatePicker';
 
-const Component = (props: Partial<DatePickerProps>) => (
-  <ThemeProvider theme={lightTheme}>
-    <DatePicker label="date picker" {...props} />
-  </ThemeProvider>
-);
+const Component = (props: Partial<DatePickerProps>) => <DatePicker locale="en-EN" label="date picker" {...props} />;
 
-const render = (props?: Partial<DatePickerProps>) => ({
-  user: userEvent.setup(),
-  ...renderRTL(<Component {...props} />),
-});
+const render = (props?: Partial<DatePickerProps>) => renderRTL(<Component {...props} />);
 
 describe('DatePicker', () => {
   describe('Input', () => {

--- a/packages/strapi-design-system/src/DateTimePicker/__tests__/DateTimePicker.spec.tsx
+++ b/packages/strapi-design-system/src/DateTimePicker/__tests__/DateTimePicker.spec.tsx
@@ -1,8 +1,5 @@
-import { render as renderRTL } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render as renderRTL } from '@test/utils';
 
-import { ThemeProvider } from '../../ThemeProvider';
-import { lightTheme } from '../../themes';
 import { DateTimePicker, DateTimePickerProps } from '../DateTimePicker';
 
 /**
@@ -11,15 +8,13 @@ import { DateTimePicker, DateTimePickerProps } from '../DateTimePicker';
  */
 
 const Component = (props: Partial<DateTimePickerProps>) => (
-  <ThemeProvider theme={lightTheme}>
-    <DateTimePicker
-      minDate={new Date('Mon Sep 04 2000')}
-      initialDate={new Date('12/01/2023')}
-      step={15}
-      label="datetime picker"
-      {...props}
-    />
-  </ThemeProvider>
+  <DateTimePicker
+    minDate={new Date('Mon Sep 04 2000')}
+    initialDate={new Date('12/01/2023')}
+    step={15}
+    label="datetime picker"
+    {...props}
+  />
 );
 
 const render = (props: Partial<DateTimePickerProps> = {}) => renderRTL(<Component {...props} />);
@@ -59,8 +54,7 @@ describe.skip('DateTimePicker', () => {
 
   describe('interactions', () => {
     it('should open the calendar when clicking on the DatePicker', async () => {
-      const user = userEvent.setup();
-      const { queryByRole, getByRole } = render();
+      const { queryByRole, getByRole, user } = render();
 
       expect(queryByRole('dialog')).not.toBeInTheDocument();
 
@@ -70,8 +64,7 @@ describe.skip('DateTimePicker', () => {
     });
 
     it('should open the menu when clicking on the TimePicker', async () => {
-      const user = userEvent.setup();
-      const { queryByRole, getByRole } = render();
+      const { queryByRole, getByRole, user } = render();
 
       expect(queryByRole('listbox')).not.toBeInTheDocument();
 
@@ -83,8 +76,7 @@ describe.skip('DateTimePicker', () => {
     it(
       'should fill the TimePicker with 00:00 when a date is picked and the TimePicker is empty',
       async () => {
-        const user = userEvent.setup();
-        const { getByRole } = render();
+        const { getByRole, user } = render();
 
         await user.click(getByRole('textbox', { name: 'datetime picker' }));
         await user.click(getByRole('button', { name: /15/ }));
@@ -96,8 +88,7 @@ describe.skip('DateTimePicker', () => {
     );
 
     it('should fill the DatePicker with the current date when a time is picked and the DatePicker is empty', async () => {
-      const user = userEvent.setup();
-      const { getByRole } = render();
+      const { getByRole, user } = render();
 
       await user.click(getByRole('combobox'));
       await user.click(getByRole('option', { name: /12:00/ }));
@@ -111,8 +102,7 @@ describe.skip('DateTimePicker', () => {
     it(
       'should not change the value of the DatePicker when a time is picked and the DatePicker is not empty',
       async () => {
-        const user = userEvent.setup();
-        const { getByRole } = render();
+        const { getByRole, user } = render();
 
         await user.click(getByRole('textbox', { name: 'datetime picker' }));
         await user.click(getByRole('button', { name: /15/ }));
@@ -131,8 +121,7 @@ describe.skip('DateTimePicker', () => {
     it(
       'should not change the value of the TimePicker when a date is picked and the TimePicker is not empty',
       async () => {
-        const user = userEvent.setup();
-        const { getByRole } = render();
+        const { getByRole, user } = render();
 
         await user.click(getByRole('combobox'));
         await user.click(getByRole('option', { name: /12:00/ }));
@@ -154,9 +143,8 @@ describe.skip('DateTimePicker', () => {
     it(
       'should clear the value of the DatePicker when clicking on the clear button and clear the TimePicker',
       async () => {
-        const user = userEvent.setup();
         const onClear = jest.fn();
-        const { getByRole } = render({ onClear });
+        const { getByRole, user } = render({ onClear });
 
         await user.click(getByRole('textbox', { name: 'datetime picker' }));
         await user.click(getByRole('button', { name: /15/ }));
@@ -178,9 +166,8 @@ describe.skip('DateTimePicker', () => {
      * TODO: This test is skipped because of an issue with the event being prevented by not calling the original...
      */
     it.skip('should reset the value of the TimePicker to 00:00 when clicking on the clear button but not clear the DatePicker and not call onClear', async () => {
-      const user = userEvent.setup();
       const onClear = jest.fn();
-      const { getByRole } = render({ onClear });
+      const { getByRole, user } = render({ onClear });
 
       await user.click(getByRole('combobox'));
       await user.click(getByRole('option', { name: /12:00/ }));
@@ -215,8 +202,7 @@ describe.skip('DateTimePicker', () => {
     });
 
     it('should pass the step prop to the TimePicker component', async () => {
-      const user = userEvent.setup();
-      const { getByRole, getAllByRole } = render({ step: 30 });
+      const { getByRole, getAllByRole, user } = render({ step: 30 });
 
       await user.click(getByRole('combobox'));
 
@@ -253,9 +239,8 @@ describe.skip('DateTimePicker', () => {
     it(
       'should call onChange when the value is updated even if the component is not controlled',
       async () => {
-        const user = userEvent.setup();
         const onChange = jest.fn();
-        const { getByRole } = render({ onChange });
+        const { getByRole, user } = render({ onChange });
 
         await user.click(getByRole('textbox', { name: 'datetime picker' }));
         await user.click(getByRole('button', { name: /15/ }));

--- a/packages/strapi-design-system/src/DesignSystemProvider.tsx
+++ b/packages/strapi-design-system/src/DesignSystemProvider.tsx
@@ -1,0 +1,37 @@
+import { createContext } from './helpers/context';
+import { ThemeProvider, ThemeProviderProps } from './ThemeProvider';
+
+const DEFAULT_LOCALE = 'en-EN';
+
+const getDefaultLocale = () => {
+  if (typeof navigator === 'undefined') {
+    return DEFAULT_LOCALE;
+  }
+
+  if (navigator.language) {
+    return navigator.language;
+  }
+
+  return DEFAULT_LOCALE;
+};
+
+interface DesignSystemContextValue {
+  locale: string;
+}
+
+const [Provider, useDesignSystem] = createContext<DesignSystemContextValue>('StrapiDesignSystem', {
+  locale: getDefaultLocale(),
+});
+
+interface DesignSystemProviderProps extends ThemeProviderProps, Partial<DesignSystemContextValue> {}
+
+const DesignSystemProvider = ({ locale = getDefaultLocale(), ...restProps }: DesignSystemProviderProps) => {
+  return (
+    <Provider locale={locale}>
+      <ThemeProvider {...restProps} />
+    </Provider>
+  );
+};
+
+export { useDesignSystem, DesignSystemProvider };
+export type { DesignSystemProviderProps, DesignSystemContextValue };

--- a/packages/strapi-design-system/src/Dialog/__tests__/Dialog.spec.js
+++ b/packages/strapi-design-system/src/Dialog/__tests__/Dialog.spec.js
@@ -1,10 +1,8 @@
 import * as React from 'react';
 
-import { render } from '@testing-library/react';
+import { render } from '@test/utils';
 
 import { Button } from '../../Button/Button';
-import { ThemeProvider } from '../../ThemeProvider';
-import { lightTheme } from '../../themes';
 import { Dialog } from '../Dialog';
 import { DialogBody } from '../DialogBody';
 import { DialogFooter } from '../DialogFooter';
@@ -12,15 +10,13 @@ import { DialogFooter } from '../DialogFooter';
 describe('Dialog', () => {
   it('should render Dialog with props', () => {
     const { getByText } = render(
-      <ThemeProvider theme={lightTheme}>
-        <Dialog isOpen onClose={jest.fn()} title="Confirmation" labelledBy="confirmation">
-          <DialogBody>are you sure you want to delete this?</DialogBody>
-          <DialogFooter
-            startAction={<Button variant="tertiary">Cancel</Button>}
-            endAction={<Button variant="danger-light">Confirm</Button>}
-          />
-        </Dialog>
-      </ThemeProvider>,
+      <Dialog isOpen onClose={jest.fn()} title="Confirmation" labelledBy="confirmation">
+        <DialogBody>are you sure you want to delete this?</DialogBody>
+        <DialogFooter
+          startAction={<Button variant="tertiary">Cancel</Button>}
+          endAction={<Button variant="danger-light">Confirm</Button>}
+        />
+      </Dialog>,
     );
 
     expect(getByText('are you sure you want to delete this?')).toBeInTheDocument();

--- a/packages/strapi-design-system/src/Field/__tests__/Field.spec.tsx
+++ b/packages/strapi-design-system/src/Field/__tests__/Field.spec.tsx
@@ -1,9 +1,6 @@
 import { PlusCircle } from '@strapi/icons';
-import { render as renderRTL } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render as renderRTL } from '@test/utils';
 
-import { ThemeProvider } from '../../ThemeProvider';
-import { lightTheme } from '../../themes';
 import {
   Field,
   FieldProps,
@@ -21,14 +18,12 @@ interface ComponentProps extends Pick<FieldProps, 'required' | 'error' | 'hint' 
 }
 
 const Component = ({ required, error, hint, name, labelAction, ...restProps }: ComponentProps) => (
-  <ThemeProvider theme={lightTheme}>
-    <Field required={required} error={error} hint={hint} name={name}>
-      <FieldLabel action={labelAction}>field label</FieldLabel>
-      <FieldInput {...restProps} />
-      <FieldError />
-      <FieldHint />
-    </Field>
-  </ThemeProvider>
+  <Field required={required} error={error} hint={hint} name={name}>
+    <FieldLabel action={labelAction}>field label</FieldLabel>
+    <FieldInput {...restProps} />
+    <FieldError />
+    <FieldHint />
+  </Field>
 );
 
 const render = (props: ComponentProps) => renderRTL(<Component {...props} />);
@@ -109,10 +104,9 @@ describe('Field', () => {
 
   describe('FieldInput props', () => {
     it('should handle the disabled prop correctly', async () => {
-      const user = userEvent.setup();
       const onChange = jest.fn();
 
-      const { getByRole } = render({ disabled: true, onChange });
+      const { getByRole, user } = render({ disabled: true, onChange });
 
       expect(getByRole('textbox')).toBeDisabled();
 
@@ -122,9 +116,8 @@ describe('Field', () => {
     });
 
     it('should handle the onChange prop correctly', async () => {
-      const user = userEvent.setup();
       const onChange = jest.fn();
-      const { getByRole } = render({ onChange });
+      const { getByRole, user } = render({ onChange });
 
       await user.type(getByRole('textbox'), 'test');
 
@@ -132,8 +125,7 @@ describe('Field', () => {
     });
 
     it('should be able to be controlled with a value', async () => {
-      const user = userEvent.setup();
-      const { getByRole } = render({ value: 'test' });
+      const { getByRole, user } = render({ value: 'test' });
 
       expect(getByRole('textbox')).toHaveValue('test');
 
@@ -143,11 +135,10 @@ describe('Field', () => {
     });
 
     it('should render the actions when passed and they should be clickable', async () => {
-      const user = userEvent.setup();
       const startClick = jest.fn();
       const endClick = jest.fn();
 
-      const { getByRole } = render({
+      const { getByRole, user } = render({
         startAction: (
           <FieldAction onClick={startClick} label="start">
             <PlusCircle />

--- a/packages/strapi-design-system/src/JSONInput/__tests__/JSONInput.spec.js
+++ b/packages/strapi-design-system/src/JSONInput/__tests__/JSONInput.spec.js
@@ -1,9 +1,7 @@
 import * as React from 'react';
 
-import { render, fireEvent, waitFor } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@test/utils';
 
-import { ThemeProvider } from '../../ThemeProvider';
-import { lightTheme } from '../../themes';
 import { JSONInput } from '../JSONInput';
 
 const mockIntersectionObserver = jest.fn();
@@ -29,11 +27,7 @@ const onError = jest.fn();
 
 const JSON_DATA = '[\n   {\n      "a":3,\n      "b":4\n   },\n   {\n      "a":5,\n      "b":6\n   }\n]';
 
-const Component = (props) => (
-  <ThemeProvider theme={lightTheme}>
-    <JSONInput {...props} />
-  </ThemeProvider>
-);
+const Component = (props) => <JSONInput {...props} />;
 
 describe('JSONInput', () => {
   beforeAll(() => {

--- a/packages/strapi-design-system/src/LiveRegions/__tests__/LiveRegions.spec.tsx
+++ b/packages/strapi-design-system/src/LiveRegions/__tests__/LiveRegions.spec.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
 
-import { render } from '@testing-library/react';
+import { render } from '@test/utils';
 
-import { ThemeProvider } from '../../ThemeProvider';
-import { lightTheme } from '../../themes';
 import { useNotifyAT } from '../useNotifyAT';
 
 describe('LiveRegions', () => {
@@ -34,11 +32,7 @@ describe('LiveRegions', () => {
       return null;
     };
 
-    const { container } = render(
-      <ThemeProvider theme={lightTheme}>
-        <TestComponent />
-      </ThemeProvider>,
-    );
+    const { container } = render(<TestComponent />);
 
     expect(container).toMatchInlineSnapshot(`
       .c0 {
@@ -93,11 +87,7 @@ describe('LiveRegions', () => {
       return null;
     };
 
-    const { container } = render(
-      <ThemeProvider theme={lightTheme}>
-        <TestComponent />
-      </ThemeProvider>,
-    );
+    const { container } = render(<TestComponent />);
 
     expect(container).toMatchInlineSnapshot(`
       .c0 {
@@ -152,11 +142,7 @@ describe('LiveRegions', () => {
       return null;
     };
 
-    const { container } = render(
-      <ThemeProvider theme={lightTheme}>
-        <TestComponent />
-      </ThemeProvider>,
-    );
+    const { container } = render(<TestComponent />);
 
     expect(container).toMatchInlineSnapshot(`
       .c0 {

--- a/packages/strapi-design-system/src/ModalLayout/__tests__/ModalLayout.spec.js
+++ b/packages/strapi-design-system/src/ModalLayout/__tests__/ModalLayout.spec.js
@@ -1,37 +1,45 @@
 import * as React from 'react';
 
-import { render } from '@testing-library/react';
+import { render } from '@test/utils';
 
 import { Button } from '../../Button';
-import { ThemeProvider } from '../../ThemeProvider';
-import { lightTheme } from '../../themes';
 import { ModalLayout, ModalHeader, ModalBody, ModalFooter } from '../index';
 
 describe('ModalLayout', () => {
   it('should render component and match snapshot', () => {
     render(
-      <ThemeProvider theme={lightTheme}>
-        <ModalLayout onClose={() => jest.fn()} labelledBy="title">
-          <ModalHeader>Modal Title</ModalHeader>
-          <ModalBody>Hello World</ModalBody>
-          <ModalFooter
-            startActions={
-              <Button onClick={() => jest.fn} variant="tertiary">
-                Cancel
-              </Button>
-            }
-            endActions={
-              <>
-                <Button variant="secondary">Add new stuff</Button>
-                <Button onClick={() => jest.fn()}>Finish</Button>
-              </>
-            }
-          />
-        </ModalLayout>
-      </ThemeProvider>,
+      <ModalLayout onClose={() => jest.fn()} labelledBy="title">
+        <ModalHeader>Modal Title</ModalHeader>
+        <ModalBody>Hello World</ModalBody>
+        <ModalFooter
+          startActions={
+            <Button onClick={() => jest.fn} variant="tertiary">
+              Cancel
+            </Button>
+          }
+          endActions={
+            <>
+              <Button variant="secondary">Add new stuff</Button>
+              <Button onClick={() => jest.fn()}>Finish</Button>
+            </>
+          }
+        />
+      </ModalLayout>,
     );
 
     expect(document.body).toMatchInlineSnapshot(`
+      .c0 {
+        border: 0;
+        -webkit-clip: rect(0 0 0 0);
+        clip: rect(0 0 0 0);
+        height: 1px;
+        margin: -1px;
+        overflow: hidden;
+        padding: 0;
+        position: absolute;
+        width: 1px;
+      }
+
       .c21 {
         font-size: 0.75rem;
         line-height: 1.33;
@@ -357,18 +365,6 @@ describe('ModalLayout', () => {
       .c23 svg > g,
       .c23 svg path {
         fill: #ffffff;
-      }
-
-      .c0 {
-        border: 0;
-        -webkit-clip: rect(0 0 0 0);
-        clip: rect(0 0 0 0);
-        height: 1px;
-        margin: -1px;
-        overflow: hidden;
-        padding: 0;
-        position: absolute;
-        width: 1px;
       }
 
       .c3 {

--- a/packages/strapi-design-system/src/NumberInput/NumberInput.js
+++ b/packages/strapi-design-system/src/NumberInput/NumberInput.js
@@ -6,9 +6,9 @@ import { CarretDown } from '@strapi/icons';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
+import { useDesignSystem } from '../DesignSystemProvider';
 import { Field, FieldLabel, FieldHint, FieldError, FieldInput } from '../Field';
 import { Flex } from '../Flex';
-import { getDefaultLocale } from '../helpers/getDefaultLocale';
 import { KeyboardKeys } from '../helpers/keyboardKeys';
 import { useControllableState } from '../hooks/useControllableState';
 import { useId } from '../hooks/useId';
@@ -52,8 +52,8 @@ export const NumberInput = React.forwardRef(
     ref,
   ) => {
     const generatedId = useId(id);
-
-    const locale = defaultLocale || getDefaultLocale();
+    const designContext = useDesignSystem('NumberInput');
+    const locale = defaultLocale || designContext.locale;
     const numberParserRef = useRef(new NumberParser(locale, { style: 'decimal' }));
     const numberFormaterRef = useRef(new NumberFormatter(locale, { maximumFractionDigits: 20 }));
 

--- a/packages/strapi-design-system/src/Popover/__tests__/Popover.spec.tsx
+++ b/packages/strapi-design-system/src/Popover/__tests__/Popover.spec.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
 
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent } from '@test/utils';
 
-import { ThemeProvider } from '../../ThemeProvider';
-import { lightTheme } from '../../themes';
 import { Popover } from '../Popover';
 
 describe('Popover', () => {
@@ -13,20 +11,18 @@ describe('Popover', () => {
       const [visible] = React.useState(true);
 
       return (
-        <ThemeProvider theme={lightTheme}>
-          <div>
-            <div ref={divRef}>Source</div>
-            {visible && (
-              <Popover source={divRef}>
-                <div>Hello world</div>
-              </Popover>
-            )}
-          </div>
-        </ThemeProvider>
+        <div>
+          <div ref={divRef}>Source</div>
+          {visible && (
+            <Popover source={divRef}>
+              <div>Hello world</div>
+            </Popover>
+          )}
+        </div>
       );
     };
 
-    const { container } = render(<Component />, { container: document.body });
+    const { container } = render(<Component />, { renderOptions: { container: document.body } });
 
     expect(container).toMatchInlineSnapshot(`
       .c3 {
@@ -129,22 +125,20 @@ describe('Popover', () => {
       const [isVisible, setIsVisible] = React.useState(false);
 
       return (
-        <ThemeProvider theme={lightTheme}>
-          <div>
-            <button type="button" ref={divRef} onClick={() => setIsVisible((s) => !s)}>
-              Source
-            </button>
-            {isVisible && (
-              <Popover source={divRef}>
-                <div>Hello world</div>
-              </Popover>
-            )}
-          </div>
-        </ThemeProvider>
+        <div>
+          <button type="button" ref={divRef} onClick={() => setIsVisible((s) => !s)}>
+            Source
+          </button>
+          {isVisible && (
+            <Popover source={divRef}>
+              <div>Hello world</div>
+            </Popover>
+          )}
+        </div>
       );
     };
 
-    render(<Component />, { container: document.body });
+    render(<Component />, { renderOptions: { container: document.body } });
 
     expect(() => screen.getByText('Hello world')).toThrow();
 

--- a/packages/strapi-design-system/src/Radio/__tests__/Radio.spec.js
+++ b/packages/strapi-design-system/src/Radio/__tests__/Radio.spec.js
@@ -1,22 +1,20 @@
 import React from 'react';
 
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent } from '@test/utils';
 
 import { RadioGroup, Radio } from '..';
-import { ThemeProvider } from '../../ThemeProvider';
-import { lightTheme } from '../../themes';
 
 describe('Radio/RadioGroup', () => {
   it('selects a Radio button when a value is passed in to RadioGroup', () => {
     const onChangeMock = jest.fn();
     const { getByRole } = render(
-      <ThemeProvider theme={lightTheme}>
+      <>
         <p id="food">Food choices</p>
         <RadioGroup labelledBy="food" onChange={onChangeMock} value="pizza" name="meal">
           <Radio value="pizza">Pizza</Radio>
           <Radio value="bagel">Bagel</Radio>
         </RadioGroup>
-      </ThemeProvider>,
+      </>,
     );
 
     expect(getByRole('radio', { name: 'Bagel' })).not.toBeChecked();
@@ -26,13 +24,13 @@ describe('Radio/RadioGroup', () => {
   it('keeps all radio buttons unselected when value passed into RadioGroup is empty', () => {
     const onChangeMock = jest.fn();
     const { getByRole } = render(
-      <ThemeProvider theme={lightTheme}>
+      <>
         <p id="food">Food choices</p>
         <RadioGroup labelledBy="food" onChange={onChangeMock} value="" name="meal">
           <Radio value="pizza">Pizza</Radio>
           <Radio value="bagel">Bagel</Radio>
         </RadioGroup>
-      </ThemeProvider>,
+      </>,
     );
 
     expect(getByRole('radio', { name: 'Bagel' })).not.toBeChecked();
@@ -42,13 +40,13 @@ describe('Radio/RadioGroup', () => {
   it('calls onChange prop when Radio button is clicked', () => {
     const onChangeMock = jest.fn();
     const { getByRole } = render(
-      <ThemeProvider theme={lightTheme}>
+      <>
         <p id="food">Food choices</p>
         <RadioGroup labelledBy="food" onChange={onChangeMock} value="" name="meal">
           <Radio value="pizza">Pizza</Radio>
           <Radio value="bagel">Bagel</Radio>
         </RadioGroup>
-      </ThemeProvider>,
+      </>,
     );
 
     fireEvent.click(getByRole('radio', { name: 'Pizza' }));

--- a/packages/strapi-design-system/src/Select/__tests__/MultiSelect.spec.tsx
+++ b/packages/strapi-design-system/src/Select/__tests__/MultiSelect.spec.tsx
@@ -1,8 +1,5 @@
-import { render as renderRTL } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render as renderRTL } from '@test/utils';
 
-import { ThemeProvider } from '../../ThemeProvider';
-import { darkTheme } from '../../themes';
 import { MultiSelect, MultiSelectOption, MultiSelectOptionProps, MultiSelectProps } from '../MultiSelect';
 
 const defaultOpts: MultiSelectOptionProps[] = [
@@ -24,20 +21,15 @@ const Component = (props: Partial<MultiSelectProps>) => (
   </MultiSelect>
 );
 
-const render = (props: Partial<MultiSelectProps> = {}) => ({
-  user: userEvent.setup(),
-  ...renderRTL(<Component {...props} />, {
-    wrapper: ({ children }) => <ThemeProvider theme={darkTheme}>{children}</ThemeProvider>,
-  }),
-});
+const render = (props: Partial<MultiSelectProps> = {}) => renderRTL(<Component {...props} />);
 
 describe('MultiSelect', () => {
   it('should render the select and the options', async () => {
-    const { getByRole } = render();
+    const { getByRole, user } = render();
 
     expect(getByRole('combobox')).toBeInTheDocument();
 
-    await userEvent.click(getByRole('combobox'));
+    await user.click(getByRole('combobox'));
 
     expect(getByRole('option', { name: 'Option 1' })).toBeInTheDocument();
     expect(getByRole('option', { name: 'Option 2' })).toBeInTheDocument();
@@ -45,19 +37,19 @@ describe('MultiSelect', () => {
   });
 
   it('should be able to select multiple options in one go without the listbox dissapearing', async () => {
-    const { getByRole } = render();
+    const { getByRole, user } = render();
 
-    await userEvent.click(getByRole('combobox'));
+    await user.click(getByRole('combobox'));
 
-    await userEvent.click(getByRole('option', { name: 'Option 1' }));
-    await userEvent.click(getByRole('option', { name: 'Option 2' }));
+    await user.click(getByRole('option', { name: 'Option 1' }));
+    await user.click(getByRole('option', { name: 'Option 2' }));
 
     expect(getByRole('option', { name: 'Option 1' })).toHaveAttribute('aria-checked', 'true');
     expect(getByRole('option', { name: 'Option 2' })).toHaveAttribute('aria-checked', 'true');
 
     expect(getByRole('listbox')).toBeInTheDocument();
 
-    await userEvent.keyboard('[Escape]');
+    await user.keyboard('[Escape]');
 
     expect(getByRole('combobox')).toHaveTextContent('Option 1Option 2');
   });

--- a/packages/strapi-design-system/src/Select/__tests__/MultiSelectNested.spec.tsx
+++ b/packages/strapi-design-system/src/Select/__tests__/MultiSelectNested.spec.tsx
@@ -1,8 +1,5 @@
-import { render as renderRTL } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render as renderRTL } from '@test/utils';
 
-import { ThemeProvider } from '../../ThemeProvider';
-import { darkTheme } from '../../themes';
 import { MultiSelectNested, MultiSelectNestedProps } from '../MultiSelectNested';
 
 const defaultOpts: MultiSelectNestedProps['options'] = [
@@ -23,20 +20,15 @@ const Component = (props: Partial<MultiSelectNestedProps>) => (
   <MultiSelectNested options={defaultOpts} placeholder="Choose an option" label="Choose" {...props} />
 );
 
-const render = (props: Partial<MultiSelectNestedProps> = {}) => ({
-  user: userEvent.setup(),
-  ...renderRTL(<Component {...props} />, {
-    wrapper: ({ children }) => <ThemeProvider theme={darkTheme}>{children}</ThemeProvider>,
-  }),
-});
+const render = (props: Partial<MultiSelectNestedProps> = {}) => renderRTL(<Component {...props} />);
 
 describe('MultiSelectNested', () => {
   it('should render the select and the options', async () => {
-    const { getByRole, getByText } = render();
+    const { getByRole, getByText, user } = render();
 
     expect(getByRole('combobox')).toBeInTheDocument();
 
-    await userEvent.click(getByRole('combobox'));
+    await user.click(getByRole('combobox'));
 
     expect(getByText('Group 1')).toBeInTheDocument();
     expect(getByRole('option', { name: 'Option 1' })).toBeInTheDocument();
@@ -45,30 +37,30 @@ describe('MultiSelectNested', () => {
   });
 
   it('should select an option when only one is pressed', async () => {
-    const { getByRole } = render();
+    const { getByRole, user } = render();
 
-    await userEvent.click(getByRole('combobox'));
+    await user.click(getByRole('combobox'));
 
-    await userEvent.click(getByRole('option', { name: 'Option 3' }));
+    await user.click(getByRole('option', { name: 'Option 3' }));
 
     expect(getByRole('option', { name: 'Option 3' })).toHaveAttribute('aria-checked', 'true');
 
-    await userEvent.keyboard('[Escape]');
+    await user.keyboard('[Escape]');
 
     expect(getByRole('combobox')).toHaveTextContent('Option 3');
   });
 
   it('should select all the options in the group if said group item is clicked', async () => {
-    const { getByRole } = render();
+    const { getByRole, user } = render();
 
-    await userEvent.click(getByRole('combobox'));
+    await user.click(getByRole('combobox'));
 
-    await userEvent.click(getByRole('option', { name: 'Group 1' }));
+    await user.click(getByRole('option', { name: 'Group 1' }));
 
     expect(getByRole('option', { name: 'Option 1' })).toHaveAttribute('aria-checked', 'true');
     expect(getByRole('option', { name: 'Option 2' })).toHaveAttribute('aria-checked', 'true');
 
-    await userEvent.keyboard('[Escape]');
+    await user.keyboard('[Escape]');
 
     expect(getByRole('combobox')).toHaveTextContent('Option 1Option 2');
   });

--- a/packages/strapi-design-system/src/Select/__tests__/Select.spec.tsx
+++ b/packages/strapi-design-system/src/Select/__tests__/Select.spec.tsx
@@ -1,8 +1,5 @@
-import { render } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render } from '@test/utils';
 
-import { ThemeProvider } from '../../ThemeProvider';
-import { darkTheme } from '../../themes';
 import { Option } from '../Option';
 import { Select } from '../Select';
 
@@ -17,15 +14,13 @@ const defaultOpts = [
 ];
 
 const Component = ({ options = defaultOpts, ...restProps }: RenderProps) => (
-  <ThemeProvider theme={darkTheme}>
-    <Select label="Pick Options" placeholder="Your option" {...restProps}>
-      {options.map((opt) => (
-        <Option key={opt.label} value={opt.value}>
-          {opt.label}
-        </Option>
-      ))}
-    </Select>
-  </ThemeProvider>
+  <Select label="Pick Options" placeholder="Your option" {...restProps}>
+    {options.map((opt) => (
+      <Option key={opt.label} value={opt.value}>
+        {opt.label}
+      </Option>
+    ))}
+  </Select>
 );
 
 const renderComponent = (props: RenderProps = {}) => render(<Component {...props} />);
@@ -33,9 +28,9 @@ const renderComponent = (props: RenderProps = {}) => render(<Component {...props
 describe('Select', () => {
   it('should infer the multi prop on the options when set to true on the Select component', async () => {
     // @ts-expect-error We are testing the the inference of the multi prop for a deprecated component
-    const { getByRole } = renderComponent({ multi: true });
+    const { getByRole, user } = renderComponent({ multi: true });
 
-    await userEvent.click(getByRole('combobox', { name: 'Pick Options' }));
+    await user.click(getByRole('combobox', { name: 'Pick Options' }));
 
     /**
      * Because we're only testing the visuals here, we're expecting a checkbox div element to be rendered
@@ -54,7 +49,7 @@ describe('Select', () => {
       .c4 {
         font-size: 0.875rem;
         line-height: 1.43;
-        color: #ffffff;
+        color: #32324d;
       }
 
       .c0 {
@@ -65,7 +60,7 @@ describe('Select', () => {
         border-radius: 4px;
         padding: 8px 16px;
         padding-left: 16px;
-        background-color: #212134;
+        background-color: #ffffff;
         display: -webkit-box;
         display: -webkit-flex;
         display: -ms-flexbox;
@@ -84,21 +79,21 @@ describe('Select', () => {
 
       .c0:focus-visible {
         outline: none;
-        background-color: #181826;
+        background-color: #f0f0ff;
       }
 
       .c0:hover {
-        background-color: #181826;
+        background-color: #f0f0ff;
       }
 
       .c0[data-state='checked'] .c3 {
         font-weight: bold;
-        color: #7b79ff;
+        color: #4945ff;
       }
 
       .c2 {
-        border: 1px solid #666687;
-        background-color: #212134;
+        border: 1px solid #c0c0cf;
+        background-color: #ffffff;
       }
 
       <div

--- a/packages/strapi-design-system/src/Select/__tests__/SingleSelect.spec.tsx
+++ b/packages/strapi-design-system/src/Select/__tests__/SingleSelect.spec.tsx
@@ -1,8 +1,5 @@
-import { screen, render, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen, render, waitFor } from '@test/utils';
 
-import { ThemeProvider } from '../../ThemeProvider';
-import { darkTheme } from '../../themes';
 import { SingleSelectOption, SingleSelect, SingleSelectProps } from '../SingleSelect';
 
 interface RenderProps extends Partial<Omit<SingleSelectProps, 'children'>> {
@@ -16,15 +13,13 @@ const defaultOpts = [
 ];
 
 const Component = ({ options = defaultOpts, ...restProps }: RenderProps) => (
-  <ThemeProvider theme={darkTheme}>
-    <SingleSelect label="Pick Options" placeholder="Your option" {...restProps}>
-      {options.map((opt) => (
-        <SingleSelectOption key={opt.label} value={opt.value}>
-          {opt.label}
-        </SingleSelectOption>
-      ))}
-    </SingleSelect>
-  </ThemeProvider>
+  <SingleSelect label="Pick Options" placeholder="Your option" {...restProps}>
+    {options.map((opt) => (
+      <SingleSelectOption key={opt.label} value={opt.value}>
+        {opt.label}
+      </SingleSelectOption>
+    ))}
+  </SingleSelect>
 );
 
 const renderComponent = (props: RenderProps = {}) => render(<Component {...props} />);
@@ -32,8 +27,7 @@ const renderComponent = (props: RenderProps = {}) => render(<Component {...props
 describe('Select', () => {
   describe('Interactions', () => {
     it('should open the list when the trigger is clicked', async () => {
-      const user = userEvent.setup();
-      renderComponent();
+      const { user } = renderComponent();
 
       await user.click(screen.getByRole('combobox', { name: 'Pick Options' }));
 
@@ -41,8 +35,7 @@ describe('Select', () => {
     });
 
     it('should close the list when an option is selected', async () => {
-      const user = userEvent.setup();
-      renderComponent();
+      const { user } = renderComponent();
 
       await user.click(screen.getByRole('combobox'));
 
@@ -56,8 +49,7 @@ describe('Select', () => {
     });
 
     it('should not open the menu if the component is disabled', async () => {
-      const user = userEvent.setup();
-      renderComponent({ disabled: true });
+      const { user } = renderComponent({ disabled: true });
 
       await user.click(screen.getByRole('combobox'));
 
@@ -89,8 +81,7 @@ describe('Select', () => {
     });
 
     it('should render the value provided and not update when an option is selected', async () => {
-      const user = userEvent.setup();
-      renderComponent({ value: 'Option 1' });
+      const { user } = renderComponent({ value: 'Option 1' });
 
       expect(screen.getByText('Option 1')).toBeInTheDocument();
 
@@ -102,8 +93,8 @@ describe('Select', () => {
 
     it('should fire the onChange handler if you have a value provided and when you dont', async () => {
       const onChange = jest.fn();
-      const user = userEvent.setup();
-      const { rerender } = renderComponent({ onChange });
+
+      const { rerender, user } = renderComponent({ onChange });
 
       await user.click(screen.getByRole('combobox'));
       await user.click(screen.getByRole('option', { name: 'Option 3' }));
@@ -131,8 +122,7 @@ describe('Select', () => {
     });
 
     it('should not render the clear button when there is a value but onClear is not passed', async () => {
-      const user = userEvent.setup();
-      const { rerender } = renderComponent({ value: 'Option 1' });
+      const { user, rerender } = renderComponent({ value: 'Option 1' });
 
       expect(screen.queryByLabelText('Clear')).not.toBeInTheDocument();
 
@@ -146,8 +136,7 @@ describe('Select', () => {
     });
 
     it('should render the clear button when both a value and onClear are passed', async () => {
-      const user = userEvent.setup();
-      const { rerender } = renderComponent({ value: 'Option 1', onClear: jest.fn() });
+      const { user, rerender } = renderComponent({ value: 'Option 1', onClear: jest.fn() });
 
       expect(screen.getByLabelText('Clear')).toBeInTheDocument();
 
@@ -162,8 +151,8 @@ describe('Select', () => {
 
     it('should call onClear when clicked', async () => {
       const onClear = jest.fn();
-      const user = userEvent.setup();
-      renderComponent({ onClear });
+
+      const { user } = renderComponent({ onClear });
 
       await user.click(screen.getByRole('combobox'));
 

--- a/packages/strapi-design-system/src/SimpleMenu/__tests__/SimpleMenu.spec.js
+++ b/packages/strapi-design-system/src/SimpleMenu/__tests__/SimpleMenu.spec.js
@@ -1,23 +1,19 @@
 import * as React from 'react';
 
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@test/utils';
 
-import { ThemeProvider } from '../../ThemeProvider';
-import { lightTheme } from '../../themes';
 import { SimpleMenu, MenuItem } from '../SimpleMenu';
 
 describe('SimpleMenu', () => {
   it('display the menu on click on the menu button', async () => {
     render(
-      <ThemeProvider theme={lightTheme}>
-        <SimpleMenu label="Menu">
-          <MenuItem onClick={() => {}}>January</MenuItem>
-          <MenuItem onClick={() => {}}>February</MenuItem>
-          <MenuItem href="https://strapi.io" isExternal>
-            Strapi website
-          </MenuItem>
-        </SimpleMenu>
-      </ThemeProvider>,
+      <SimpleMenu label="Menu">
+        <MenuItem onClick={() => {}}>January</MenuItem>
+        <MenuItem onClick={() => {}}>February</MenuItem>
+        <MenuItem href="https://strapi.io" isExternal>
+          Strapi website
+        </MenuItem>
+      </SimpleMenu>,
     );
 
     const button = await waitFor(() => screen.getByText('Menu'));
@@ -32,15 +28,13 @@ describe('SimpleMenu', () => {
     const onClickSpy = jest.fn();
 
     render(
-      <ThemeProvider theme={lightTheme}>
-        <SimpleMenu label="Menu">
-          <MenuItem onClick={onClickSpy}>January</MenuItem>
-          <MenuItem onClick={onClickSpy}>February</MenuItem>
-          <MenuItem href="https://strapi.io" isExternal>
-            Strapi website
-          </MenuItem>
-        </SimpleMenu>
-      </ThemeProvider>,
+      <SimpleMenu label="Menu">
+        <MenuItem onClick={onClickSpy}>January</MenuItem>
+        <MenuItem onClick={onClickSpy}>February</MenuItem>
+        <MenuItem href="https://strapi.io" isExternal>
+          Strapi website
+        </MenuItem>
+      </SimpleMenu>,
     );
 
     const button = await waitFor(() => screen.getByText('Menu'));
@@ -54,15 +48,13 @@ describe('SimpleMenu', () => {
 
   it('display the menu on click on the external link menu button', async () => {
     render(
-      <ThemeProvider theme={lightTheme}>
-        <SimpleMenu label="Menu">
-          <MenuItem onClick={() => {}}>January</MenuItem>
-          <MenuItem onClick={() => {}}>February</MenuItem>
-          <MenuItem href="https://strapi.io" isExternal>
-            Strapi website
-          </MenuItem>
-        </SimpleMenu>
-      </ThemeProvider>,
+      <SimpleMenu label="Menu">
+        <MenuItem onClick={() => {}}>January</MenuItem>
+        <MenuItem onClick={() => {}}>February</MenuItem>
+        <MenuItem href="https://strapi.io" isExternal>
+          Strapi website
+        </MenuItem>
+      </SimpleMenu>,
     );
 
     const button = await waitFor(() => screen.getByText('Menu'));

--- a/packages/strapi-design-system/src/Status/__tests__/Status.spec.js
+++ b/packages/strapi-design-system/src/Status/__tests__/Status.spec.js
@@ -1,18 +1,12 @@
 import * as React from 'react';
 
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor } from '@test/utils';
 
-import { ThemeProvider } from '../../ThemeProvider';
-import { lightTheme } from '../../themes';
 import { Status } from '../Status';
 
 describe('Status', () => {
   it('it displays its children', async () => {
-    const { getByText } = render(
-      <ThemeProvider theme={lightTheme}>
-        <Status>My status</Status>
-      </ThemeProvider>,
-    );
+    const { getByText } = render(<Status>My status</Status>);
 
     await waitFor(() => {
       expect(getByText('My status')).toBeInTheDocument();
@@ -20,11 +14,7 @@ describe('Status', () => {
   });
 
   it('it displays a preceeding bullet by default', async () => {
-    const { queryByText } = render(
-      <ThemeProvider theme={lightTheme}>
-        <Status>My status</Status>
-      </ThemeProvider>,
-    );
+    const { queryByText } = render(<Status>My status</Status>);
 
     const textNode = queryByText('My status');
 
@@ -34,11 +24,7 @@ describe('Status', () => {
   });
 
   it('it is possible to disable the preceeding bullet', async () => {
-    const { queryByText } = render(
-      <ThemeProvider theme={lightTheme}>
-        <Status showBullet={false}>My status</Status>
-      </ThemeProvider>,
-    );
+    const { queryByText } = render(<Status showBullet={false}>My status</Status>);
 
     const textNode = queryByText('My status');
 

--- a/packages/strapi-design-system/src/Tag/__tests__/Tag.spec.tsx
+++ b/packages/strapi-design-system/src/Tag/__tests__/Tag.spec.tsx
@@ -1,18 +1,13 @@
 import { Cross } from '@strapi/icons';
-import { render as renderRTL } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render as renderRTL } from '@test/utils';
 
-import { ThemeProvider } from '../../ThemeProvider';
-import { lightTheme } from '../../themes';
 import { Tag, TagProps } from '../Tag';
 
 const render = ({ icon = <Cross />, children = 'hello', ...props }: Partial<TagProps> = {}) =>
   renderRTL(
-    <ThemeProvider theme={lightTheme}>
-      <Tag icon={icon} {...props}>
-        {children}
-      </Tag>
-    </ThemeProvider>,
+    <Tag icon={icon} {...props}>
+      {children}
+    </Tag>,
   );
 
 describe('Tag', () => {
@@ -38,10 +33,9 @@ describe('Tag', () => {
   });
 
   it('should fire the onClick callback', async () => {
-    const user = userEvent.setup();
     const onClick = jest.fn();
 
-    const { getByRole } = render({ onClick });
+    const { getByRole, user } = render({ onClick });
 
     await user.click(getByRole('button', { name: 'hello' }));
 
@@ -49,9 +43,8 @@ describe('Tag', () => {
   });
 
   it('should handle the disabled prop correctly', async () => {
-    const user = userEvent.setup();
     const onClick = jest.fn();
-    const { getByRole } = render({ disabled: true, onClick });
+    const { getByRole, user } = render({ disabled: true, onClick });
 
     expect(getByRole('button', { name: 'hello' })).toBeDisabled();
     expect(getByRole('button', { name: 'hello' })).toHaveAttribute('aria-disabled', 'true');

--- a/packages/strapi-design-system/src/TextInput/__tests__/TextInput.spec.tsx
+++ b/packages/strapi-design-system/src/TextInput/__tests__/TextInput.spec.tsx
@@ -1,19 +1,12 @@
 import { PlusCircle } from '@strapi/icons';
-import { render as renderRTL } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render as renderRTL } from '@test/utils';
 
 import { FieldAction } from '../../Field';
-import { ThemeProvider } from '../../ThemeProvider';
-import { lightTheme } from '../../themes';
 import { TextInput, TextInputProps } from '../TextInput';
 
 type ComponentProps = Partial<TextInputProps>;
 
-const Component = (props: ComponentProps) => (
-  <ThemeProvider theme={lightTheme}>
-    <TextInput label="text label" {...props} />
-  </ThemeProvider>
-);
+const Component = (props: ComponentProps) => <TextInput label="text label" {...props} />;
 
 const render = (props?: ComponentProps) => renderRTL(<Component {...props} />);
 
@@ -38,10 +31,9 @@ describe('TextInput', () => {
   });
 
   it('should pass other props to the underlying FieldInput component', async () => {
-    const user = userEvent.setup();
     const onChange = jest.fn();
 
-    const { getByRole, rerender } = render({
+    const { getByRole, rerender, user } = render({
       onChange,
       value: 'Value',
       startAction: (

--- a/packages/strapi-design-system/src/ThemeProvider/ThemeProvider.tsx
+++ b/packages/strapi-design-system/src/ThemeProvider/ThemeProvider.tsx
@@ -1,8 +1,12 @@
+/**
+ * TODO: remove this in v2 in favour of DesignSystemProvider, but this is rather convienient for now.
+ */
 import * as React from 'react';
 
 import { ThemeProvider as StyledThemeProvider, createGlobalStyle, DefaultTheme } from 'styled-components';
 
 import { LiveRegions } from '../LiveRegions/LiveRegions';
+import { lightTheme } from '../themes';
 
 const GlobalStyle = createGlobalStyle`
  /* http://meyerweb.com/eric/tools/css/reset/ 
@@ -178,17 +182,17 @@ const GlobalStyle = createGlobalStyle`
   }
 `;
 
-interface ThemeProviderProps {
+export interface ThemeProviderProps {
   children: React.ReactNode;
-  theme: DefaultTheme;
+  theme?: DefaultTheme;
 }
 
-export const ThemeProvider = ({ children, theme }: ThemeProviderProps) => {
+export const ThemeProvider = ({ children, theme = lightTheme }: ThemeProviderProps) => {
   return (
     <StyledThemeProvider theme={theme}>
-      <GlobalStyle />
       {children}
       <LiveRegions />
+      <GlobalStyle />
     </StyledThemeProvider>
   );
 };

--- a/packages/strapi-design-system/src/TimePicker/TimePicker.tsx
+++ b/packages/strapi-design-system/src/TimePicker/TimePicker.tsx
@@ -1,7 +1,6 @@
 import { Clock } from '@strapi/icons';
 import styled from 'styled-components';
 
-import { Flex } from '../Flex';
 import { useId } from '../hooks/useId';
 import { SingleSelect, SingleSelectOption, SingleSelectProps } from '../Select/SingleSelect';
 
@@ -63,11 +62,7 @@ export const TimePicker = ({ id, value, step = 15, onChange, ...props }: TimePic
       id={generatedId}
       placeholder="--:--"
       value={value ? getClosestValue() : undefined}
-      startIcon={
-        <TimeIconWrapper as="span">
-          <Clock />
-        </TimeIconWrapper>
-      }
+      startIcon={<StyledClock />}
       onChange={handleChange}
       {...props}
     >
@@ -80,13 +75,11 @@ export const TimePicker = ({ id, value, step = 15, onChange, ...props }: TimePic
   );
 };
 
-const TimeIconWrapper = styled(Flex)`
-  & > svg {
-    height: 1rem;
-    width: 1rem;
-  }
+const StyledClock = styled(Clock)`
+  height: 1rem;
+  width: 1rem;
 
-  & > svg path {
+  & > path {
     fill: ${({ theme }) => theme.colors.neutral500};
   }
 `;

--- a/packages/strapi-design-system/src/TimePicker/__tests__/TimePicker.spec.tsx
+++ b/packages/strapi-design-system/src/TimePicker/__tests__/TimePicker.spec.tsx
@@ -1,20 +1,13 @@
 import { useState } from 'react';
 
-import { render as renderRTL } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render as renderRTL } from '@test/utils';
 
-import { ThemeProvider } from '../../ThemeProvider';
-import { lightTheme } from '../../themes';
 import { TimePicker, TimePickerProps } from '../TimePicker';
 
 const Component = (props: Partial<TimePickerProps>) => {
   const [value, setValue] = useState<string>();
 
-  return (
-    <ThemeProvider theme={lightTheme}>
-      <TimePicker label="timepicker" value={value} onChange={setValue} {...props} />
-    </ThemeProvider>
-  );
+  return <TimePicker label="timepicker" value={value} onChange={setValue} {...props} />;
 };
 
 const render = (props?: Partial<TimePickerProps>) => renderRTL(<Component {...props} />);
@@ -40,8 +33,7 @@ describe('TimePicker', () => {
 
   describe('step prop', () => {
     it('should render 96 options for time by default', async () => {
-      const user = userEvent.setup();
-      const { getAllByRole, getByRole } = render();
+      const { getAllByRole, getByRole, user } = render();
 
       await user.click(getByRole('combobox'));
 
@@ -49,8 +41,7 @@ describe('TimePicker', () => {
     });
 
     it('should handle a different step count being passed', async () => {
-      const user = userEvent.setup();
-      const { getAllByRole, getByRole } = render({ step: 30 });
+      const { getAllByRole, getByRole, user } = render({ step: 30 });
 
       await user.click(getByRole('combobox'));
 

--- a/packages/strapi-design-system/src/Tooltip/__tests__/Tooltip.spec.tsx
+++ b/packages/strapi-design-system/src/Tooltip/__tests__/Tooltip.spec.tsx
@@ -1,17 +1,13 @@
-import { render, fireEvent, screen } from '@testing-library/react';
+import { render, fireEvent, screen } from '@test/utils';
 
-import { ThemeProvider } from '../../ThemeProvider';
-import { lightTheme } from '../../themes';
 import { Tooltip } from '../Tooltip';
 
 describe('Tooltip', () => {
   it('snapshots document.body when the tooltip is not visible but exists in the DOM', () => {
     render(
-      <ThemeProvider theme={lightTheme}>
-        <Tooltip description="Content of the tooltip fefe">
-          <button type="button">Show tooltip</button>
-        </Tooltip>
-      </ThemeProvider>,
+      <Tooltip description="Content of the tooltip fefe">
+        <button type="button">Show tooltip</button>
+      </Tooltip>,
     );
 
     expect(document.body).toMatchInlineSnapshot(`
@@ -101,11 +97,9 @@ describe('Tooltip', () => {
 
   it('snapshots document.body when the button is focused (aria-describedby exists)', () => {
     render(
-      <ThemeProvider theme={lightTheme}>
-        <Tooltip description="Content of the tooltip fefe">
-          <button type="button">Show tooltip</button>
-        </Tooltip>
-      </ThemeProvider>,
+      <Tooltip description="Content of the tooltip fefe">
+        <button type="button">Show tooltip</button>
+      </Tooltip>,
     );
 
     fireEvent.focus(screen.getByText('Show tooltip'));
@@ -204,11 +198,9 @@ describe('Tooltip', () => {
 
   it('snapshots document.body with a label', () => {
     render(
-      <ThemeProvider theme={lightTheme}>
-        <Tooltip label="Content of the tooltip fefe">
-          <button type="button">+</button>
-        </Tooltip>
-      </ThemeProvider>,
+      <Tooltip label="Content of the tooltip fefe">
+        <button type="button">+</button>
+      </Tooltip>,
     );
 
     fireEvent.focus(screen.getByText('+'));

--- a/packages/strapi-design-system/src/Typography/__tests__/Typography.spec.tsx
+++ b/packages/strapi-design-system/src/Typography/__tests__/Typography.spec.tsx
@@ -1,15 +1,8 @@
-import { render } from '@testing-library/react';
+import { render } from '@test/utils';
 
-import { ThemeProvider } from '../../ThemeProvider';
-import { lightTheme } from '../../themes';
 import { Typography, TypographyProps } from '../Typography';
 
-const setup = (props: TypographyProps) =>
-  render(
-    <ThemeProvider theme={lightTheme}>
-      <Typography {...props} />
-    </ThemeProvider>,
-  );
+const setup = (props: TypographyProps) => render(<Typography {...props} />);
 
 describe('Typography', () => {
   test('textAlign', async () => {

--- a/packages/strapi-design-system/src/helpers/__tests__/deprecations.spec.tsx
+++ b/packages/strapi-design-system/src/helpers/__tests__/deprecations.spec.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render } from '@test/utils';
 
 import { once, PREFIX } from '../deprecations';
 

--- a/packages/strapi-design-system/src/helpers/getDefaultLocale.ts
+++ b/packages/strapi-design-system/src/helpers/getDefaultLocale.ts
@@ -16,6 +16,10 @@
  */
 const DEFAULT_LOCALE = 'en-EN';
 
+/**
+ * @preserve
+ * @deprecated This will be removed in v2.0.0, you can access the locale from `useDesignSystem` instead.
+ */
 export const getDefaultLocale = () => {
   if (typeof navigator === 'undefined') {
     return DEFAULT_LOCALE;
@@ -23,12 +27,6 @@ export const getDefaultLocale = () => {
 
   if (navigator.language) {
     return navigator.language;
-  }
-
-  // @ts-expect-error this is not in the TS definition but is in the spec
-  if (navigator.userLanguage) {
-    // @ts-expect-error this is not in the TS definition but is in the spec
-    return navigator.userLanguage;
   }
 
   return DEFAULT_LOCALE;

--- a/packages/strapi-design-system/src/hooks/__tests__/useId.spec.tsx
+++ b/packages/strapi-design-system/src/hooks/__tests__/useId.spec.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render } from '@test/utils';
 
 import { useId } from '../useId';
 
@@ -12,10 +12,44 @@ describe('useId', () => {
 
     const { container } = render(<TestCompo />);
     expect(container).toMatchInlineSnapshot(`
+      .c0 {
+        border: 0;
+        -webkit-clip: rect(0 0 0 0);
+        clip: rect(0 0 0 0);
+        height: 1px;
+        margin: -1px;
+        overflow: hidden;
+        padding: 0;
+        position: absolute;
+        width: 1px;
+      }
+
       <div>
         <div
           id=":r0:"
         />
+        <div
+          class="c0"
+        >
+          <p
+            aria-live="polite"
+            aria-relevant="all"
+            id="live-region-log"
+            role="log"
+          />
+          <p
+            aria-live="polite"
+            aria-relevant="all"
+            id="live-region-status"
+            role="status"
+          />
+          <p
+            aria-live="assertive"
+            aria-relevant="all"
+            id="live-region-alert"
+            role="alert"
+          />
+        </div>
       </div>
     `);
   });
@@ -29,10 +63,44 @@ describe('useId', () => {
 
     const { container } = render(<TestCompo />);
     expect(container).toMatchInlineSnapshot(`
+      .c0 {
+        border: 0;
+        -webkit-clip: rect(0 0 0 0);
+        clip: rect(0 0 0 0);
+        height: 1px;
+        margin: -1px;
+        overflow: hidden;
+        padding: 0;
+        position: absolute;
+        width: 1px;
+      }
+
       <div>
         <div
           id="my-custom-id"
         />
+        <div
+          class="c0"
+        >
+          <p
+            aria-live="polite"
+            aria-relevant="all"
+            id="live-region-log"
+            role="log"
+          />
+          <p
+            aria-live="polite"
+            aria-relevant="all"
+            id="live-region-status"
+            role="status"
+          />
+          <p
+            aria-live="assertive"
+            aria-relevant="all"
+            id="live-region-alert"
+            role="alert"
+          />
+        </div>
       </div>
     `);
   });

--- a/packages/strapi-design-system/src/index.ts
+++ b/packages/strapi-design-system/src/index.ts
@@ -16,6 +16,7 @@ export * from './Card';
 export * from './CarouselInput';
 export * from './Checkbox';
 export * from './Combobox';
+export * from './DesignSystemProvider';
 export * from './Dialog';
 export * from './DismissibleLayer';
 export * from './DatePicker';

--- a/packages/strapi-design-system/src/v2/Breadcrumbs/__tests__/Breadcrumbs.spec.js
+++ b/packages/strapi-design-system/src/v2/Breadcrumbs/__tests__/Breadcrumbs.spec.js
@@ -1,21 +1,17 @@
 import * as React from 'react';
 
-import { render } from '@testing-library/react';
+import { render } from '@test/utils';
 
-import { ThemeProvider } from '../../../ThemeProvider';
-import { lightTheme } from '../../../themes';
 import { Breadcrumbs } from '../Breadcrumbs';
 import { Crumb } from '../Crumb';
 
 describe('Breadcrumb', () => {
   it('should render only one crumb without any separator', async () => {
     const { container } = render(
-      <ThemeProvider theme={lightTheme}>
-        <Breadcrumbs label="test">
-          <Crumb>First</Crumb>
-          {undefined && <Crumb>Second</Crumb>}
-        </Breadcrumbs>
-      </ThemeProvider>,
+      <Breadcrumbs label="test">
+        <Crumb>First</Crumb>
+        {undefined && <Crumb>Second</Crumb>}
+      </Breadcrumbs>,
     );
 
     const crumbList = container.querySelectorAll('li');
@@ -29,12 +25,10 @@ describe('Breadcrumb', () => {
 
   it('should render two crumbs with only one separator', async () => {
     const { container } = render(
-      <ThemeProvider theme={lightTheme}>
-        <Breadcrumbs label="test">
-          <Crumb>First</Crumb>
-          <Crumb>Second</Crumb>
-        </Breadcrumbs>
-      </ThemeProvider>,
+      <Breadcrumbs label="test">
+        <Crumb>First</Crumb>
+        <Crumb>Second</Crumb>
+      </Breadcrumbs>,
     );
 
     const crumbList = container.querySelectorAll('li');

--- a/packages/strapi-design-system/src/v2/SimpleMenu/__tests__/Menu.spec.tsx
+++ b/packages/strapi-design-system/src/v2/SimpleMenu/__tests__/Menu.spec.tsx
@@ -1,8 +1,5 @@
-import { render as renderRTL } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render as renderRTL } from '@test/utils';
 
-import { ThemeProvider } from '../../../ThemeProvider';
-import { lightTheme } from '../../../themes';
 import { Menu } from '../SimpleMenu';
 
 interface ComponentProps {
@@ -11,29 +8,27 @@ interface ComponentProps {
 }
 
 const Component = ({ onAction1Select, onSubmenuAction1Select }: ComponentProps) => (
-  <ThemeProvider theme={lightTheme}>
-    <Menu.Root>
-      <Menu.Trigger>Actions</Menu.Trigger>
-      <Menu.Content>
-        <Menu.Item onSelect={onAction1Select}>Action 1</Menu.Item>
-        <Menu.Item isLink href="/home">
-          Action 2
-        </Menu.Item>
-        <Menu.Item isExternal href="https://google.com">
-          Action 3
-        </Menu.Item>
-        <Menu.SubRoot>
-          <Menu.SubTrigger>Subactions</Menu.SubTrigger>
-          <Menu.SubContent>
-            <Menu.Label>Submenu Actions</Menu.Label>
-            <Menu.Item onSelect={onSubmenuAction1Select}>Subaction 1</Menu.Item>
-            <Menu.Item>Subaction 2</Menu.Item>
-            <Menu.Item>Subaction 3</Menu.Item>
-          </Menu.SubContent>
-        </Menu.SubRoot>
-      </Menu.Content>
-    </Menu.Root>
-  </ThemeProvider>
+  <Menu.Root>
+    <Menu.Trigger>Actions</Menu.Trigger>
+    <Menu.Content>
+      <Menu.Item onSelect={onAction1Select}>Action 1</Menu.Item>
+      <Menu.Item isLink href="/home">
+        Action 2
+      </Menu.Item>
+      <Menu.Item isExternal href="https://google.com">
+        Action 3
+      </Menu.Item>
+      <Menu.SubRoot>
+        <Menu.SubTrigger>Subactions</Menu.SubTrigger>
+        <Menu.SubContent>
+          <Menu.Label>Submenu Actions</Menu.Label>
+          <Menu.Item onSelect={onSubmenuAction1Select}>Subaction 1</Menu.Item>
+          <Menu.Item>Subaction 2</Menu.Item>
+          <Menu.Item>Subaction 3</Menu.Item>
+        </Menu.SubContent>
+      </Menu.SubRoot>
+    </Menu.Content>
+  </Menu.Root>
 );
 
 const render = (props: ComponentProps = {}) => renderRTL(<Component {...props} />);
@@ -49,9 +44,7 @@ describe('Menu', () => {
   });
 
   it('should open the menu when the trigger is clicked', async () => {
-    const user = userEvent.setup();
-
-    const { getByRole } = render();
+    const { getByRole, user } = render();
 
     await user.click(getByRole('button', { name: 'Actions' }));
 
@@ -63,9 +56,7 @@ describe('Menu', () => {
   });
 
   it('should close the menu when the escape key is pressed after its opened', async () => {
-    const user = userEvent.setup();
-
-    const { getByRole, queryByRole } = render();
+    const { getByRole, queryByRole, user } = render();
 
     await user.click(getByRole('button', { name: 'Actions' }));
     await user.keyboard('{Escape}');
@@ -76,9 +67,7 @@ describe('Menu', () => {
 
   describe('Menu Items', () => {
     it('should render an anchor if we pass a isLink', async () => {
-      const user = userEvent.setup();
-
-      const { getByRole } = render();
+      const { getByRole, user } = render();
 
       await user.click(getByRole('button', { name: 'Actions' }));
 
@@ -87,9 +76,7 @@ describe('Menu', () => {
     });
 
     it('should render an anchor if we pass isExternal', async () => {
-      const user = userEvent.setup();
-
-      const { getByRole } = render();
+      const { getByRole, user } = render();
 
       await user.click(getByRole('button', { name: 'Actions' }));
 
@@ -98,9 +85,7 @@ describe('Menu', () => {
     });
 
     it('should allow navigating through the list of items with the arrow keys', async () => {
-      const user = userEvent.setup();
-
-      const { getByRole } = render();
+      const { getByRole, user } = render();
 
       await user.click(getByRole('button', { name: 'Actions' }));
       await user.keyboard('{ArrowDown}');
@@ -121,10 +106,9 @@ describe('Menu', () => {
     });
 
     it('should fire the menu item onClick handler when clicked', async () => {
-      const user = userEvent.setup();
       const onAction1Select = jest.fn();
 
-      const { getByRole } = render({ onAction1Select });
+      const { getByRole, user } = render({ onAction1Select });
 
       await user.click(getByRole('button', { name: 'Actions' }));
       await user.click(getByRole('menuitem', { name: 'Action 1' }));
@@ -134,10 +118,9 @@ describe('Menu', () => {
 
     ['Enter', 'Space'].forEach((key) => {
       it(`should fire the menu item onSelect handler when ${key} is pressed`, async () => {
-        const user = userEvent.setup();
         const onAction1Select = jest.fn();
 
-        const { getByRole } = render({ onAction1Select });
+        const { getByRole, user } = render({ onAction1Select });
 
         await user.click(getByRole('button', { name: 'Actions' }));
 
@@ -151,9 +134,7 @@ describe('Menu', () => {
 
   describe('Submenus', () => {
     it('should open the submenu when the submenu trigger is clicked', async () => {
-      const user = userEvent.setup();
-
-      const { getByRole, getByText } = render();
+      const { getByRole, getByText, user } = render();
 
       await user.click(getByRole('button', { name: 'Actions' }));
       await user.click(getByRole('menuitem', { name: 'Subactions' }));
@@ -169,10 +150,9 @@ describe('Menu', () => {
      * This test fails and i'm not sure why...
      */
     it.skip('should fire the onSelect of a submenu item when clicked', async () => {
-      const user = userEvent.setup();
       const onSubmenuAction1Select = jest.fn();
 
-      const { getByRole } = render({ onSubmenuAction1Select });
+      const { getByRole, user } = render({ onSubmenuAction1Select });
 
       await user.click(getByRole('button', { name: 'Actions' }));
       await user.click(getByRole('menuitem', { name: 'Subactions' }));
@@ -184,10 +164,9 @@ describe('Menu', () => {
 
     ['Enter', 'Space'].forEach((key) => {
       it(`should fire the onSelect of a submenu item when ${key} is pressed`, async () => {
-        const user = userEvent.setup();
         const onSubmenuAction1Select = jest.fn();
 
-        const { getByRole } = render({ onSubmenuAction1Select });
+        const { getByRole, user } = render({ onSubmenuAction1Select });
 
         await user.click(getByRole('button', { name: 'Actions' }));
 

--- a/packages/strapi-design-system/src/v2/SimpleMenu/__tests__/SimpleMenu.spec.tsx
+++ b/packages/strapi-design-system/src/v2/SimpleMenu/__tests__/SimpleMenu.spec.tsx
@@ -1,23 +1,18 @@
-import { render as renderRTL } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render as renderRTL } from '@test/utils';
 
-import { ThemeProvider } from '../../../ThemeProvider';
-import { lightTheme } from '../../../themes';
 import { SimpleMenu, MenuItem, SimpleMenuProps } from '../SimpleMenu';
 
 const Component = ({ onClick = () => {}, ...restProps }: SimpleMenuProps) => (
-  <ThemeProvider theme={lightTheme}>
-    <SimpleMenu label="Menu" {...restProps}>
-      <MenuItem onClick={onClick}>January</MenuItem>
-      <MenuItem onClick={onClick}>February</MenuItem>
-      <MenuItem href="https://strapi.io" isExternal>
-        Strapi website
-      </MenuItem>
-      <MenuItem href="/" isLink>
-        Home
-      </MenuItem>
-    </SimpleMenu>
-  </ThemeProvider>
+  <SimpleMenu label="Menu" {...restProps}>
+    <MenuItem onClick={onClick}>January</MenuItem>
+    <MenuItem onClick={onClick}>February</MenuItem>
+    <MenuItem href="https://strapi.io" isExternal>
+      Strapi website
+    </MenuItem>
+    <MenuItem href="/" isLink>
+      Home
+    </MenuItem>
+  </SimpleMenu>
 );
 
 const render = (props: Partial<SimpleMenuProps> = {}) => renderRTL(<Component {...props} />);
@@ -33,9 +28,7 @@ describe('SimpleMenu', () => {
   });
 
   it('should open the menu when the trigger is clicked', async () => {
-    const user = userEvent.setup();
-
-    const { getByRole } = render();
+    const { getByRole, user } = render();
 
     await user.click(getByRole('button', { name: 'Menu' }));
 
@@ -47,9 +40,7 @@ describe('SimpleMenu', () => {
   });
 
   it('should close the menu when the escape key is pressed after its opened', async () => {
-    const user = userEvent.setup();
-
-    const { getByRole, queryByRole } = render();
+    const { getByRole, queryByRole, user } = render();
 
     await user.click(getByRole('button', { name: 'Menu' }));
     await user.keyboard('{Escape}');
@@ -59,10 +50,9 @@ describe('SimpleMenu', () => {
   });
 
   it('should call onOpen when the menu is opened', async () => {
-    const user = userEvent.setup();
     const onOpen = jest.fn();
 
-    const { getByRole } = render({ onOpen });
+    const { getByRole, user } = render({ onOpen });
 
     await user.click(getByRole('button', { name: 'Menu' }));
 
@@ -70,10 +60,9 @@ describe('SimpleMenu', () => {
   });
 
   it('should call onClose when the menu is closed', async () => {
-    const user = userEvent.setup();
     const onClose = jest.fn();
 
-    const { getByRole } = render({ onClose });
+    const { getByRole, user } = render({ onClose });
 
     await user.click(getByRole('button', { name: 'Menu' }));
     await user.keyboard('[Escape]');

--- a/packages/strapi-design-system/test/utils.tsx
+++ b/packages/strapi-design-system/test/utils.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+
+import { render as renderRTL, RenderOptions as RTLRenderOptions } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { DesignSystemProvider } from '../src/DesignSystemProvider';
+
+interface RenderOptions {
+  renderOptions?: RTLRenderOptions;
+  userEventOptions?: Parameters<typeof userEvent.setup>[0];
+}
+
+// eslint-disable-next-line react/jsx-no-useless-fragment
+const fallbackWrapper = ({ children }) => <>{children}</>;
+
+const render = (ui: React.ReactElement, { renderOptions, userEventOptions }: RenderOptions = {}) => {
+  const { wrapper: Wrapper = fallbackWrapper, ...restOptions } = renderOptions ?? {};
+
+  return {
+    ...renderRTL(ui, {
+      wrapper: ({ children }) => (
+        <DesignSystemProvider locale="en-GB">
+          <Wrapper>{children}</Wrapper>
+        </DesignSystemProvider>
+      ),
+      ...restOptions,
+    }),
+    user: userEvent.setup(userEventOptions),
+  };
+};
+
+export * from '@testing-library/react';
+export { render };

--- a/packages/strapi-design-system/tsconfig.json
+++ b/packages/strapi-design-system/tsconfig.json
@@ -15,7 +15,11 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["vite/client", "jest", "@testing-library/jest-dom"]
+    "types": ["vite/client", "jest", "@testing-library/jest-dom"],
+    "baseUrl": ".",
+    "paths": {
+      "@test/*": ["./test/*"]
+    }
   },
   "include": ["src", "styled.d.ts"],
   "references": [


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* Adds `DesignSystemProvider` component
* Adds a test-util file as an abstraction for `@testing-library/react` to avoid importing `ThemeProvider` etc. _everywhere_ and giving you `userEvent` ootb.
* refactors tests with this in mind

### Why is it needed?

* Components can access a global locale
* Test utilities make lives easier

### How to test it?

* Automated testing
