### PR TITLE
make labelledBy prop optional for Main component and remove redundant type

### DIFF
--- a/.changeset/breezy-jobs-agree.md
+++ b/.changeset/breezy-jobs-agree.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+Make labelledBy prop optional for Main component

--- a/packages/strapi-design-system/src/Layout/HeaderLayout.tsx
+++ b/packages/strapi-design-system/src/Layout/HeaderLayout.tsx
@@ -12,7 +12,7 @@ interface BaseHeaderLayoutProps extends TypographyProps {
   navigationAction?: React.ReactNode;
   primaryAction?: React.ReactNode;
   secondaryAction?: React.ReactNode;
-  subtitle?: string | React.ReactNode;
+  subtitle?: React.ReactNode;
   sticky?: boolean;
   width?: number;
 }

--- a/packages/strapi-design-system/src/Main/Main.tsx
+++ b/packages/strapi-design-system/src/Main/Main.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Box, BoxProps } from '../Box';
 
 export interface MainProps extends BoxProps<'main'> {
-  labelledBy: string;
+  labelledBy?: string | undefined;
 }
 
 const MainWrapper = styled(Box)`


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

1. makes `labelledBy` optional because there is default value assignment inside component. I used `| undefined` by design so it's compatible with https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes.
2. removed `string` type because it's already part of `React.ReactNode` type

### Why is it needed?

Better developer experience.

### How to test it?

### Related issue(s)/PR(s)
