### PR TITLE
chore: Add storybook to dependabot storybook group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,6 +51,7 @@ updates:
         patterns:
           - '@storybook/*'
           - 'storybook-dark-mode'
+          - 'storybook'
 
       styled-components:
         patterns:
@@ -67,7 +68,7 @@ updates:
         patterns:
           - 'vite'
           - '@vitejs/*'
-          - 'vite-plugin-dts'
+          - 'vite-plugin-*'
           - '@swc/core'
 
   - package-ecosystem: github-actions


### PR DESCRIPTION
### What does it do?

Adds `storybook` as dependency to update along the storybook dependabot group.

### Why is it needed?

It was missing.

### Related issue(s)/PR(s)

Refs https://github.com/strapi/design-system/pull/1286
