### PR TITLE
fix: export LinkButton type

### DIFF
--- a/.changeset/lovely-mangos-lick.md
+++ b/.changeset/lovely-mangos-lick.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+Exporting LinkButton v2 type

--- a/packages/strapi-design-system/src/v2/LinkButton/LinkButton.tsx
+++ b/packages/strapi-design-system/src/v2/LinkButton/LinkButton.tsx
@@ -17,7 +17,7 @@ interface SharedLinkProps extends BaseLinkProps {
   variant?: (typeof VARIANTS)[number];
 }
 
-type LinkButtonProps = SharedLinkProps & BaseButtonProps;
+export type LinkButtonProps = SharedLinkProps & BaseButtonProps;
 
 const LinkWrapper = styled(BaseButtonWrapper)`
   text-decoration: none;


### PR DESCRIPTION
### What does it do?

Export the v2 LinkButton to start using it in other packages.
