### PR TITLE
Omit selectedTabIndex and selectTabIndex in TabGroup

### DIFF
--- a/packages/strapi-design-system/src/Tabs/TabGroup.tsx
+++ b/packages/strapi-design-system/src/Tabs/TabGroup.tsx
@@ -3,7 +3,9 @@ import * as React from 'react';
 import { TabsContext, type TabsContextState } from './TabsContext';
 import { useId } from '../hooks/useId';
 
-export interface TabGroupProps extends Omit<TabsContextState, 'id'>, React.HTMLAttributes<HTMLDivElement> {
+export interface TabGroupProps
+  extends Omit<TabsContextState, 'id' | 'selectedTabIndex' | 'selectTabIndex'>,
+    React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
   id?: string;
   initialSelectedTabIndex?: number;


### PR DESCRIPTION
### What does it do?
It omits selectedTabIndex and selectTabIndex in TabGroup because they are not required as props since they are being passed to the context inside the TabGroup component. 


### Why is it needed?

To avoid TS errors.

### How to test it?

Check that the TabGroup component doesn't fail when you don't pass the selectTabIndex and selectedTabIndex properties to it. 

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
