### PR TITLE
Add a flag to the build config of the design-system to publish types

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,6 +114,12 @@ In your application, link your local copy of the design system with [`yarn link`
 yarn link -r ../<relative-path-to-strapi-design-system>
 ```
 
+You can also link a local copy of a specific package. For example, if you want to link the package strapi-design-system, you can run:
+
+```
+yarn link -r ../<relative-path-to-strapi-design-system>/packages/strapi-design-system
+```
+
 You should also remove the webpack alias for `@strapi/design-system` in the Strapi monorepo at `packages/core/admin/webpack.alias.js`
 
 Your application should now be using your local copy of the design system.

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "rimraf": "^5.0.1",
     "tiny-glob": "^0.2.9",
     "typescript": "^5.1.6",
-    "vite": "^4.4.9"
+    "vite": "^4.4.9",
+    "vite-plugin-dts": "^3.5.1"
   },
   "packageManager": "yarn@3.5.0",
   "engines": {

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -48,8 +48,5 @@
   "peerDependencies": {
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"
-  },
-  "devDependencies": {
-    "vite-plugin-dts": "^3.5.2"
   }
 }

--- a/packages/strapi-design-system/vite.config.ts
+++ b/packages/strapi-design-system/vite.config.ts
@@ -4,6 +4,7 @@ import typescript from '@rollup/plugin-typescript';
 import react from '@vitejs/plugin-react';
 import glob from 'tiny-glob';
 import { defineConfig } from 'vite';
+import dts from 'vite-plugin-dts';
 
 export default defineConfig(async () => {
   const paths = await glob('./src/**/!(*.spec|*.e2e|*.test).{js,svg,ts,tsx}');
@@ -37,6 +38,13 @@ export default defineConfig(async () => {
         plugins: [typescript()],
       },
     },
-    plugins: [react()],
+    // We need to pass entryRoot: 'src' as an argument to dts because otherwise when we run the build,
+    // a src folder is generated inside the dist folder containing all the d.ts files.
+    // This is due to how the tsconfig.json file was defined, specifically this part:
+    //  "baseUrl": ".",
+    //  "paths": {
+    //    "@test/*": ["./test/*"]
+    //  }
+    plugins: process.env.DTS !== 'true' ? [react()] : [dts({ entryRoot: 'src' }), react()],
   };
 });

--- a/packages/strapi-icons/package.json
+++ b/packages/strapi-icons/package.json
@@ -25,11 +25,10 @@
     "react-dom": "^17.0.0 || ^18.0.0"
   },
   "scripts": {
-    "build": "yarn generate:icons && yarn build:prod && yarn generate:types",
+    "build": "yarn generate:icons && yarn build:prod",
     "build:prod": "vite build",
     "clean": "rimraf src dist node_modules",
-    "generate:icons": "svgr -- ./assets/icons",
-    "generate:types": "tsc --noEmit false --emitDeclarationOnly --declarationDir dist"
+    "generate:icons": "svgr -- ./assets/icons"
   },
   "gitHead": "c74900b0ee3525510d266dc83c9743cb24dafced"
 }

--- a/packages/strapi-icons/vite.config.ts
+++ b/packages/strapi-icons/vite.config.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'path';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import dts from 'vite-plugin-dts';
 
 export default defineConfig({
   build: {
@@ -22,5 +23,5 @@ export default defineConfig({
       },
     },
   },
-  plugins: [react()],
+  plugins: [dts(), react()],
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5662,7 +5662,6 @@ __metadata:
     "@radix-ui/react-visually-hidden": ^1.0.3
     aria-hidden: ^1.2.3
     react-remove-scroll: ^2.5.6
-    vite-plugin-dts: ^3.5.2
   peerDependencies:
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
@@ -10626,6 +10625,7 @@ __metadata:
     tiny-glob: ^0.2.9
     typescript: ^5.1.6
     vite: ^4.4.9
+    vite-plugin-dts: ^3.5.1
   languageName: unknown
   linkType: soft
 
@@ -22642,7 +22642,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite-plugin-dts@npm:^3.5.2":
+"vite-plugin-dts@npm:^3.5.1":
   version: 3.5.2
   resolution: "vite-plugin-dts@npm:3.5.2"
   dependencies:


### PR DESCRIPTION
### What does it do?

Passing a env var we can publish types in the DS

### Why is it needed?

We want to convert the helper-plugin and to do it we need the types from the design-system.
We can’t publish a version of this because it will be a breaking change, instead we can use an ENV flag to produce the types on demand and use yarn link to connect the design-system to the monorepo.

### How to test it?

Run the yarn build with a env var 
`DTS=true yarn build`
Then, as said, with yarn link you can connect your local DS with the CMS

