### PR TITLE
fix: export IconButtonProps to be used in helper-plugin migration

### DIFF
--- a/packages/strapi-design-system/src/IconButton/IconButton.tsx
+++ b/packages/strapi-design-system/src/IconButton/IconButton.tsx
@@ -38,7 +38,7 @@ type ChildrenWithAriaLabel = AriaLabelOnlyProps & ChildrenOnlyProps;
 type IconWithLabel = LabelOnlyProps & IconOnlyProps;
 type IconWithAriaLabel = AriaLabelOnlyProps & IconOnlyProps;
 
-type IconButtonProps = ChildrenWithLabel | ChildrenWithAriaLabel | IconWithLabel | IconWithAriaLabel;
+export type IconButtonProps = ChildrenWithLabel | ChildrenWithAriaLabel | IconWithLabel | IconWithAriaLabel;
 
 export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
   (


### PR DESCRIPTION
### What does it do?

Exporting IconButton props

### Why is it needed?

We are migrating helper-plugin/icons folder to TS, we need IconButtonProps to be exported from DS alongwith the component

### Related issue(s)/PR(s)

https://strapi-inc.atlassian.net/browse/CS-158
