### PR TITLE
fix(design-system): use FieldLabelProps['action'] to define labelAction

### DIFF
--- a/.changeset/pink-hats-tie.md
+++ b/.changeset/pink-hats-tie.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+fix: use an alias for labelAction type to improve consistency

--- a/packages/strapi-design-system/src/Accordion/AccordionGroup.tsx
+++ b/packages/strapi-design-system/src/Accordion/AccordionGroup.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import styled from 'styled-components';
 
 import { Box } from '../Box';
+import { FieldLabelProps } from '../Field';
 import { Flex } from '../Flex';
 import { KeyboardNavigable } from '../KeyboardNavigable';
 import { Typography } from '../Typography';
@@ -64,7 +65,7 @@ export interface AccordionGroupProps {
   error?: string;
   footer?: React.ReactNode;
   label?: string;
-  labelAction?: React.ReactNode;
+  labelAction?: FieldLabelProps['action'];
 }
 
 export const AccordionGroup = ({ children, footer, label, labelAction, error }: AccordionGroupProps) => {

--- a/packages/strapi-design-system/src/Combobox/Combobox.tsx
+++ b/packages/strapi-design-system/src/Combobox/Combobox.tsx
@@ -5,7 +5,7 @@ import { Combobox as ComboboxPrimitive } from '@strapi/ui-primitives';
 import styled from 'styled-components';
 
 import { Box } from '../Box';
-import { Field, FieldError, FieldHint, FieldLabel, FieldProps } from '../Field';
+import { Field, FieldError, FieldHint, FieldLabel, FieldLabelProps, FieldProps } from '../Field';
 import { Flex } from '../Flex';
 import { stripReactIdOfColon } from '../helpers/strings';
 import { useComposedRefs } from '../hooks/useComposeRefs';
@@ -289,7 +289,7 @@ export const ComboboxInput = React.forwardRef<ComboboxInputElement, ComboboxInpu
  * -----------------------------------------------------------------------------------------------*/
 
 interface ComboboxPropsWithoutLabel extends ComboboxInputProps, Pick<FieldProps, 'hint'> {
-  labelAction?: React.ReactNode;
+  labelAction?: FieldLabelProps['action'];
 }
 
 export type ComboboxProps =

--- a/packages/strapi-design-system/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/strapi-design-system/src/DateTimePicker/DateTimePicker.tsx
@@ -1,11 +1,11 @@
-import React, { forwardRef, ReactNode } from 'react';
+import * as React from 'react';
 
 import { CalendarDateTime, parseAbsoluteToLocal, toCalendarDateTime, getLocalTimeZone } from '@internationalized/date';
 import styled from 'styled-components';
 
 import { DatePickerInput, DatePickerInputProps, DatePickerElement } from '../DatePicker/DatePicker';
 import { useDesignSystem } from '../DesignSystemProvider';
-import { Field, FieldHint, FieldLabel, FieldError, FieldProps } from '../Field';
+import { Field, FieldHint, FieldLabel, FieldError, FieldProps, FieldLabelProps } from '../Field';
 import { Flex } from '../Flex';
 import { once } from '../helpers/deprecations';
 import { useComposedRefs } from '../hooks/useComposeRefs';
@@ -36,7 +36,7 @@ export interface DateTimePickerProps
   /**
    * Label Action
    */
-  labelAction?: ReactNode;
+  labelAction?: FieldLabelProps['action'];
   onChange?: (date: Date | undefined) => void;
   /**
    * Value. The Date passed as value
@@ -44,7 +44,7 @@ export interface DateTimePickerProps
   value?: Date | null;
 }
 
-export const DateTimePicker = forwardRef<DatePickerElement, DateTimePickerProps>(
+export const DateTimePicker = React.forwardRef<DatePickerElement, DateTimePickerProps>(
   (
     {
       /**

--- a/packages/strapi-design-system/src/JSONInput/JSONInput.tsx
+++ b/packages/strapi-design-system/src/JSONInput/JSONInput.tsx
@@ -6,19 +6,16 @@ import { useCodeMirror, ReactCodeMirrorRef, ReactCodeMirrorProps } from '@uiw/re
 import styled from 'styled-components';
 
 import { markField, addMarks, filterMarks, lineHighlightMark } from './utils/decorationExtension';
-import { Field, FieldLabel, FieldError, FieldHint } from '../Field';
+import { Field, FieldLabel, FieldError, FieldHint, FieldLabelProps, FieldProps } from '../Field';
 import { Flex, FlexProps } from '../Flex';
 import { useComposedRefs } from '../hooks/useComposeRefs';
 import { inputFocusStyle } from '../themes';
 
-interface JSONInputProps extends Omit<FlexProps, 'onChange'> {
+interface JSONInputProps extends Omit<FlexProps, 'onChange'>, Pick<FieldProps, 'hint' | 'error' | 'required'> {
   label?: string;
   value?: string;
-  error?: string | boolean;
-  hint?: string | React.ReactNode | React.ReactNode[];
-  required?: boolean;
   disabled?: boolean;
-  labelAction?: React.ReactNode;
+  labelAction?: FieldLabelProps['action'];
   onChange?: (value: string) => void;
 }
 

--- a/packages/strapi-design-system/src/Select/MultiSelect.tsx
+++ b/packages/strapi-design-system/src/Select/MultiSelect.tsx
@@ -7,7 +7,7 @@ import styled, { css } from 'styled-components';
 import * as SelectParts from './SelectParts';
 import checkmarkIcon from '../BaseCheckbox/assets/checkmark.svg';
 import { Box } from '../Box';
-import { Field, FieldError, FieldHint, FieldLabel } from '../Field';
+import { Field, FieldError, FieldHint, FieldLabel, FieldLabelProps, FieldProps } from '../Field';
 import { Flex } from '../Flex';
 import { stripReactIdOfColon } from '../helpers/strings';
 import { useComposedRefs } from '../hooks/useComposeRefs';
@@ -17,15 +17,13 @@ import { Tag } from '../Tag';
 import { Typography } from '../Typography';
 
 type MultiSelectPropsWithoutLabel = Omit<SelectParts.MultiSelectProps, 'value' | 'multi'> &
-  Pick<SelectParts.TriggerProps, 'clearLabel' | 'onClear' | 'size' | 'startIcon' | 'placeholder'> & {
+  Pick<SelectParts.TriggerProps, 'clearLabel' | 'onClear' | 'size' | 'startIcon' | 'placeholder'> &
+  Pick<FieldProps, 'hint' | 'id' | 'error'> & {
     /**
      * @default (value) => value.join(',')
      */
     customizeContent?(value?: string[]): string;
-    error?: string | boolean;
-    hint?: string | React.ReactNode | React.ReactNode[];
-    id?: string | number;
-    labelAction?: React.ReactElement;
+    labelAction?: FieldLabelProps['action'];
     onChange?: (value: string[]) => void;
     onReachEnd?: (entry: IntersectionObserverEntry) => void;
     /**

--- a/packages/strapi-design-system/src/Select/SingleSelect.tsx
+++ b/packages/strapi-design-system/src/Select/SingleSelect.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import * as SelectParts from './SelectParts';
 import { Box } from '../Box';
-import { Field, FieldError, FieldHint, FieldLabel } from '../Field';
+import { Field, FieldError, FieldHint, FieldLabel, FieldLabelProps, FieldProps } from '../Field';
 import { Flex } from '../Flex';
 import { stripReactIdOfColon } from '../helpers/strings';
 import { useComposedRefs } from '../hooks/useComposeRefs';
@@ -11,15 +11,13 @@ import { useIntersection } from '../hooks/useIntersection';
 import { Typography } from '../Typography';
 
 type SingleSelectPropsWithoutLabel = Omit<SelectParts.SingleSelectProps, 'value'> &
-  Pick<SelectParts.TriggerProps, 'clearLabel' | 'onClear' | 'size' | 'startIcon' | 'placeholder'> & {
+  Pick<SelectParts.TriggerProps, 'clearLabel' | 'onClear' | 'size' | 'startIcon' | 'placeholder'> &
+  Pick<FieldProps, 'error' | 'hint' | 'id'> & {
     /**
      * @default (value) => value.toString()
      */
     customizeContent?(value?: string | number): string;
-    error?: string | boolean;
-    hint?: string | React.ReactNode | React.ReactNode[];
-    id?: string | number;
-    labelAction?: React.ReactElement;
+    labelAction?: FieldLabelProps['action'];
     onChange?: (value: string | number) => void;
     onReachEnd?: (entry: IntersectionObserverEntry) => void;
     /**

--- a/packages/strapi-design-system/src/Textarea/Textarea.tsx
+++ b/packages/strapi-design-system/src/Textarea/Textarea.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { Box, BoxProps } from '../Box';
-import { Field, FieldLabel, FieldHint, FieldError, FieldProps, useField } from '../Field';
+import { Field, FieldLabel, FieldHint, FieldError, FieldProps, useField, FieldLabelProps } from '../Field';
 import { Flex } from '../Flex';
 import { useId } from '../hooks/useId';
 import { inputFocusStyle } from '../themes/utils';
@@ -15,7 +15,7 @@ export interface TextareaProps extends TextareaInputBoxProps, Pick<FieldProps, '
    */
   children?: string;
   label?: string;
-  labelAction?: string;
+  labelAction?: FieldLabelProps['action'];
   value?: string;
 }
 

--- a/packages/strapi-design-system/src/TimePicker/TimePicker.tsx
+++ b/packages/strapi-design-system/src/TimePicker/TimePicker.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import { ComboboxInput, ComboboxInputProps, ComboboxInputElement, Option } from '../Combobox/Combobox';
 import { useDesignSystem } from '../DesignSystemProvider';
-import { Field, FieldError, FieldHint, FieldLabel, FieldProps } from '../Field';
+import { Field, FieldError, FieldHint, FieldLabel, FieldLabelProps, FieldProps } from '../Field';
 import { Flex } from '../Flex';
 import { useControllableState } from '../hooks/useControllableState';
 import { useDateFormatter } from '../hooks/useDateFormatter';
@@ -201,7 +201,7 @@ const StyledClock = styled(Clock)`
 
 export interface TimePickerProps extends TimePickerInputProps, Pick<FieldProps, 'hint'> {
   label: string;
-  labelAction?: React.ReactNode;
+  labelAction?: FieldLabelProps['action'];
 }
 
 export const TimePicker = React.forwardRef<ComboboxInputElement, TimePickerProps>(

--- a/packages/strapi-design-system/src/ToggleInput/ToggleInput.tsx
+++ b/packages/strapi-design-system/src/ToggleInput/ToggleInput.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import styled from 'styled-components';
 
-import { Field, FieldHint, FieldError, FieldLabel, type FieldProps, useField } from '../Field';
+import { Field, FieldHint, FieldError, FieldLabel, type FieldProps, useField, FieldLabelProps } from '../Field';
 import { Flex } from '../Flex';
 import { useControllableState } from '../hooks/useControllableState';
 import { useId } from '../hooks/useId';
@@ -151,7 +151,7 @@ interface ToggleInputPropsWithoutLabel
   extends Pick<FieldProps, 'error' | 'hint' | 'name' | 'required' | 'id'>,
     ToggleInputInputProps {
   clearLabel?: string;
-  labelAction?: React.ReactNode;
+  labelAction?: FieldLabelProps['action'];
   onClear?: () => void;
 }
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* changes all instances of `labelAction` to use the type `FieldLableProps['labelAction']`

### Why is it needed?

* through strapi/strapi#17746 there were some inconsistencies with the meaning of `labelAction` even though it's always passed to the same place
