### PR TITLE
refactor: boxProps to use ComponentPropsWithoutRef

### DIFF
--- a/packages/strapi-design-system/src/BaseButton/BaseButton.tsx
+++ b/packages/strapi-design-system/src/BaseButton/BaseButton.tsx
@@ -1,4 +1,4 @@
-import React, { ButtonHTMLAttributes } from 'react';
+import * as React from 'react';
 
 import styled from 'styled-components';
 
@@ -23,10 +23,7 @@ export const BaseButtonWrapper = styled(Flex)`
   ${buttonFocusStyle}
 `;
 
-export interface BaseButtonProps<TElement extends HTMLElement = HTMLButtonElement> extends FlexProps<TElement> {
-  disabled?: boolean;
-  type?: ButtonHTMLAttributes<HTMLButtonElement>['type'];
-}
+export type BaseButtonProps<TElement extends keyof JSX.IntrinsicElements = 'button'> = FlexProps<TElement>;
 
 export const BaseButton = React.forwardRef<HTMLButtonElement, BaseButtonProps>(
   ({ disabled, children, background = 'neutral0', ...props }, ref) => {

--- a/packages/strapi-design-system/src/BaseLink/BaseLink.tsx
+++ b/packages/strapi-design-system/src/BaseLink/BaseLink.tsx
@@ -2,13 +2,10 @@ import React from 'react';
 
 import { Box, BoxProps } from '../Box';
 
-export interface BaseLinkProps extends BoxProps<HTMLAnchorElement> {
+export type BaseLinkProps = BoxProps<'a'> & {
   disabled?: boolean;
-  href?: string;
   isExternal?: boolean;
-  rel?: string;
-  target?: string;
-}
+};
 
 export const BaseLink = React.forwardRef<HTMLAnchorElement, BaseLinkProps>(
   ({ href, rel = 'noreferrer noopener', target = '_self', disabled = false, isExternal = false, ...props }, ref) => {

--- a/packages/strapi-design-system/src/Box/Box.tsx
+++ b/packages/strapi-design-system/src/Box/Box.tsx
@@ -11,22 +11,22 @@ type DefaultThemeOrCSSProp<T extends keyof DefaultTheme, K extends keyof CSSProp
   | keyof DefaultTheme[T]
   | CSSProperties[K];
 
-export type BoxProps<TElement extends HTMLElement = HTMLDivElement> = Pick<
-  CSSProperties,
-  | 'pointerEvents'
-  | 'display'
-  | 'position'
-  | 'zIndex'
-  | 'overflow'
-  | 'cursor'
-  | 'transition'
-  | 'transform'
-  | 'animation'
-  | 'textAlign'
-  | 'textTransform'
-  | 'lineHeight'
-> &
-  React.HTMLAttributes<TElement> & {
+export type BoxProps<TElement extends keyof JSX.IntrinsicElements = 'div'> = React.ComponentPropsWithoutRef<TElement> &
+  Pick<
+    CSSProperties,
+    | 'pointerEvents'
+    | 'display'
+    | 'position'
+    | 'zIndex'
+    | 'overflow'
+    | 'cursor'
+    | 'transition'
+    | 'transform'
+    | 'animation'
+    | 'textAlign'
+    | 'textTransform'
+    | 'lineHeight'
+  > & {
     /**
      * JavaScript hover handler
      */

--- a/packages/strapi-design-system/src/Divider/Divider.tsx
+++ b/packages/strapi-design-system/src/Divider/Divider.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 import { Box, BoxProps } from '../Box';
 
-export interface DividerProps extends Omit<BoxProps<HTMLHRElement>, 'as' | 'background'> {
+export interface DividerProps extends Omit<BoxProps<'hr'>, 'as' | 'background'> {
   /**
    * @preserve
    * @deprecated use `margin` style props instead

--- a/packages/strapi-design-system/src/Field/FieldAction.tsx
+++ b/packages/strapi-design-system/src/Field/FieldAction.tsx
@@ -10,7 +10,7 @@ const FieldActionWrapper = styled(Flex)`
   padding: 0;
 `;
 
-export interface FieldActionProps extends FlexProps<HTMLButtonElement> {
+export interface FieldActionProps extends FlexProps<'button'> {
   label: string;
   children: ReactNode;
 }

--- a/packages/strapi-design-system/src/Flex/Flex.tsx
+++ b/packages/strapi-design-system/src/Flex/Flex.tsx
@@ -10,7 +10,7 @@ const transientProps: Partial<Record<keyof FlexProps, boolean>> = {
   direction: true,
 };
 
-export interface FlexProps<TElement extends HTMLElement = HTMLDivElement> extends BoxProps<TElement> {
+export type FlexProps<TElement extends keyof JSX.IntrinsicElements = 'div'> = BoxProps<TElement> & {
   alignItems?: CSSProperties['alignItems'];
   direction?: CSSProperties['flexDirection'];
   /**
@@ -20,7 +20,7 @@ export interface FlexProps<TElement extends HTMLElement = HTMLDivElement> extend
   inline?: boolean;
   justifyContent?: CSSProperties['justifyContent'];
   wrap?: CSSProperties['flexWrap'];
-}
+};
 
 export const Flex = styled(Box).withConfig<FlexProps>({
   shouldForwardProp: (prop, defPropValFN) => !transientProps[prop as keyof FlexProps] && defPropValFN(prop),

--- a/packages/strapi-design-system/src/Main/Main.tsx
+++ b/packages/strapi-design-system/src/Main/Main.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 import { Box, BoxProps } from '../Box';
 
-export interface MainProps extends BoxProps<HTMLElement> {
+export interface MainProps extends BoxProps<'main'> {
   labelledBy: string;
 }
 

--- a/packages/strapi-design-system/src/Popover/Popover.tsx
+++ b/packages/strapi-design-system/src/Popover/Popover.tsx
@@ -31,7 +31,7 @@ const PopoverWrapper = styled(Box)`
   background: ${({ theme }) => theme.colors.neutral0};
 `;
 
-interface ContentProps extends BoxProps<HTMLDivElement> {
+interface ContentProps extends BoxProps<'div'> {
   source: React.MutableRefObject<HTMLElement>;
   placement?: Placement;
   fullWidth?: boolean;
@@ -91,7 +91,7 @@ export const Content = ({
   );
 };
 
-export interface ScrollingProps extends BoxProps<HTMLDivElement> {
+export interface ScrollingProps extends BoxProps<'div'> {
   intersectionId?: string;
   onReachEnd?: (entry: IntersectionObserverEntry) => void;
 }

--- a/packages/strapi-design-system/src/Portal/Portal.tsx
+++ b/packages/strapi-design-system/src/Portal/Portal.tsx
@@ -4,7 +4,7 @@ import { createPortal } from 'react-dom';
 
 import { Box, BoxProps } from '../Box';
 
-export interface PortalProps extends BoxProps<HTMLDivElement> {
+export interface PortalProps extends BoxProps<'div'> {
   container?: HTMLElement | null;
 }
 

--- a/packages/strapi-design-system/src/RawTable/RawCell.tsx
+++ b/packages/strapi-design-system/src/RawTable/RawCell.tsx
@@ -5,7 +5,7 @@ import { Box, BoxProps } from '../Box';
 import { getFocusableNodes, getFocusableNodesWithKeyboardNav } from '../helpers/getFocusableNodes';
 import { KeyboardKeys } from '../helpers/keyboardKeys';
 
-export interface RawTdProps extends BoxProps<HTMLTableCellElement> {
+export interface RawTdProps extends BoxProps<'td'> {
   'aria-colindex'?: number;
   as?: 'td' | 'th';
   children: ReactNode;

--- a/packages/strapi-design-system/src/RawTable/RawTr.tsx
+++ b/packages/strapi-design-system/src/RawTable/RawTr.tsx
@@ -2,7 +2,7 @@ import { cloneElement, Children, isValidElement, ReactElement } from 'react';
 
 import { Box, BoxProps } from '../Box';
 
-interface RawTrProps extends BoxProps<HTMLTableRowElement> {
+interface RawTrProps extends BoxProps<'tr'> {
   'aria-rowindex'?: number;
 }
 

--- a/packages/strapi-design-system/src/Select/SelectParts.tsx
+++ b/packages/strapi-design-system/src/Select/SelectParts.tsx
@@ -14,14 +14,14 @@ import { Typography, TypographyProps } from '../Typography';
  * SelectTrigger
  * -----------------------------------------------------------------------------------------------*/
 
-interface TriggerProps extends BoxProps<HTMLSpanElement> {
+interface TriggerProps extends BoxProps<'div'> {
   /**
    * @default "Clear"
    */
   clearLabel?: string;
   disabled?: boolean;
   hasError?: boolean;
-  onClear?: (e: React.MouseEvent<HTMLButtonElement | HTMLSpanElement>) => void;
+  onClear?: (e: React.MouseEvent<HTMLButtonElement | HTMLDivElement>) => void;
   startIcon?: React.ReactElement;
   /**
    * @default "M"
@@ -29,11 +29,11 @@ interface TriggerProps extends BoxProps<HTMLSpanElement> {
   size?: 'S' | 'M';
 }
 
-const SelectTrigger = React.forwardRef<HTMLSpanElement, TriggerProps>(
+const SelectTrigger = React.forwardRef<HTMLDivElement, TriggerProps>(
   ({ onClear, clearLabel = 'Clear', startIcon, disabled, hasError, size = 'M', children, ...restProps }, ref) => {
     const triggerRef = React.useRef<HTMLSpanElement>(null!);
 
-    const handleClearClick = (e: React.MouseEvent<HTMLButtonElement | HTMLSpanElement>) => {
+    const handleClearClick = (e: React.MouseEvent<HTMLButtonElement | HTMLDivElement>) => {
       if (onClear && !disabled) {
         onClear(e);
         triggerRef.current.focus();

--- a/packages/strapi-design-system/src/Tag/Tag.tsx
+++ b/packages/strapi-design-system/src/Tag/Tag.tsx
@@ -5,8 +5,7 @@ import styled from 'styled-components';
 import { Flex, FlexProps } from '../Flex';
 import { Typography } from '../Typography';
 
-export interface TagProps extends FlexProps<HTMLButtonElement> {
-  disabled?: boolean;
+export interface TagProps extends FlexProps<'button'> {
   icon: React.ReactNode;
 }
 

--- a/packages/strapi-design-system/src/TextButton/TextButton.tsx
+++ b/packages/strapi-design-system/src/TextButton/TextButton.tsx
@@ -38,14 +38,11 @@ const TextButtonWrapper = styled(Flex)`
   ${buttonFocusStyle}
 `;
 
-export type TextButtonProps = FlexProps<HTMLButtonElement> &
-  React.ButtonHTMLAttributes<HTMLButtonElement> & {
-    disabled?: boolean;
-    endIcon?: React.ReactNode;
-    loading?: boolean;
-    onClick?: React.MouseEventHandler<HTMLButtonElement>;
-    startIcon?: React.ReactNode;
-  };
+export interface TextButtonProps extends FlexProps<'button'> {
+  endIcon?: React.ReactNode;
+  loading?: boolean;
+  startIcon?: React.ReactNode;
+}
 
 export const TextButton = React.forwardRef<HTMLButtonElement, TextButtonProps>(
   ({ children, startIcon, endIcon, onClick, disabled = false, loading = false, ...props }, ref) => {

--- a/packages/strapi-design-system/src/Tooltip/Tooltip.tsx
+++ b/packages/strapi-design-system/src/Tooltip/Tooltip.tsx
@@ -17,7 +17,7 @@ const TooltipWrapper = styled(Box)<{ visible: boolean }>`
   display: ${({ visible }) => (visible ? 'revert' : 'none')};
 `;
 
-export interface TooltipProps extends Omit<BoxProps<HTMLDivElement>, 'position'> {
+export interface TooltipProps extends Omit<BoxProps<'div'>, 'position'> {
   description?: string;
   delay?: number;
   id?: string;

--- a/packages/strapi-design-system/src/v2/SimpleMenu/Menu.tsx
+++ b/packages/strapi-design-system/src/v2/SimpleMenu/Menu.tsx
@@ -49,7 +49,7 @@ const MenuTrigger = forwardRef<HTMLButtonElement, TriggerProps>(({ size, ...prop
  * MenuContent
  * -----------------------------------------------------------------------------------------------*/
 
-interface ContentProps extends FlexProps<HTMLDivElement> {
+interface ContentProps extends FlexProps<'div'> {
   intersectionId?: string;
   popoverPlacement?: (typeof POPOVER_PLACEMENTS)[number];
 }
@@ -122,7 +122,7 @@ type ItemInternalLinkProps<TComponent extends React.ComponentType = typeof BaseL
     isExternal?: false;
   };
 
-interface ItemButtonProps extends ItemSharedProps, Omit<BoxProps<HTMLButtonElement>, 'onSelect'> {
+interface ItemButtonProps extends ItemSharedProps, Omit<BoxProps<'button'>, 'onSelect'> {
   as?: never;
   isLink?: false;
   isExternal?: false;
@@ -229,9 +229,7 @@ const MenuSubRoot = DropdownMenu.Sub;
  * MenuSubTrigger
  * -----------------------------------------------------------------------------------------------*/
 
-interface SubTriggerProps extends BoxProps<HTMLButtonElement> {
-  disabled?: boolean;
-}
+interface SubTriggerProps extends BoxProps<'button'> {}
 
 const MenuSubTrigger = forwardRef<HTMLButtonElement, SubTriggerProps>(({ disabled = false, ...props }, ref) => {
   return (
@@ -269,7 +267,7 @@ const TriggerArrow = styled(ChevronRight)`
  * MenuSubContent
  * -----------------------------------------------------------------------------------------------*/
 
-interface SubContentProps extends FlexProps<HTMLDivElement> {}
+interface SubContentProps extends FlexProps<'div'> {}
 
 const MenuSubContent = forwardRef<HTMLDivElement, SubContentProps>((props, ref) => {
   return (


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* refactors `BoxProps` to use `ComponentPropsWithoutRef<TElement>` as opposed to `HTMLAttributes`

### Why is it needed?

* `HTMLAttributes` was too loose but you couldn't realistically use a stronger version of it, however `ComponentPropsWithoutRef` is more accurate to what we want – e.g. typing `disabled` for buttons isn't necessary (this was a flag there was a problem)
