### PR TITLE
Chore: Setup dependabot dependency grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,23 +3,73 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      day: sunday
+      time: '22:00'
+    open-pull-requests-limit: 10
     versioning-strategy: increase
-    ignore:
-      - dependency-name: 'react-router-dom'
-        update-types:
-          - 'version-update:semver-major'
-      - dependency-name: 'styled-components'
-        update-types:
-          - 'version-update:semver-major'
-
     labels:
       - 'source: dependencies'
       - 'pr: chore'
+    groups:
+      codemirror:
+        patterns:
+          - '@codemirror/*'
+          - '@uiw/react-codemirror'
+
+      eslint:
+        patterns:
+          - 'eslint*'
+          - '@typescript-eslint/*'
+          - 'prettier'
+
+      jest:
+        patterns:
+          - 'jest*'
+          - '@swc/jest'
+          - '@testing-library/*'
+          - '@types/jest'
+
+      radix-ui:
+        patterns:
+          - '@radix-ui/*'
+
+      react:
+        patterns:
+          - 'react'
+          - 'react-dom'
+          - '@types/react'
+          - '@types/react-dom'
+
+      react-router:
+        patterns:
+          - 'react-router-dom'
+          - '@types/react-router-dom'
+
+      styled-components:
+        patterns:
+          - '@types/styled-components'
+          - 'styled-components'
+
+      typescript:
+        patterns:
+          - '@rollup/plugin-typescript'
+          - 'typescript'
+          - '@tsconfig/*'
+
+      vite:
+        patterns:
+          - 'vite'
+          - '@vitejs/*'
+          - 'vite-plugin-dts'
+          - '@swc/core'
+
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      day: sunday
+      time: '22:00'
     labels:
       - 'source: dependencies'
       - 'pr: chore'


### PR DESCRIPTION
### What does it do?

- Changes the dependabot schedule to only update dependencies on Sunday evening (in sync with the monorepo)
- Setup dependency groups for dependencies that should be updated together

### Why is it needed?

- Less PRs.

