### PR TITLE
Chore: Extend dependabot groups with storybook and eslint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,7 @@ updates:
           - 'eslint*'
           - '@typescript-eslint/*'
           - 'prettier'
+          - 'eslint-plugin-*'
 
       jest:
         patterns:
@@ -45,6 +46,11 @@ updates:
         patterns:
           - 'react-router-dom'
           - '@types/react-router-dom'
+
+      storybook:
+        patterns:
+          - '@storybook/*'
+          - 'storybook-dark-mode'
 
       styled-components:
         patterns:


### PR DESCRIPTION
### What does it do?

Extends the dependabot groups with storybook and eslint.

### Why is it needed?

More dependency grouping - less PRs.

