### PR TITLE
Fix: Use theme values for lineHeight

### DIFF
--- a/packages/strapi-design-system/src/Box/Box.tsx
+++ b/packages/strapi-design-system/src/Box/Box.tsx
@@ -25,7 +25,6 @@ export type BoxProps<TElement extends keyof JSX.IntrinsicElements = 'div'> = Rea
     | 'animation'
     | 'textAlign'
     | 'textTransform'
-    | 'lineHeight'
   > & {
     /**
      * JavaScript hover handler
@@ -101,6 +100,7 @@ export type BoxProps<TElement extends keyof JSX.IntrinsicElements = 'div'> = Rea
      */
     shrink?: CSSProperties['flexShrink'];
 
+    lineHeight?: DefaultThemeOrCSSProp<'lineHeights', 'lineHeight'>;
     width?: DefaultThemeOrCSSProp<'spaces', 'width'>;
     minWidth?: DefaultThemeOrCSSProp<'spaces', 'minWidth'>;
     maxWidth?: DefaultThemeOrCSSProp<'spaces', 'maxWidth'>;
@@ -215,7 +215,7 @@ export const Box = styled.div.withConfig<BoxProps>({
   // Text
   text-align: ${({ textAlign }) => textAlign};
   text-transform: ${({ textTransform }) => textTransform};
-  line-height: ${({ lineHeight }) => lineHeight};
+  line-height: ${({ theme, lineHeight }) => extractStyleFromTheme(theme.lineHeights, lineHeight, lineHeight)};
 
   // Cursor
   cursor: ${({ cursor }) => cursor};


### PR DESCRIPTION
### What does it do?

Fixes how `lineHeight` is applied to `Box` components. Instead of using theme values (based on index) it applied the value directly, which lead to `line-height: 4` instead of `line-height: ${theme.lineHeights[4]}`.

### Why is it needed?

Fixes `Textarea` styles.

### Related issue(s)/PR(s)

Broken since https://github.com/strapi/design-system/pull/1030
