### PR TITLE
Fix: Button start and end icon size

### DIFF
--- a/packages/strapi-design-system/src/Button/Button.tsx
+++ b/packages/strapi-design-system/src/Button/Button.tsx
@@ -19,13 +19,18 @@ const rotation = keyframes`
   }
 `;
 
-const LoadingWrapper = styled.div`
+const LoaderAnimated = styled(Loader)`
   animation: ${rotation} 2s infinite linear;
   will-change: transform;
 `;
 
 export const ButtonWrapper = styled(BaseButton)<Required<Pick<ButtonProps, 'size' | 'variant'>>>`
   height: ${({ theme, size }) => theme.sizes.button[size]};
+
+  svg {
+    height: ${12 / 16}rem;
+    width: auto;
+  }
 
   &[aria-disabled='true'] {
     ${getDisabledStyle}
@@ -100,17 +105,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         width={fullWidth ? '100%' : undefined}
         {...props}
       >
-        {(startIcon || loading) && (
-          <Box aria-hidden>
-            {loading ? (
-              <LoadingWrapper>
-                <Loader />
-              </LoadingWrapper>
-            ) : (
-              startIcon
-            )}
-          </Box>
-        )}
+        {(startIcon || loading) && <Box aria-hidden>{loading ? <LoaderAnimated /> : startIcon}</Box>}
 
         <Typography
           variant={size === 'S' ? 'pi' : undefined}

--- a/packages/strapi-design-system/src/ModalLayout/__tests__/ModalLayout.spec.tsx
+++ b/packages/strapi-design-system/src/ModalLayout/__tests__/ModalLayout.spec.tsx
@@ -192,6 +192,11 @@ describe('ModalLayout', () => {
         background: #ffffff;
       }
 
+      .c16 svg {
+        height: 0.75rem;
+        width: auto;
+      }
+
       .c16[aria-disabled='true'] {
         border: 1px solid #dcdce4;
         background: #eaeaef;
@@ -241,6 +246,11 @@ describe('ModalLayout', () => {
         height: 2rem;
         border: 1px solid #d9d8ff;
         background: #f0f0ff;
+      }
+
+      .c19 svg {
+        height: 0.75rem;
+        width: auto;
       }
 
       .c19[aria-disabled='true'] {
@@ -300,6 +310,11 @@ describe('ModalLayout', () => {
 
       .c20 {
         height: 2rem;
+      }
+
+      .c20 svg {
+        height: 0.75rem;
+        width: auto;
       }
 
       .c20[aria-disabled='true'] {


### PR DESCRIPTION
### What does it do?

Fixes the size of icons in `Button` components.

### Why is it needed?

It lead to alignment issues and doesn't follow the UI Kit.

### How to test it?

|Before|After|
|-|-|
| <img width="580" alt="Screenshot 2023-05-26 at 15 50 30" src="https://github.com/strapi/design-system/assets/2244375/dfaad6aa-3a3e-43f8-948c-e7f0a9511035"> | <img width="580" alt="Screenshot 2023-05-26 at 15 50 13" src="https://github.com/strapi/design-system/assets/2244375/e3d7cc2a-7a48-40c8-bba5-d35360bf4d09"> |

### Related issue(s)/PR(s)

- Broke in https://github.com/strapi/design-system/pull/878
- Fixes https://github.com/strapi/design-system/issues/1079
