### PR TITLE
fix: make label an optional prop

### DIFF
--- a/packages/strapi-design-system/src/Combobox/Combobox.tsx
+++ b/packages/strapi-design-system/src/Combobox/Combobox.tsx
@@ -274,10 +274,13 @@ export const ComboboxInput = ({
  * Combobox
  * -----------------------------------------------------------------------------------------------*/
 
-export interface ComboboxProps extends ComboboxInputProps, Pick<FieldProps, 'hint'> {
-  label: string;
+interface ComboboxPropsWithoutLabel extends ComboboxInputProps, Pick<FieldProps, 'hint'> {
   labelAction?: React.ReactNode;
 }
+
+export type ComboboxProps =
+  | (ComboboxPropsWithoutLabel & { label: string; 'aria-label'?: never })
+  | (ComboboxPropsWithoutLabel & { label?: never; 'aria-label': string });
 
 export const Combobox = ({ error, hint, id, label, labelAction, required = false, ...restProps }: ComboboxProps) => {
   const generatedId = useId(id);
@@ -285,7 +288,7 @@ export const Combobox = ({ error, hint, id, label, labelAction, required = false
   return (
     <Field hint={hint} error={error} id={generatedId} required={required}>
       <Flex direction="column" alignItems="stretch" gap={1}>
-        <FieldLabel action={labelAction}>{label}</FieldLabel>
+        {label ? <FieldLabel action={labelAction}>{label}</FieldLabel> : null}
         <ComboboxInput id={generatedId} error={error} required={required} {...restProps} />
         <FieldHint />
         <FieldError />
@@ -298,8 +301,12 @@ export const Combobox = ({ error, hint, id, label, labelAction, required = false
  * CreatableCombobox
  * -----------------------------------------------------------------------------------------------*/
 
-export type CreatableComboboxProps = Omit<ComboboxProps, 'onCreateOption'> &
-  Required<Pick<ComboboxProps, 'onCreateOption'>>;
+type CreatableComboboxPropsWithoutLabel = Omit<ComboboxPropsWithoutLabel, 'onCreateOption'> &
+  Required<Pick<ComboboxPropsWithoutLabel, 'onCreateOption'>>;
+
+export type CreatableComboboxProps =
+  | (CreatableComboboxPropsWithoutLabel & { label: string; 'aria-label'?: never })
+  | (CreatableComboboxPropsWithoutLabel & { label?: never; 'aria-label': string });
 
 export const CreatableCombobox = (props: CreatableComboboxProps) => <Combobox {...props} creatable />;
 

--- a/packages/strapi-design-system/src/Combobox/__tests__/Combobox.spec.tsx
+++ b/packages/strapi-design-system/src/Combobox/__tests__/Combobox.spec.tsx
@@ -11,7 +11,7 @@ const defaultOptions = [
   { value: 'carbonara', children: 'Carbonara' },
 ];
 
-const Component = ({ options = defaultOptions, ...restProps }: Partial<ComponentProps>) => (
+const Component = ({ options = defaultOptions, ...restProps }: Partial<Omit<ComponentProps, 'aria-label'>>) => (
   <Combobox label="Food" {...restProps}>
     {options.map((opt) => (
       <Option key={opt.value} {...opt} />
@@ -27,6 +27,14 @@ describe('Combobox', () => {
 
     expect(getByText('Food')).toBeInTheDocument();
     expect(getByText('hey!')).toBeInTheDocument();
+  });
+
+  it('should be accessible if I only pass an aria-label', () => {
+    const { getByRole, queryByRole } = render({ 'aria-label': 'Food', label: undefined });
+
+    expect(queryByRole('label')).not.toBeInTheDocument();
+
+    expect(getByRole('combobox', { name: 'Food' })).toBeInTheDocument();
   });
 
   it('if a default value is passed it should set that value on the primitive', () => {

--- a/packages/strapi-design-system/src/Select/MultiSelect.tsx
+++ b/packages/strapi-design-system/src/Select/MultiSelect.tsx
@@ -15,7 +15,7 @@ import { useIntersection } from '../hooks/useIntersection';
 import { Tag } from '../Tag';
 import { Typography } from '../Typography';
 
-export type MultiSelectProps = Omit<SelectParts.MultiSelectProps, 'value' | 'multi'> &
+type MultiSelectPropsWithoutLabel = Omit<SelectParts.MultiSelectProps, 'value' | 'multi'> &
   Pick<SelectParts.TriggerProps, 'clearLabel' | 'onClear' | 'size' | 'startIcon' | 'placeholder'> & {
     /**
      * @default (value) => value.join(',')
@@ -24,7 +24,6 @@ export type MultiSelectProps = Omit<SelectParts.MultiSelectProps, 'value' | 'mul
     error?: string | boolean;
     hint?: string | React.ReactNode | React.ReactNode[];
     id?: string | number;
-    label: string;
     labelAction?: React.ReactElement;
     onChange?: (value: string[]) => void;
     onReachEnd?: (entry: IntersectionObserverEntry) => void;
@@ -38,7 +37,12 @@ export type MultiSelectProps = Omit<SelectParts.MultiSelectProps, 'value' | 'mul
     withTags?: boolean;
   };
 
+export type MultiSelectProps =
+  | (MultiSelectPropsWithoutLabel & { label: string; 'aria-label'?: never })
+  | (MultiSelectPropsWithoutLabel & { 'aria-label': string; label?: never });
+
 export const MultiSelect = ({
+  'aria-label': ariaLabel,
   children,
   clearLabel = 'Clear',
   customizeContent,
@@ -150,9 +154,11 @@ export const MultiSelect = ({
   return (
     <Field hint={hint} error={error} id={generatedId} required={required}>
       <Flex direction="column" alignItems="stretch" gap={1}>
-        <FieldLabel onClick={handleFieldLabelClick} action={labelAction}>
-          {label}
-        </FieldLabel>
+        {label ? (
+          <FieldLabel onClick={handleFieldLabelClick} action={labelAction}>
+            {label}
+          </FieldLabel>
+        ) : null}
         <SelectParts.Root
           onOpenChange={handleOpenChange}
           disabled={disabled}
@@ -164,7 +170,7 @@ export const MultiSelect = ({
         >
           <SelectParts.Trigger
             ref={triggerRef}
-            aria-label={label}
+            aria-label={label ?? ariaLabel}
             aria-describedby={`${hintId} ${errorId}`}
             id={generatedId}
             startIcon={startIcon}

--- a/packages/strapi-design-system/src/Select/MultiSelectNested.tsx
+++ b/packages/strapi-design-system/src/Select/MultiSelectNested.tsx
@@ -18,9 +18,9 @@ interface MulitSelectNestedGroup extends Omit<MultiSelectGroupProps, 'children'>
   children: Array<MulitSelectNestedOption>;
 }
 
-export interface MultiSelectNestedProps extends MultiSelectProps {
+export type MultiSelectNestedProps = MultiSelectProps & {
   options: Array<MulitSelectNestedOption | MulitSelectNestedGroup>;
-}
+};
 
 export const MultiSelectNested = ({ options, ...props }: MultiSelectNestedProps) => {
   return (

--- a/packages/strapi-design-system/src/Select/SingleSelect.tsx
+++ b/packages/strapi-design-system/src/Select/SingleSelect.tsx
@@ -9,7 +9,7 @@ import { useId } from '../hooks/useId';
 import { useIntersection } from '../hooks/useIntersection';
 import { Typography } from '../Typography';
 
-export type SingleSelectProps = Omit<SelectParts.SingleSelectProps, 'value'> &
+type SingleSelectPropsWithoutLabel = Omit<SelectParts.SingleSelectProps, 'value'> &
   Pick<SelectParts.TriggerProps, 'clearLabel' | 'onClear' | 'size' | 'startIcon' | 'placeholder'> & {
     /**
      * @default (value) => value.toString()
@@ -18,7 +18,6 @@ export type SingleSelectProps = Omit<SelectParts.SingleSelectProps, 'value'> &
     error?: string | boolean;
     hint?: string | React.ReactNode | React.ReactNode[];
     id?: string | number;
-    label: string;
     labelAction?: React.ReactElement;
     onChange?: (value: string | number) => void;
     onReachEnd?: (entry: IntersectionObserverEntry) => void;
@@ -30,6 +29,10 @@ export type SingleSelectProps = Omit<SelectParts.SingleSelectProps, 'value'> &
     selectButtonTitle?: string;
     value?: string | number | null;
   };
+
+export type SingleSelectProps =
+  | (SingleSelectPropsWithoutLabel & { label: string; 'aria-label'?: never })
+  | (SingleSelectPropsWithoutLabel & { 'aria-label': string; label?: never });
 
 export const SingleSelect = ({
   error,
@@ -56,9 +59,11 @@ export const SingleSelect = ({
   return (
     <Field hint={hint} error={error} id={generatedId} required={required}>
       <Flex direction="column" alignItems="stretch" gap={1}>
-        <FieldLabel onClick={handleFieldLabelClick} action={labelAction}>
-          {label}
-        </FieldLabel>
+        {label ? (
+          <FieldLabel onClick={handleFieldLabelClick} action={labelAction}>
+            {label}
+          </FieldLabel>
+        ) : null}
         <SingleSelectInput label={label} id={generatedId} triggerRef={triggerRef} required={required} {...restProps} />
         <FieldHint />
         <FieldError />
@@ -67,13 +72,15 @@ export const SingleSelect = ({
   );
 };
 
-export interface SingleSelectInputProps extends Omit<SingleSelectProps, 'label' | 'labelAction' | 'hint' | 'id'> {
+export interface SingleSelectInputProps extends Omit<SingleSelectPropsWithoutLabel, 'labelAction' | 'hint' | 'id'> {
+  'aria-label'?: string;
   id?: string;
-  triggerRef?: React.RefObject<HTMLDivElement>;
   label?: string;
+  triggerRef?: React.RefObject<HTMLDivElement>;
 }
 
 export const SingleSelectInput = ({
+  'aria-label': ariaLabel,
   id,
   children,
   clearLabel = 'Clear',
@@ -163,7 +170,7 @@ export const SingleSelectInput = ({
     >
       <SelectParts.Trigger
         ref={triggerRef}
-        aria-label={label}
+        aria-label={label ?? ariaLabel}
         aria-describedby={id ? `${hintId} ${errorId}` : undefined}
         id={id}
         startIcon={startIcon}

--- a/packages/strapi-design-system/src/Select/__tests__/MultiSelect.spec.tsx
+++ b/packages/strapi-design-system/src/Select/__tests__/MultiSelect.spec.tsx
@@ -11,7 +11,7 @@ const defaultOpts: MultiSelectOptionProps[] = [
   },
 ];
 
-const Component = (props: Partial<MultiSelectProps>) => (
+const Component = (props: Partial<Omit<MultiSelectProps, 'aria-label'>>) => (
   <MultiSelect placeholder="Choose an option" label="Choose" {...props}>
     {defaultOpts.map((option) => (
       <MultiSelectOption key={option.value.toString()} value={option.value}>
@@ -34,6 +34,14 @@ describe('MultiSelect', () => {
     expect(getByRole('option', { name: 'Option 1' })).toBeInTheDocument();
     expect(getByRole('option', { name: 'Option 2' })).toBeInTheDocument();
     expect(getByRole('option', { name: 'Option 3' })).toBeInTheDocument();
+  });
+
+  it('should be accessible if I only pass an aria-label', () => {
+    const { getByRole, queryByRole } = render({ 'aria-label': 'Choose', label: undefined });
+
+    expect(queryByRole('label')).not.toBeInTheDocument();
+
+    expect(getByRole('combobox', { name: 'Choose' })).toBeInTheDocument();
   });
 
   it('should be able to select multiple options in one go without the listbox dissapearing', async () => {

--- a/packages/strapi-design-system/src/Select/__tests__/MultiSelectNested.spec.tsx
+++ b/packages/strapi-design-system/src/Select/__tests__/MultiSelectNested.spec.tsx
@@ -16,7 +16,7 @@ const defaultOpts: MultiSelectNestedProps['options'] = [
   },
 ];
 
-const Component = (props: Partial<MultiSelectNestedProps>) => (
+const Component = (props: Partial<Omit<MultiSelectNestedProps, 'aria-label'>>) => (
   <MultiSelectNested options={defaultOpts} placeholder="Choose an option" label="Choose" {...props} />
 );
 

--- a/packages/strapi-design-system/src/Select/__tests__/SingleSelect.spec.tsx
+++ b/packages/strapi-design-system/src/Select/__tests__/SingleSelect.spec.tsx
@@ -2,9 +2,9 @@ import { screen, render, waitFor } from '@test/utils';
 
 import { SingleSelectOption, SingleSelect, SingleSelectProps } from '../SingleSelect';
 
-interface RenderProps extends Partial<Omit<SingleSelectProps, 'children'>> {
+type RenderProps = Partial<Omit<SingleSelectProps, 'children' | 'aria-label'>> & {
   options?: Array<{ value: string; label: string }>;
-}
+};
 
 const defaultOpts = [
   { value: 'Option 1', label: 'Option 1' },
@@ -12,15 +12,17 @@ const defaultOpts = [
   { value: 'Option 3', label: 'Option 3' },
 ];
 
-const Component = ({ options = defaultOpts, ...restProps }: RenderProps) => (
-  <SingleSelect label="Pick Options" placeholder="Your option" {...restProps}>
-    {options.map((opt) => (
-      <SingleSelectOption key={opt.label} value={opt.value}>
-        {opt.label}
-      </SingleSelectOption>
-    ))}
-  </SingleSelect>
-);
+const Component = ({ options = defaultOpts, ...restProps }: RenderProps) => {
+  return (
+    <SingleSelect label="Pick Options" placeholder="Your option" {...restProps}>
+      {options.map((opt) => (
+        <SingleSelectOption key={opt.label} value={opt.value}>
+          {opt.label}
+        </SingleSelectOption>
+      ))}
+    </SingleSelect>
+  );
+};
 
 const renderComponent = (props: RenderProps = {}) => render(<Component {...props} />);
 
@@ -62,6 +64,22 @@ describe('Select', () => {
       renderComponent({ label: 'Label' });
 
       expect(screen.getByText('Label')).toBeInTheDocument();
+    });
+
+    it('should be accessible if I only pass an aria-label', () => {
+      const { getByRole, queryByRole } = render(
+        <SingleSelect aria-label="Label">
+          {defaultOpts.map((opt) => (
+            <SingleSelectOption key={opt.label} value={opt.value}>
+              {opt.label}
+            </SingleSelectOption>
+          ))}
+        </SingleSelect>,
+      );
+
+      expect(queryByRole('label')).not.toBeInTheDocument();
+
+      expect(getByRole('combobox', { name: 'Label' })).toBeInTheDocument();
     });
 
     it('should render a placeholder when provided', () => {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* Makes it so you must pass either `label` or `aria-label` as a prop
* no longer renders the label element if `label` is not included

### Why is it needed?

* There are a lot of places where we don't have a visible label in the UI and because of how we want our components it still tries to render the `label` element which causes the flex gap to still be there, no we don't render that element – re-aligning a lot of the UI.

### How to test it?

* Automated testing to make sure it's still accessible with just an `aria-label` prop.

### Related issue(s)/PR(s)

* resolves CONTENT-1557
