### PR TITLE
fix: date picker with some timezones would change date automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "fs-extra": "^11.1.1",
     "husky": "8.0.3",
-    "intl": "^1.2.5",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "jest-styled-components": "^7.1.1",

--- a/packages/strapi-design-system/src/DatePicker/__tests__/DatePicker.spec.tsx
+++ b/packages/strapi-design-system/src/DatePicker/__tests__/DatePicker.spec.tsx
@@ -344,7 +344,7 @@ describe('DatePicker', () => {
     it('should format by en locale', async () => {
       const { getByRole, user } = render({ selectedDate: new Date('Tue Sep 06 2022'), locale: 'en' });
 
-      expect(getByRole('combobox')).toHaveValue('9/6/2022');
+      expect(getByRole('combobox')).toHaveValue('09/06/2022');
 
       await user.click(getByRole('combobox', { name: 'date picker' }));
 
@@ -393,6 +393,48 @@ describe('DatePicker', () => {
       await user.type(getByRole('combobox', { name: 'date picker' }), '/18');
 
       expect(getByRole('gridcell', { name: '2022年12月18日日曜日' })).toHaveAttribute('aria-selected', 'true');
+    });
+
+    /**
+     * TODO: the spying doesn't work :(
+     */
+    it.skip('should not change the date automatically if the timezone is not UTC but is America/Los_Angeles', async () => {
+      let resolvedOptions = Intl.DateTimeFormat.prototype.resolvedOptions;
+
+      const resolvedOptionsSpy = jest.spyOn(Intl.DateTimeFormat.prototype, 'resolvedOptions');
+
+      resolvedOptionsSpy.mockImplementation(function (this: Intl.DateTimeFormat) {
+        let s = resolvedOptions.call(this);
+        s.timeZone = 'America/Los_Angeles';
+
+        return s;
+      });
+
+      const { getByRole, user } = render(
+        { initialDate: new Date('1990-01-01') },
+        {
+          wrapper({ children }) {
+            return (
+              <div>
+                {children}
+                <button type="button">testing</button>
+              </div>
+            );
+          },
+        },
+      );
+
+      expect(resolvedOptionsSpy).toHaveBeenCalled();
+
+      expect(getByRole('combobox')).toHaveValue('01/01/1990');
+
+      await user.click(getByRole('combobox', { name: 'date picker' }));
+
+      await user.keyboard('[Escape]');
+
+      await user.tab();
+
+      expect(getByRole('combobox')).toHaveValue('01/01/1990');
     });
   });
 

--- a/test/env-setup.js
+++ b/test/env-setup.js
@@ -1,17 +1,8 @@
 import { ResizeObserver } from '@juggle/resize-observer';
-import IntlPolyfill from 'intl';
 
-import 'intl/locale-data/jsonp/en';
 import 'jest-styled-components';
 
 beforeAll(() => {
-  if (global.Intl) {
-    Intl.NumberFormat = IntlPolyfill.NumberFormat;
-    Intl.DateTimeFormat = IntlPolyfill.DateTimeFormat;
-  } else {
-    global.Intl = IntlPolyfill;
-  }
-
   global.ResizeObserver = ResizeObserver;
 
   class IntersectionObserver {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10092,7 +10092,6 @@ __metadata:
     eslint-plugin-react-hooks: ^4.6.0
     fs-extra: ^11.1.1
     husky: 8.0.3
-    intl: ^1.2.5
     jest: ^29.5.0
     jest-environment-jsdom: ^29.5.0
     jest-styled-components: ^7.1.1
@@ -13307,13 +13306,6 @@ __metadata:
   version: 2.2.0
   resolution: "interpret@npm:2.2.0"
   checksum: f51efef7cb8d02da16408ffa3504cd6053014c5aeb7bb8c223727e053e4235bf565e45d67028b0c8740d917c603807aa3c27d7bd2f21bf20b6417e2bb3e5fd6e
-  languageName: node
-  linkType: hard
-
-"intl@npm:^1.2.5":
-  version: 1.2.5
-  resolution: "intl@npm:1.2.5"
-  checksum: 54c2444ec334b4e7f501c1b988ccfdae96d62a6275a915b9c75a38fc42d611bfc7dd33447e94079b7a8fdb3fbf36b95afd13132af4bfd70e2ec4bf9c9e0935f9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* removes `intl` polyfill (not needed anymore, JSDOM has it)
* uses `getLocalTimeZone` for the timezone context
* uses timzone to format the date correctly to a UTC format

### Why is it needed?

* because the time was always `00:00` any timezone -GMT would go to the day before on update

### Related issue(s)/PR(s)

* resolves #1171 
