### PR TITLE
fix: date time picker value from being masked in small screens

### DIFF
--- a/.changeset/happy-pants-ring.md
+++ b/.changeset/happy-pants-ring.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+fix: date time picker value from being masked in small screens

--- a/packages/strapi-design-system/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/strapi-design-system/src/DateTimePicker/DateTimePicker.tsx
@@ -269,5 +269,5 @@ const DatePicker = styled(DatePickerInput)`
 
 const TimePicker = styled(TimePickerInput)`
   flex: 1 1 30%;
-  min-width: 120px;
+  min-width: 140px;
 `;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Increases the time picker min-width to accommodate the content when in smaller desktop screens. 

### Why is it needed?

Currently the time picker min-width is set too low that in smaller screens the content exceeds the min-width causing the content to be "cropped/masked" off.

### How to test it?

Open the DateTimePicker `controlled` component in Storyboard and set browser to a width of 600px using your favorite responsive web tool. Set time to 05:45. Resize the browser width to see in various widths.

<img width="714" alt="Screenshot 2023-09-26 at 11 08 01 PM" src="https://github.com/strapi/design-system/assets/179356/7e69f01e-0e12-4ffb-b953-4e44f9711390">

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/18159