### PR TITLE
Release 1.7.10

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "packages": ["packages/*", "docs"],
-  "version": "1.7.9",
+  "version": "1.7.10",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strapi/ui-primitives",
-  "version": "1.7.9",
+  "version": "1.7.10",
   "license": "MIT",
   "type": "module",
   "sideEffects": false,

--- a/packages/strapi-design-system/package.json
+++ b/packages/strapi-design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strapi/design-system",
-  "version": "1.7.9",
+  "version": "1.7.10",
   "license": "MIT",
   "type": "module",
   "sideEffects": false,
@@ -24,7 +24,7 @@
     "@radix-ui/react-dismissable-layer": "^1.0.3",
     "@radix-ui/react-dropdown-menu": "^2.0.4",
     "@radix-ui/react-focus-scope": "1.0.2",
-    "@strapi/ui-primitives": "^1.7.9",
+    "@strapi/ui-primitives": "^1.7.10",
     "@uiw/react-codemirror": "^4.19.16",
     "aria-hidden": "^1.2.3",
     "compute-scroll-into-view": "^3.0.3",
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@playwright/test": "1.33.0",
-    "@strapi/icons": "^1.7.9",
+    "@strapi/icons": "^1.7.10",
     "@types/react-router-dom": "^5.3.3",
     "@types/styled-components": "^5.1.26",
     "axe-playwright": "^1.2.3",

--- a/packages/strapi-icons/package.json
+++ b/packages/strapi-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strapi/icons",
-  "version": "1.7.9",
+  "version": "1.7.10",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5119,8 +5119,8 @@ __metadata:
     "@radix-ui/react-dismissable-layer": ^1.0.3
     "@radix-ui/react-dropdown-menu": ^2.0.4
     "@radix-ui/react-focus-scope": 1.0.2
-    "@strapi/icons": ^1.7.9
-    "@strapi/ui-primitives": ^1.7.9
+    "@strapi/icons": ^1.7.10
+    "@strapi/ui-primitives": ^1.7.10
     "@types/react-router-dom": ^5.3.3
     "@types/styled-components": ^5.1.26
     "@uiw/react-codemirror": ^4.19.16
@@ -5167,7 +5167,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@strapi/icons@^1.7.0, @strapi/icons@^1.7.9, @strapi/icons@workspace:packages/strapi-icons":
+"@strapi/icons@^1.7.0, @strapi/icons@^1.7.10, @strapi/icons@workspace:packages/strapi-icons":
   version: 0.0.0-use.local
   resolution: "@strapi/icons@workspace:packages/strapi-icons"
   dependencies:
@@ -5178,7 +5178,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/ui-primitives@^1.7.0, @strapi/ui-primitives@^1.7.9, @strapi/ui-primitives@workspace:packages/primitives":
+"@strapi/ui-primitives@^1.7.0, @strapi/ui-primitives@^1.7.10, @strapi/ui-primitives@workspace:packages/primitives":
   version: 0.0.0-use.local
   resolution: "@strapi/ui-primitives@workspace:packages/primitives"
   dependencies:


### PR DESCRIPTION
### What does it do?

Updates package versions to 1.7.10.

### Why is it needed?

Should have been done in https://github.com/strapi/design-system/pull/1098
