### PR TITLE
fix: Pass the 'open' prop to ComboboxPrimitive.Root in the DS Combobo…

### DIFF
--- a/packages/strapi-design-system/src/Combobox/Combobox.tsx
+++ b/packages/strapi-design-system/src/Combobox/Combobox.tsx
@@ -189,6 +189,7 @@ export const ComboboxInput = ({
     <ComboboxPrimitive.Root
       autocomplete={autocomplete || (creatable ? 'list' : 'both')}
       onOpenChange={handleOpenChange}
+      open={internalIsOpen}
       onTextValueChange={handleTextValueChange}
       textValue={internalTextValue}
       allowCustomValue={creatable || allowCustomValue}


### PR DESCRIPTION
…x component

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Passes the `internalIsOpen` value as the `open` prop for the `<ComboboxPrimitive.Root>` component in the design-system's main `<ComboboxInput>` component.

### Why is it needed?

So I can controll the open state when I implement the Combobox component

### How to test it?

Implement the Combobox component as described here:
https://design-system-git-main-strapijs.vercel.app/?path=/docs/design-system-components-combobox--basic

Pass the `open` prop to try and open the combobox programatically.

With this PR change it works properly, without it will not open the combobox.
