### PR TITLE
Chore: Fix type generation

### DIFF
--- a/packages/strapi-design-system/package.json
+++ b/packages/strapi-design-system/package.json
@@ -54,7 +54,7 @@
     "build": "yarn build:prod",
     "build:prod": "vite build",
     "clean": "rimraf dist node_modules",
-    "generate:types": "tsc --noEmit false --emitDeclarationOnly --declarationDir dist",
+    "generate:types": "tsc --noEmit false --declaration --emitDeclarationOnly --declarationDir dist",
     "lint": "eslint . --ext .js,.jsx,.tsx,.ts",
     "format": "yarn lint --fix",
     "test": "jest -c jest.config.js",

--- a/packages/strapi-design-system/test/utils.tsx
+++ b/packages/strapi-design-system/test/utils.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { render as renderRTL, RenderOptions as RTLRenderOptions } from '@testing-library/react';
+import { render as renderRTL, RenderOptions as RTLRenderOptions, RenderResult } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { DesignSystemProvider } from '../src/DesignSystemProvider';
@@ -10,10 +10,17 @@ interface RenderOptions {
   userEventOptions?: Parameters<typeof userEvent.setup>[0];
 }
 
+type RenderRTLResult = RenderResult & {
+  user: ReturnType<typeof userEvent.setup>;
+};
+
 // eslint-disable-next-line react/jsx-no-useless-fragment
 const fallbackWrapper = ({ children }) => <>{children}</>;
 
-const render = (ui: React.ReactElement, { renderOptions, userEventOptions }: RenderOptions = {}) => {
+export const render = (
+  ui: React.ReactElement,
+  { renderOptions, userEventOptions }: RenderOptions = {},
+): RenderRTLResult => {
   const { wrapper: Wrapper = fallbackWrapper, ...restOptions } = renderOptions ?? {};
 
   return {
@@ -30,4 +37,3 @@ const render = (ui: React.ReactElement, { renderOptions, userEventOptions }: Ren
 };
 
 export * from '@testing-library/react';
-export { render };


### PR DESCRIPTION
### What does it do?

- Fixes the `generate:types` tsc command; `--declarationDir` requires `--declaration`
- Fixes the return type of the test util; before it failed with "The inferred type of 'render' cannot be named without a reference to '@testing-library/dom/node_modules/pretty-format'. This is likely not portable. A type annotation is necessary."

### Why is it needed?

Paves the path towards published types and allows me to learn.

### How to test it?

Run `yarn generate:types` in the design-system package.

