### PR TITLE
feat(icons): First SVG coloring API idea

### DIFF
--- a/packages/strapi-icons/package.json
+++ b/packages/strapi-icons/package.json
@@ -29,7 +29,7 @@
     "build": "yarn generate:icons && yarn build:prod && yarn generate:types",
     "build:prod": "vite build",
     "clean": "rimraf src dist node_modules",
-    "generate:icons": "svgr -- ./assets/icons",
+    "generate:icons": "svgr --template template.cjs -- ./assets/icons",
     "generate:types": "tsc --noEmit false --emitDeclarationOnly --declarationDir dist"
   },
   "gitHead": "c74900b0ee3525510d266dc83c9743cb24dafced"

--- a/packages/strapi-icons/template.cjs
+++ b/packages/strapi-icons/template.cjs
@@ -1,0 +1,34 @@
+function template(
+  { imports, interfaces, componentName, props, jsx, exports },
+  { tpl }
+) {
+  const iconName = componentName + 'Component';
+  const styleName = componentName + 'Wrapper';
+  const svgIconComponent = '<' + iconName + ' {...props} />';
+  const wrapperComponentStart = '<' + styleName + ' colors={colors}>';
+  const wrapperComponentEnd = '</' + styleName + '>';
+  const toRender = wrapperComponentStart + svgIconComponent + wrapperComponentEnd;
+
+  return tpl`
+    import * as React from 'react';
+    import styled from 'styled-components';
+
+    const ${styleName} = styled.div\`
+      \${({ theme, color }) => \`
+        color: \${theme.colors[color]};
+      \`};
+
+      \${({ theme, colors }) => \`
+        \${Object.entries(colors).map(([name, value], index) => \`
+          --var-color-\${color.name}: \${theme.colors[value]};
+        \`)}
+      \`};
+    \`;
+
+    const ${iconName} = (props: React.SVGProps<SVGSVGElement>) => ${jsx};
+
+    export default ({ colors, color, ...props }) => (${toRender});
+  `;
+}
+
+module.exports = template;


### PR DESCRIPTION
### What does it do?

This is the first idea for what an SVG coloring API could look like using an svgr template.

#### Single color icons

Most icons use one color. We would have to remove the hard-coded colors and replace them with `currentColor`:

```html
<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
    <path d="...." fill="currentColor"/>
</svg>
```

Usage:

```jsx
import { Icon } from '@strapi/icons'

function Component() {
  return (
    <Icon color="primary100">
  )
}
```

#### Multi color icons

For icons using multiple colors we could use a similar approach with named colors using CSS custom properties in the background:

```html
<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
    <style>
     #logoRocket {
       fill: var(--color-logo-rocket, red);
     }
    </style>

    <path id="logoRocket" d="...." />
</svg>
```

Usage:

```jsx
import { Icon } from '@strapi/icons'

function Component() {
  return (
    <Icon colors={{ 'logo-rocket': 'primary100' }}>
  )
}
```


### Why is it needed?

Explore paths to remove default colors from SVGs.

