### PR TITLE
fix: popover focus scope

### DIFF
--- a/packages/strapi-design-system/src/Popover/Popover.tsx
+++ b/packages/strapi-design-system/src/Popover/Popover.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { useFloating, flip, shift, offset, autoUpdate, Placement } from '@floating-ui/react-dom';
 import { FocusScope } from '@radix-ui/react-focus-scope';
-import { useCallbackRef } from '@strapi/ui-primitives';
+import { useCallbackRef, composeEventHandlers } from '@strapi/ui-primitives';
 import { hideOthers } from 'aria-hidden';
 import { RemoveScroll } from 'react-remove-scroll';
 import styled from 'styled-components';
@@ -38,7 +38,7 @@ const PopoverWrapper = styled(Box)`
 `;
 interface ContentProps
   extends BoxProps<'div'>,
-    Pick<DismissibleLayerProps, 'onEscapeKeyDown' | 'onPointerDownOutside' | 'onDismiss'> {
+    Pick<DismissibleLayerProps, 'onEscapeKeyDown' | 'onPointerDownOutside' | 'onDismiss' | 'onFocusOutside'> {
   source: React.MutableRefObject<HTMLElement>;
   placement?: Placement;
   fullWidth?: boolean;
@@ -56,9 +56,11 @@ export const Content = ({
   onEscapeKeyDown,
   onPointerDownOutside,
   onDismiss,
+  onFocusOutside,
   ...props
 }: ContentProps) => {
   const [content, setContent] = React.useState<HTMLDivElement | null>(null);
+  const isRightClickOutsideRef = React.useRef(false);
   const [width, setWidth] = React.useState<number | undefined>(undefined);
   const { x, y, reference, floating, strategy } = useFloating({
     strategy: 'fixed',
@@ -109,28 +111,36 @@ export const Content = ({
     <RemoveScroll allowPinchZoom>
       <FocusScope
         asChild
+        loop
         // we make sure we're not trapping once it's been closed
         // (closed !== unmounted when animating out)
         trapped
-        onMountAutoFocus={(event) => {
-          // we prevent open autofocus because we manually focus the selected item
-          event.preventDefault();
-        }}
         onUnmountAutoFocus={(event) => {
-          source.current?.focus({ preventScroll: true });
           event.preventDefault();
+
+          if (!isRightClickOutsideRef.current) source.current?.focus({ preventScroll: true });
         }}
       >
         <DismissibleLayer
           asChild
           disableOutsidePointerEvents
           onEscapeKeyDown={onEscapeKeyDown}
-          onPointerDownOutside={onPointerDownOutside}
-          // When focus is trapped, a focusout event may still happen.
+          onPointerDownOutside={composeEventHandlers(
+            onPointerDownOutside,
+            (event) => {
+              const originalEvent = event.detail.originalEvent;
+              const ctrlLeftClick = originalEvent.button === 0 && originalEvent.ctrlKey === true;
+              const isRightClick = originalEvent.button === 2 || ctrlLeftClick;
+
+              isRightClickOutsideRef.current = isRightClick;
+            },
+            { checkForDefaultPrevented: false },
+          )}
+          // When focus is trapped, a `focusout` event may still happen.
           // We make sure we don't trigger our `onDismiss` in such case.
-          onFocusOutside={(event) => {
-            event.preventDefault();
-          }}
+          onFocusOutside={composeEventHandlers(onFocusOutside, (event) => event.preventDefault(), {
+            checkForDefaultPrevented: false,
+          })}
           onDismiss={onDismiss}
         >
           <PopoverWrapper

--- a/packages/strapi-design-system/src/Popover/__tests__/Popover.spec.tsx
+++ b/packages/strapi-design-system/src/Popover/__tests__/Popover.spec.tsx
@@ -19,7 +19,7 @@ const Component = () => {
         </button>
         {isVisible && (
           <Popover source={sourceRef} onDismiss={() => setIsVisible(false)}>
-            <div>Hello world</div>
+            <button type="button">Hello world</button>
           </Popover>
         )}
       </div>
@@ -40,7 +40,8 @@ describe('Popover', () => {
 
     await user.click(getByRole('button', { name: 'Source' }));
 
-    expect(queryByText('Hello world')).toBeInTheDocument();
+    expect(getByRole('button', { name: 'Hello world' })).toBeInTheDocument();
+    expect(getByRole('button', { name: 'Hello world' })).toHaveFocus();
   });
 
   it('should close the popover when the escape key is used', async () => {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* Removes `preventDefault` from `onMountAutoFocus`
* Tightens up `onPointerDownOutside` to be more inline with `radix` implementation

### Why is it needed?

* FocusScope was not focussing first item in the popover

### How to test it?

* Automated testing added
