### PR TITLE
fix: turbo cache for strapi-icons

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -5,6 +5,11 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**", "storybook-static/**"]
     },
+    "@strapi/icons#build": {
+      "dependsOn": ["^build"],
+      "inputs": ["assets/**"],
+      "outputs": ["dist/**", "src/**"]
+    },
     "clean": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* writes a specific turbo config for the build command for `strapi-icons` due to unique pipeline

### Why is it needed?

* the action was being cached incorrectly in vercel where it assumed `src` was the input, not the output
