### PR TITLE
fixed:[bug]: Combobox returning NULL if not option is given #1185

### DIFF
--- a/packages/primitives/src/components/Combobox/Combobox.tsx
+++ b/packages/primitives/src/components/Combobox/Combobox.tsx
@@ -1127,10 +1127,6 @@ const ComboboxNoValueFound = React.forwardRef<HTMLDivElement, NoValueFoundProps>
     };
   }, [subscribe]);
 
-  if (items.length === 0) {
-    return <Primitive.div {...props} ref={ref} />;
-  }
-
   if (autocomplete === 'none') {
     return null;
   }


### PR DESCRIPTION


### What does it do?

It fixes the bug [bug]: Combobox returning NULL if no option is available #1185


### Why is it needed?

Bad User experience (UX)

### Related issue(s)/PR(s)
The issue "CM: Relations no longer display "No relations available" when target CT is empty #17231" is related to this.