### PR TITLE
fix: only call onBlur if the menu is not open

### DIFF
--- a/packages/primitives/src/components/Combobox/Combobox.tsx
+++ b/packages/primitives/src/components/Combobox/Combobox.tsx
@@ -536,6 +536,10 @@ const ComboxboxTextInput = React.forwardRef<ComboboxInputElement, TextInputProps
         }
       })}
       onBlur={composeEventHandlers(props.onBlur, () => {
+        if (context.open) {
+          return;
+        }
+
         context.onVisuallyFocussedItemChange(null);
 
         const [activeItem] = getItems().filter(

--- a/packages/strapi-design-system/src/Combobox/__tests__/Combobox.spec.tsx
+++ b/packages/strapi-design-system/src/Combobox/__tests__/Combobox.spec.tsx
@@ -35,6 +35,34 @@ describe('Combobox', () => {
     expect(getByRole('combobox')).toHaveValue('Hamburger');
   });
 
+  /**
+   * @see https://github.com/strapi/design-system/issues/1074
+   */
+  it('should correctly change the text value and value of the combobox even if two items are very similarly named', async () => {
+    const { getByRole, user } = render({
+      options: [
+        {
+          value: 'strawberry1',
+          children: 'Strawberry 1',
+        },
+        {
+          value: 'strawberry2',
+          children: 'Strawberry 2',
+        },
+      ],
+    });
+
+    getByRole('combobox').focus();
+
+    await user.type(getByRole('combobox'), 'Straw');
+
+    expect(getByRole('combobox')).toHaveValue('Strawberry 1');
+
+    await user.click(getByRole('option', { name: 'Strawberry 2' }));
+
+    expect(getByRole('combobox')).toHaveValue('Strawberry 2');
+  });
+
   describe('callbacks', () => {
     it('should fire onChange only when the value is changed not when the input does', async () => {
       const onChange = jest.fn();


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* Stops the onBlur calls if the menu is not open

### Why is it needed?

* It would call when the menu was open so therefore if you clicked an item in the menu it would not register.

### How to test it?

* Added automated testing
* I did a hard `return` always from `onBlur` and found several tests failed surrounding the `onBlur` functionality, so even though this seems _very_ simple, it seems to be the solution

### Related issue(s)/PR(s)

* resolves #1074 
