### PR TITLE
fix: IconButton disabled property

### DIFF
--- a/packages/strapi-design-system/src/IconButton/IconButton.tsx
+++ b/packages/strapi-design-system/src/IconButton/IconButton.tsx
@@ -84,6 +84,7 @@ export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
     const component = (
       <IconButtonWrapper
         aria-disabled={disabled}
+        disabled={disabled}
         background={disabled ? 'neutral150' : background}
         borderWidth={noBorder ? 0 : borderWidth}
         justifyContent="center"


### PR DESCRIPTION
### What does it do?
-  Fixes [issue](https://github.com/strapi/design-system/issues/1345) where the `IconButton` does not apply `disable` prop on the button

### Why is it needed?
- Can cause unexpected behavior 

### How to test it?
1. Run the app `yarn develop`
2. Find  `IconButton ` and click on Disabled
3. Check if `disable` property is applied to the button

### **Demo**

https://github.com/GitStartHQ/client-strapi-design-system/assets/22890925/ac490fe9-7e53-49a0-90a9-1df48e703fd3


