### PR TITLE
SDS-158 - [bug]: Disabled focus state of Select and Combobox is inconsistent

### DIFF
--- a/packages/primitives/src/components/Combobox/Combobox.tsx
+++ b/packages/primitives/src/components/Combobox/Combobox.tsx
@@ -291,7 +291,14 @@ const ComboboxTrigger = React.forwardRef<ComboboxTriggerElement, TriggerProps>((
           ref={forwardedRef}
           data-disabled={context.disabled ? '' : undefined}
           {...triggerProps} // Enable compatibility with native label or custom `Label` "click" for Safari:
-          onClick={composeEventHandlers(triggerProps.onClick, () => {
+          onClick={composeEventHandlers(triggerProps.onClick, (event) => {
+            // To prevent focus() calls from Slot, it causes unexpected focus states on UI
+            // ref: https://github.com/strapi/design-system/issues/1330
+            if (context.disabled) {
+              event.preventDefault();
+              return;
+            }
+
             // Whilst browsers generally have no issue focusing the trigger when clicking
             // on a label, Safari seems to struggle with the fact that there's no `onClick`.
             // We force `focus` in this case. Note: this doesn't create any other side-effect
@@ -300,6 +307,13 @@ const ComboboxTrigger = React.forwardRef<ComboboxTriggerElement, TriggerProps>((
             context.trigger?.focus();
           })}
           onPointerDown={composeEventHandlers(triggerProps.onPointerDown, (event) => {
+            // To prevent focus() calls from Slot, it causes unexpected focus states on UI
+            // ref: https://github.com/strapi/design-system/issues/1330
+            if (context.disabled) {
+              event.preventDefault();
+              return;
+            }
+
             // prevent implicit pointer capture
             // https://www.w3.org/TR/pointerevents3/#implicit-pointer-capture
             const target = event.target as HTMLElement;


### PR DESCRIPTION
### What does it do?
-  Fixes [issue](https://github.com/strapi/design-system/issues/1330) of the  disabled Combobox display focused state. 

### Why is it needed?
- The focus state of a disabled `Select` and `Combobox` is inconsistent. 

### How to test it?
1. Run the app `yarn develop`
2. Find  `Combobox` in `Components` and click  `show the disabled state` button.
3. See that the Combobox doesn't display the primary outline.

### **Demo**

https://www.loom.com/share/e8c19a7cccd84270ba65a8a27a2345b4
---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.

