### PR TITLE
Chore: Flatten Layout component

### DIFF
--- a/packages/strapi-design-system/src/Layout/ActionLayout.tsx
+++ b/packages/strapi-design-system/src/Layout/ActionLayout.tsx
@@ -1,4 +1,3 @@
-import { Box } from '../Box';
 import { Flex } from '../Flex';
 
 interface ActionLayoutProps {
@@ -12,18 +11,14 @@ export const ActionLayout = ({ startActions, endActions }: ActionLayoutProps) =>
   }
 
   return (
-    <Box paddingLeft={10} paddingRight={10}>
-      <Box paddingBottom={4}>
-        <Flex justifyContent="space-between" alignItems="flex-start">
-          <Flex gap={2} wrap="wrap">
-            {startActions}
-          </Flex>
+    <Flex justifyContent="space-between" alignItems="flex-start" paddingBottom={4} paddingLeft={10} paddingRight={10}>
+      <Flex gap={2} wrap="wrap">
+        {startActions}
+      </Flex>
 
-          <Flex gap={2} shrink={0} wrap="wrap">
-            {endActions}
-          </Flex>
-        </Flex>
-      </Box>
-    </Box>
+      <Flex gap={2} shrink={0} wrap="wrap">
+        {endActions}
+      </Flex>
+    </Flex>
   );
 };


### PR DESCRIPTION
### What does it do?

Flattens the DOM structure of the `Layout` component.

### Why is it needed?

It was bloated unnecessarily (bundle-size and DOM depth)

### Related issue(s)/PR(s)

Follow up of https://github.com/strapi/design-system/pull/1043
