### PR TITLE
Chore: Add engines configuration to package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,5 +75,9 @@
     "typescript": "^5.1.6",
     "vite": "^4.4.7"
   },
-  "packageManager": "yarn@3.5.0"
+  "packageManager": "yarn@3.5.0",
+  "engines": {
+    "node": ">=16.0.0 <=20.x.x",
+    "npm": ">=6.0.0"
+  }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -29,5 +29,9 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.26.1",
     "react-router-dom": "^6.0.2"
+  },
+  "engines": {
+    "node": ">=16.0.0 <=20.x.x",
+    "npm": ">=6.0.0"
   }
 }


### PR DESCRIPTION
### What does it do?

Adds a node engine definition to the package.json files. Right now it is in sync with the monorepo.

### Why is it needed?

Otherwise the vercel website deployment fails, because it attempts to use node@14 as seen [here](https://vercel.com/strapijs/design-system-website/5zpBbRSFKnBZndnz8YZRoGfnLnnw).

