### PR TITLE
fix: combobox filtering / race-condition and flash rendering

### DIFF
--- a/packages/primitives/src/components/Combobox/Combobox.tsx
+++ b/packages/primitives/src/components/Combobox/Combobox.tsx
@@ -1009,7 +1009,7 @@ const NO_VALUE_FOUND_NAME = 'ComboboxNoValueFound';
 interface NoValueFoundProps extends PrimitiveDivProps {}
 
 const ComboboxNoValueFound = React.forwardRef<HTMLDivElement, NoValueFoundProps>((props, ref) => {
-  const { textValue = '', locale } = useComboboxContext(NO_VALUE_FOUND_NAME);
+  const { filterValue = '', locale } = useComboboxContext(NO_VALUE_FOUND_NAME);
   const [items, setItems] = React.useState<CollectionData[]>([]);
   const { subscribe } = useCollection(undefined);
 
@@ -1029,7 +1029,7 @@ const ComboboxNoValueFound = React.forwardRef<HTMLDivElement, NoValueFoundProps>
     };
   }, [subscribe]);
 
-  if (items.some((item) => startsWith(item.textValue, textValue))) {
+  if (items.some((item) => startsWith(item.textValue, filterValue))) {
     return null;
   }
 

--- a/packages/primitives/src/components/Combobox/Combobox.tsx
+++ b/packages/primitives/src/components/Combobox/Combobox.tsx
@@ -406,6 +406,10 @@ const ComboxboxTextInput = React.forwardRef<ComboboxInputElement, TextInputProps
       ref={composedRefs}
       onKeyDown={composeEventHandlers(props.onKeyDown, (event) => {
         if (['ArrowUp', 'ArrowDown', 'Home', 'End'].includes(event.key)) {
+          if (!context.open) {
+            handleOpen();
+          }
+
           setTimeout(() => {
             const items = getItems().filter((item) => !item.disabled);
             let candidateNodes = items.map((item) => item.ref.current!);
@@ -491,10 +495,7 @@ const ComboxboxTextInput = React.forwardRef<ComboboxInputElement, TextInputProps
         }
       })}
       onKeyUp={composeEventHandlers(props.onKeyUp, (event) => {
-        if (
-          !context.open &&
-          (isPrintableCharacter(event.key) || ['ArrowUp', 'ArrowDown', 'Home', 'End', 'Backspace'].includes(event.key))
-        ) {
+        if (!context.open && (isPrintableCharacter(event.key) || ['Backspace'].includes(event.key))) {
           handleOpen();
         }
 

--- a/packages/primitives/src/components/Combobox/__tests__/index.test.tsx
+++ b/packages/primitives/src/components/Combobox/__tests__/index.test.tsx
@@ -580,37 +580,6 @@ describe('Combobox', () => {
 
       expect(onValueChange).toHaveBeenCalled();
     });
-
-    it('should correctly show the NoValue text as the textValue changes in different ways', async () => {
-      const { getByRole, queryByText, user } = render({ hideCreatable: true });
-
-      await user.click(getByRole('combobox'));
-
-      /**
-       * see note above
-       */
-      getByRole('combobox').focus();
-
-      await user.keyboard('Option 1');
-
-      expect(getByRole('combobox')).toHaveValue('Option 1');
-      expect(queryByText('No value found')).not.toBeInTheDocument();
-
-      await user.keyboard('2');
-
-      expect(getByRole('combobox')).toHaveValue('Option 12');
-      expect(queryByText('No value found')).toBeInTheDocument();
-
-      await user.keyboard('[Backspace]');
-
-      expect(getByRole('combobox')).toHaveValue('Option 1');
-      expect(queryByText('No value found')).not.toBeInTheDocument();
-
-      await user.clear(getByRole('combobox'));
-
-      expect(getByRole('combobox')).toHaveValue('');
-      expect(queryByText('No value found')).not.toBeInTheDocument();
-    });
   });
 
   describe('Controlling the component', () => {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* uses filterValue or textValue depending on autocomplete mode to show the NoValueFound element 
* Does not show NoValueFound when autocomplete is `none` because nothing is being filtered
* solves race condition between opening list and trying to focus an item causing the wrong items to fill autocomplete because they're no being rendered
* refactors code to ensure we always have the slot data so we can avoid rendering no value in split seconds (bad flashes are caused) – this is mainly just a quick shuffle to avoid duplication unnecessarily
 
### Why is it needed?

* Combobox very nitty bugs that we've found battle testing it in Strapi CMS 

### How to test it?

* realistically you want to connect it to the CMS & use the react-select branch
