### PR TITLE
When combobox has no items show the creatable option

### DIFF
--- a/packages/primitives/src/components/Combobox/Combobox.tsx
+++ b/packages/primitives/src/components/Combobox/Combobox.tsx
@@ -1025,10 +1025,14 @@ const ComboboxCreateItem = React.forwardRef<ComboboxItemElement, CreateItemProps
       setShow(!state.some((item) => item.textValue === textValue && item.type !== 'create'));
     });
 
+    if (getItems().length === 0) {
+      setShow(true);
+    }
+
     return () => {
       unsub();
     };
-  }, [textValue, subscribe]);
+  }, [textValue, subscribe, getItems]);
 
   if (!textValue || !show) {
     return null;

--- a/packages/strapi-design-system/src/Combobox/__tests__/Combobox.spec.tsx
+++ b/packages/strapi-design-system/src/Combobox/__tests__/Combobox.spec.tsx
@@ -5,15 +5,21 @@ import { ThemeProvider } from '../../ThemeProvider';
 import { lightTheme } from '../../themes';
 import { Combobox, Option, ComboboxProps } from '../Combobox';
 
-type ComponentProps = Omit<ComboboxProps, 'children'>;
+type ComponentProps = Omit<ComboboxProps, 'children'> & { options?: typeof defaultOptions };
 
-const Component = (props: ComponentProps) => (
+const defaultOptions = [
+  { value: 'hamburger', children: 'Hamburger' },
+  { value: 'bagel', children: 'Bagel' },
+  { value: 'tartuffo', children: 'Tartuffo' },
+  { value: 'carbonara', children: 'Carbonara' },
+];
+
+const Component = ({ options = defaultOptions, ...restProps }: ComponentProps) => (
   <ThemeProvider theme={lightTheme}>
-    <Combobox label="Food" {...props}>
-      <Option value="hamburger">Hamburger</Option>
-      <Option value="bagel">Bagel</Option>
-      <Option value="tartuffo">Tartuffo</Option>
-      <Option value="carbonara">Carbonara</Option>
+    <Combobox label="Food" {...restProps}>
+      {options.map((opt) => (
+        <Option key={opt.value} {...opt} />
+      ))}
     </Combobox>
   </ThemeProvider>
 );
@@ -180,6 +186,22 @@ describe('Combobox', () => {
       await user.type(getByRole('combobox'), 'urger');
 
       expect(queryByRole('option', { name: /Create/ })).not.toBeInTheDocument();
+    });
+
+    it('should show the creatable button even if there are no options to begin with when we have typed something', async () => {
+      const user = userEvent.setup();
+      const { getByRole, queryByRole } = render({
+        creatable: true,
+        options: [],
+      });
+
+      await user.click(getByRole('combobox'));
+
+      expect(queryByRole('option', { name: /Create/ })).not.toBeInTheDocument();
+
+      await user.type(getByRole('combobox'), 'Hamb');
+
+      expect(queryByRole('option', { name: 'Create "Hamb"' })).toBeInTheDocument();
     });
 
     it("should by default show the 'Create {value}' label", async () => {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* adds a check to see if there are any items, if there are no items we show "create" by default

### Why is it needed?

* The "create component" combobox has no items by default but right now you can't create anything either

### How to test it?

* I added an automated test 🪄 

### Related issue(s)/PR(s)

* resolves https://github.com/strapi/strapi/issues/16677
