### PR TITLE
fix: The content-manager header has a z-index of 10 while the modal has a z-index of 4 

### DIFF
--- a/packages/strapi-design-system/src/Dialog/Dialog.tsx
+++ b/packages/strapi-design-system/src/Dialog/Dialog.tsx
@@ -47,7 +47,7 @@ export const Dialog = ({ onClose, title, as = 'h2', isOpen, id, ...props }: Dial
 
   return (
     <Portal>
-      <DialogWrapper padding={8} position="fixed" zIndex={4}>
+      <DialogWrapper padding={8} position="fixed" zIndex={10}>
         <FocusTrap>
           <DismissibleLayer onEscapeKeyDown={onClose} onPointerDownOutside={onClose}>
             <DialogContainer

--- a/packages/strapi-design-system/src/ModalLayout/ModalLayout.tsx
+++ b/packages/strapi-design-system/src/ModalLayout/ModalLayout.tsx
@@ -24,7 +24,7 @@ export const ModalLayout = ({ onClose, labelledBy, ...props }: ModalLayoutProps)
   return (
     <Portal>
       <ModalContext.Provider value={onClose}>
-        <ModalWrapper justifyContent="center" paddingLeft={8} paddingRight={8} position="fixed" zIndex={4}>
+        <ModalWrapper justifyContent="center" paddingLeft={8} paddingRight={8} position="fixed" zIndex={10}>
           <FocusTrap>
             <DismissibleLayer onEscapeKeyDown={onClose} onPointerDownOutside={onClose}>
               <Box


### PR DESCRIPTION
### What does it do?
-  Fixes [issue](https://github.com/strapi/strapi/issues/17871) where the Modal and Dialog appear behind the content-manager because they have a lower z-index value. 

### Why is it needed?
- Improve UI/UX when the Modal and Dialog is correctly positioned when opened.

### How to test it?
1. Run the app `yarn develop`
2. Find  `combined-w-scroll` in `Components` and click on `Add an entry` button.
3. See that the modal is in front of header.

### **Demo**

https://www.loom.com/share/06f94943db7046fb955bbf8530fa6f65

### **Before**
![image](https://github.com/GitStartHQ/client-strapi-design-system/assets/42426077/047cf6eb-0c65-4c6c-8e5d-28d4824fc305)

### **After**
![image](https://github.com/GitStartHQ/client-strapi-design-system/assets/42426077/7776e6be-59bf-4d62-b511-835c16182603)


---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
