### PR TITLE
fix(IconButton): respect `borderWidth`

### DIFF
--- a/.changeset/forty-seals-tan.md
+++ b/.changeset/forty-seals-tan.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+fix(IconButton): respect `borderWidth`

--- a/packages/strapi-design-system/src/IconButton/IconButton.tsx
+++ b/packages/strapi-design-system/src/IconButton/IconButton.tsx
@@ -20,6 +20,10 @@ type Variant = (typeof VARIANTS)[number];
 
 interface SharedIconButtonProps extends BaseButtonProps {
   disabled?: boolean;
+  /**
+   * @preserve
+   * @deprecated use `borderWidth={0}` instead
+   */
   noBorder?: boolean;
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
   size?: IconButtonSizes;
@@ -103,21 +107,20 @@ export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
 );
 
 const IconButtonWrapper = styled(BaseButton)<Required<Pick<IconButtonProps, 'size' | 'variant'>>>`
-  background: ${({ theme, variant }) => {
+  background-color: ${({ theme, variant }) => {
     if (variant === VARIANT_SECONDARY) {
       return theme.colors.primary100;
     }
 
     return undefined;
   }};
-  border: 1px solid
-    ${({ theme, variant }) => {
-      if (variant === VARIANT_SECONDARY) {
-        return theme.colors.primary200;
-      }
+  border-color: ${({ theme, variant }) => {
+    if (variant === VARIANT_SECONDARY) {
+      return theme.colors.primary200;
+    }
 
-      return theme.colors.neutral200;
-    }};
+    return theme.colors.neutral200;
+  }};
   height: ${({ theme, size }) => theme.sizes.button[size]};
   width: ${({ theme, size }) => theme.sizes.button[size]};
 

--- a/packages/strapi-design-system/src/ModalLayout/__tests__/__snapshots__/ModalLayout.spec.tsx.snap
+++ b/packages/strapi-design-system/src/ModalLayout/__tests__/__snapshots__/ModalLayout.spec.tsx.snap
@@ -346,7 +346,7 @@ exports[`ModalLayout should render component and match snapshot 1`] = `
 }
 
 .c10 {
-  border: 1px solid #dcdce4;
+  border-color: #dcdce4;
   height: 2rem;
   width: 2rem;
 }


### PR DESCRIPTION
### What does it do?

Apply only border-color to `IconButton`s, bceause they also receive `borderWidth` and `noBorder` to set the border width. This bug has been introduced in https://github.com/strapi/design-system/pull/1319 and leads to too many borders being rendered.

### Why is it needed?

Fixes a bug.

### How to test it?

Add `noBorder` or `borderWidth={0}` attributes to `variants`.

### Related issue(s)/PR(s)

- https://github.com/strapi/design-system/pull/1319
