### PR TITLE
Bring primitive/Combobox popover behaviour to be in line with Select

### DIFF
--- a/docs/stories/Select.stories.mdx
+++ b/docs/stories/Select.stories.mdx
@@ -118,7 +118,7 @@ const customizeContent = (values: string[]) => `${values.length} are currently s
           required
           placeholder="My favourite fruit is..."
           onClear={() => {
-            setValue(undefined);
+            setValues(undefined);
           }}
           value={values}
           onChange={setValues}
@@ -150,7 +150,7 @@ Instead of passing a `customizeContent` prop, you can pass the `withTags` prop w
           required
           placeholder="My favourite fruit is..."
           onClear={() => {
-            setValue(undefined);
+            setValues(undefined);
           }}
           value={values}
           onChange={setValues}
@@ -221,7 +221,7 @@ Instead of passing a `customizeContent` prop, you can pass the `withTags` prop w
           required
           placeholder="My favourite fruit is..."
           onClear={() => {
-            setValue(undefined);
+            setValues(undefined);
           }}
           value={values}
           onChange={setValues}

--- a/packages/primitives/src/components/Combobox/__tests__/index.test.tsx
+++ b/packages/primitives/src/components/Combobox/__tests__/index.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { render as renderRTL } from '@testing-library/react';
+import { RenderOptions, render as renderRTL } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { Combobox } from '../index';
@@ -39,9 +39,9 @@ const Component = ({ options = defaultOptions, hideCreatable = false, ...restPro
   </Combobox.Root>
 );
 
-const render = (props?: ComponentProps) => ({
+const render = (props?: ComponentProps, renderOptions?: RenderOptions) => ({
   user: userEvent.setup({ document }),
-  ...renderRTL(<Component {...props} />),
+  ...renderRTL(<Component {...props} />, renderOptions),
 });
 
 /**
@@ -195,13 +195,22 @@ describe('Combobox', () => {
       expect(queryByText('Option 3')).toBeInTheDocument();
     });
 
-    /**
-     * Window blur events are not being fired
-     */
-    it.skip('should revert to the related items textValue based on the set value if an unaccepted textValue is left onBlur', async () => {
+    it('should revert to the related items textValue based on the set value if an unaccepted textValue is left onBlur', async () => {
       const onValueChange = jest.fn();
 
-      const { getByRole, user } = render({ onValueChange });
+      const { getByRole, queryByRole, user } = render(
+        { onValueChange },
+        {
+          wrapper({ children }) {
+            return (
+              <div>
+                {children}
+                <button type="button">testing</button>
+              </div>
+            );
+          },
+        },
+      );
 
       await user.click(getByRole('combobox'));
 
@@ -212,6 +221,10 @@ describe('Combobox', () => {
 
       await user.type(getByRole('combobox'), 'apples');
 
+      await user.keyboard('[Escape]');
+
+      expect(queryByRole('listbox')).not.toBeInTheDocument();
+
       await user.tab();
 
       expect(getByRole('combobox')).toHaveValue('');
@@ -219,13 +232,22 @@ describe('Combobox', () => {
       expect(onValueChange).not.toHaveBeenCalled();
     });
 
-    /**
-     * Window blur events are not being fired
-     */
-    it.skip("should set the value to the textValue's item's value assuming an allowed textValue is left onBlur", async () => {
+    it("should set the value to the textValue's item's value assuming an allowed textValue is left onBlur", async () => {
       const onValueChange = jest.fn();
 
-      const { getByRole, user } = render({ onValueChange });
+      const { getByRole, queryByRole, user } = render(
+        { onValueChange },
+        {
+          wrapper({ children }) {
+            return (
+              <div>
+                {children}
+                <button type="button">testing</button>
+              </div>
+            );
+          },
+        },
+      );
 
       await user.click(getByRole('combobox'));
 
@@ -235,6 +257,10 @@ describe('Combobox', () => {
       getByRole('combobox').focus();
 
       await user.type(getByRole('combobox'), 'Option 1');
+
+      await user.keyboard('[Escape]');
+
+      expect(queryByRole('listbox')).not.toBeInTheDocument();
 
       await user.tab();
 
@@ -243,13 +269,22 @@ describe('Combobox', () => {
       expect(onValueChange).toHaveBeenCalledWith('1');
     });
 
-    /**
-     * Window blur events are not being fired
-     */
-    it.skip('should not revert to the related items textValue based on the set value if the field is emptied', async () => {
+    it('should not revert to the related items textValue based on the set value if the field is emptied', async () => {
       const onValueChange = jest.fn();
 
-      const { getByRole, user } = render({ onValueChange });
+      const { getByRole, queryByRole, user } = render(
+        { onValueChange },
+        {
+          wrapper({ children }) {
+            return (
+              <div>
+                {children}
+                <button type="button">testing</button>
+              </div>
+            );
+          },
+        },
+      );
 
       await user.click(getByRole('combobox'));
 
@@ -259,6 +294,10 @@ describe('Combobox', () => {
       getByRole('combobox').focus();
 
       await user.type(getByRole('combobox'), 'Option 1');
+
+      await user.keyboard('[Escape]');
+
+      expect(queryByRole('listbox')).not.toBeInTheDocument();
 
       await user.tab();
 
@@ -272,6 +311,10 @@ describe('Combobox', () => {
       getByRole('combobox').focus();
 
       await user.clear(getByRole('combobox'));
+
+      await user.keyboard('[Escape]');
+
+      expect(queryByRole('listbox')).not.toBeInTheDocument();
 
       await user.tab();
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* Uses `FocusScope` to capture the focus for the input and popover of the Primitive/Combobox
* Removes the `handleDismiss` callback to "sort out" the value on blur and moves it to the input to make it more predictable
* Adds `useFocusGuards` similarly to be inline with the Select primitive

### Why is it needed?

* The popover wouldn't close when you tabbed away from it to another focussable element and if you added the expected callbacks we wanted when you leave the combobox it would cause other issues. It was simpler and perhaps more predictable to match the behaviour of the Select enforcing a user to close the popover first before tabbing away. It also means the aria-scoping makes more sense because you are in fact locked to what you can focus.

### How to test it?

* Automated testing! Turns out my tests weren't that great but doing this meant I could "unskip" them.
