### PR TITLE
fix: Combobox rendered text when value prop changes

### DIFF
--- a/.changeset/long-buses-yawn.md
+++ b/.changeset/long-buses-yawn.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+Fixed a visual bug for Combobox component when value is updated externally

--- a/packages/strapi-design-system/src/Combobox/Combobox.tsx
+++ b/packages/strapi-design-system/src/Combobox/Combobox.tsx
@@ -191,6 +191,15 @@ export const ComboboxInput = React.forwardRef<ComboboxInputElement, ComboboxInpu
       skipWhen: !internalIsOpen,
     });
 
+    React.useEffect(() => {
+      /**
+       * When the value prop changes "externally" update the text input value too
+       */
+      handleTextValueChange(value || '');
+
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [value]);
+
     const hintId = `${generatedId}-hint`;
     const errorId = `${generatedId}-error`;
 

--- a/packages/strapi-design-system/src/Combobox/__tests__/Combobox.spec.tsx
+++ b/packages/strapi-design-system/src/Combobox/__tests__/Combobox.spec.tsx
@@ -71,6 +71,19 @@ describe('Combobox', () => {
     expect(getByRole('combobox')).toHaveValue('Strawberry 2');
   });
 
+  it('should correctly change the rendered text value of the combobox when the value prop changes externally', async () => {
+    const onTextValueChange = jest.fn();
+    const { rerender } = renderRTL(<Component options={defaultOptions} onTextValueChange={onTextValueChange} />);
+
+    expect(onTextValueChange).toHaveBeenCalledTimes(1);
+    expect(onTextValueChange).toHaveBeenCalledWith('');
+
+    rerender(<Component options={defaultOptions} onTextValueChange={onTextValueChange} value="bagel" />);
+
+    expect(onTextValueChange).toHaveBeenCalledTimes(2);
+    expect(onTextValueChange).toHaveBeenCalledWith('bagel');
+  });
+
   describe('callbacks', () => {
     it('should fire onChange only when the value is changed not when the input does', async () => {
       const onChange = jest.fn();


### PR DESCRIPTION
### What does it do?

Updates the Combobox rendered value if the corresponding prop changes "externally" (without clicking an option)

### Why is it needed?

Because if the prop changes, the "internal" value is actually updated but the rendered text not

### How to test it?

I tested this manually, let me know if I should update UT

```
// docs/stories/Combobox.stories.tsx

export const Depending = {
  render: () => {
    const [value, setValue] = useState('');

    const options = ['apple', 'avocado', 'banana', 'kiwi', 'mango', 'orange', 'strawberry'];

    const handleChange = (index) => {
      setValue(options[index]);
    };

    return (
      <Flex direction="column" alignItems="stretch" gap={11}>
        {options.map((option, index) => (
          <Button key={index} onClick={() => handleChange(index)}>
            {index}
          </Button>
        ))}
        <span style={{ color: 'white' }}>{value}</span>
        <Combobox
          placeholder="My favourite fruit is..."
          label="Fruits"
          value={value}
          onChange={setValue}
          onClear={() => setValue('')}
        >
          {options.map((option) => (
            <ComboboxOption key={option} value={option}>
              {option}
            </ComboboxOption>
          ))}
        </Combobox>
      </Flex>
    );
  },

  name: 'depending',
} satisfies Story;

```

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
