### PR TITLE
remove webpack.alias.js from Contribution.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,8 +176,6 @@ You can also link a local copy of a specific package. For example, if you want t
 yarn link -r ../<relative-path-to-strapi-design-system>/packages/strapi-design-system
 ```
 
-You should also remove the webpack alias for `@strapi/design-system` in the Strapi monorepo at `packages/core/admin/webpack.alias.js`
-
 Your application should now be using your local copy of the design system.
 
 To revert back to the released version of the design system use [`yarn unlink`](https://yarnpkg.com/cli/unlink#usage):


### PR DESCRIPTION
### What does it do?

Updates the contribution.md file to equal the online contribution docs.

### Why is it needed?

If you visit the design-system and use the contributing docs, it will tell you to remove the package in the webpack config, which is no longer necessary. 

https://contributor.strapi.io/guides/working-with-the-design-system

https://github.com/strapi/design-system/blob/fcdf1f2b88fce49c79691ee84334b2ffccc8d61e/CONTRIBUTING.md?plain=1#L179

