### PR TITLE
fix: LinkButton does not open in new tab

### DIFF
--- a/packages/strapi-design-system/src/v2/LinkButton/LinkButton.tsx
+++ b/packages/strapi-design-system/src/v2/LinkButton/LinkButton.tsx
@@ -42,11 +42,23 @@ const LinkWrapper = styled(BaseButtonWrapper)`
 
 export const LinkButton = React.forwardRef<HTMLAnchorElement, LinkButtonProps>(
   (
-    { variant = 'default', startIcon, endIcon, disabled = false, children, size = 'S', as = BaseLink, ...props },
+    {
+      variant = 'default',
+      startIcon,
+      endIcon,
+      disabled = false,
+      children,
+      isExternal,
+      size = 'S',
+      as = BaseLink,
+      ...props
+    },
     ref,
   ) => {
     const paddingX = size === 'S' ? 2 : '10px';
     const paddingY = 4;
+    const target = isExternal ? '_blank' : undefined;
+    const rel = isExternal ? 'noreferrer noopener' : undefined;
 
     return (
       <LinkWrapper
@@ -64,6 +76,8 @@ export const LinkButton = React.forwardRef<HTMLAnchorElement, LinkButtonProps>(
         paddingRight={paddingY}
         paddingTop={paddingX}
         pointerEvents={disabled ? 'none' : undefined}
+        target={target}
+        rel={rel}
         {...props}
         as={as || BaseLink}
       >


### PR DESCRIPTION
Fixes https://github.com/strapi/strapi/issues/16378

### What does it do?
- External links do not open a new tab with `isExternal` set to `true`. 

### Why is it needed?
- External links open in a new tab with `isExternal` set to `true` on `LinkButton`. 

### How to test it?
1. Run the app `yarn develop`
2. Find  `LinkButton` in `V2` and click on `Default` button.
3. See that it opens a new tab.

## Demo

https://github.com/strapi/design-system/assets/1501599/d21a0f27-2f7e-49d4-a775-14d4feb9e44e


