### PR TITLE
fix: Breadcrumbs (v2) abbrevation menu is broken

### DIFF
--- a/packages/strapi-design-system/src/Button/Button.tsx
+++ b/packages/strapi-design-system/src/Button/Button.tsx
@@ -107,12 +107,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       >
         {(startIcon || loading) && <Box aria-hidden>{loading ? <LoaderAnimated /> : startIcon}</Box>}
 
-        <Typography
-          variant={size === 'S' ? 'pi' : undefined}
-          fontWeight="bold"
-          lineHeight={0}
-          textColor="buttonNeutral0"
-        >
+        <Typography variant={size === 'S' ? 'pi' : undefined} fontWeight="bold" textColor="buttonNeutral0">
           {children}
         </Typography>
 

--- a/packages/strapi-design-system/src/ModalLayout/__tests__/ModalLayout.spec.tsx
+++ b/packages/strapi-design-system/src/ModalLayout/__tests__/ModalLayout.spec.tsx
@@ -42,7 +42,6 @@ describe('ModalLayout', () => {
         font-size: 0.75rem;
         line-height: 1.33;
         font-weight: 600;
-        line-height: 0;
         color: #ffffff;
       }
 

--- a/packages/strapi-design-system/src/v2/Breadcrumbs/CrumbSimpleMenu.tsx
+++ b/packages/strapi-design-system/src/v2/Breadcrumbs/CrumbSimpleMenu.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
-import { CarretDown } from '@strapi/icons';
 import styled from 'styled-components';
 
 import { Button, ButtonProps } from '../../Button';
 import { SimpleMenu } from '../SimpleMenu';
 
 const StyledButton = styled(Button)`
-  padding: ${({ theme }) => `${theme.spaces[1]} ${theme.spaces[3]}`};
+  padding: ${({ theme }) => `${theme.spaces[1]} ${theme.spaces[2]}`};
+  height: unset;
 
   :hover,
   :focus {
@@ -18,10 +18,11 @@ const StyledButton = styled(Button)`
 export interface CrumbSimpleMenuProps extends ButtonProps {
   'aria-label': string;
   icon?: React.ReactElement;
+  endIcon?: React.ReactNode;
 }
 
 export const CrumbSimpleMenu = ({ children, ...props }: CrumbSimpleMenuProps) => (
-  <SimpleMenu icon={<CarretDown />} as={StyledButton} size="S" {...props}>
+  <SimpleMenu endIcon={null} as={StyledButton} size="S" {...props}>
     {children}
   </SimpleMenu>
 );

--- a/packages/strapi-design-system/src/v2/SimpleMenu/Menu.tsx
+++ b/packages/strapi-design-system/src/v2/SimpleMenu/Menu.tsx
@@ -27,23 +27,25 @@ const MenuRoot = DropdownMenu.Root;
 
 interface TriggerProps extends ButtonProps {}
 
-const MenuTrigger = forwardRef<HTMLButtonElement, TriggerProps>(({ size, ...props }, ref) => {
-  return (
-    <DropdownMenu.Trigger asChild>
-      <Button
-        ref={ref}
-        type="button"
-        variant="ghost"
-        endIcon={<CarretDown width={`${6 / 16}rem`} height={`${4 / 16}rem`} aria-hidden />}
-        paddingTop={size === 'S' ? 1 : 2}
-        paddingBottom={size === 'S' ? 1 : 2}
-        paddingLeft={size === 'S' ? 3 : 4}
-        paddingRight={size === 'S' ? 3 : 4}
-        {...props}
-      />
-    </DropdownMenu.Trigger>
-  );
-});
+const MenuTrigger = forwardRef<HTMLButtonElement, TriggerProps>(
+  ({ size, endIcon = <CarretDown width={`${6 / 16}rem`} height={`${4 / 16}rem`} aria-hidden />, ...props }, ref) => {
+    return (
+      <DropdownMenu.Trigger asChild>
+        <Button
+          ref={ref}
+          type="button"
+          variant="ghost"
+          endIcon={endIcon}
+          paddingTop={size === 'S' ? 1 : 2}
+          paddingBottom={size === 'S' ? 1 : 2}
+          paddingLeft={size === 'S' ? 3 : 4}
+          paddingRight={size === 'S' ? 3 : 4}
+          {...props}
+        />
+      </DropdownMenu.Trigger>
+    );
+  },
+);
 
 /* -------------------------------------------------------------------------------------------------
  * MenuContent


### PR DESCRIPTION
### What does it do?

It fixes the problem we had inside the Breadcrumb v2 
<img width="342" alt="Schermata 2023-06-21 alle 14 24 40" src="https://github.com/strapi/design-system/assets/2589748/310edcc1-4563-48bc-a786-f29f9fa70314">
The CarretDown icon is an error based on the Mockups
<img width="552" alt="Schermata 2023-06-21 alle 14 26 00" src="https://github.com/strapi/design-system/assets/2589748/7c39b323-76f7-49f0-9548-101385169e5a">
You can find them here
https://www.figma.com/file/doUJzYdMJTjpgtw6Lyaa7D/%5B%E2%9C%85Done%5D-Content-squad---Media-folders?type=design&node-id=1741-30931&t=6Xu5lry10tCSaxRB-0

### Why is it needed?

Because in prod the actual implementation is not the desired one

### How to test it?

You can just check the storybook generated (v2 Breadcrumb with menu) 

### Related issue(s)/PR(s)
https://github.com/strapi/design-system/issues/1090