### PR TITLE
fix(design-system): never types should be optional

### DIFF
--- a/.changeset/gold-mugs-brake.md
+++ b/.changeset/gold-mugs-brake.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+fix(design-system): never types should be optional

--- a/packages/strapi-design-system/src/Link/Link.tsx
+++ b/packages/strapi-design-system/src/Link/Link.tsx
@@ -52,12 +52,12 @@ interface SharedLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> 
 
 interface ToLinkProps extends SharedLinkProps {
   to: NavLinkProps['to'];
-  href: never;
+  href?: never;
 }
 
 interface HrefLinkProps extends SharedLinkProps {
   href: string;
-  to: never;
+  to?: never;
 }
 
 type LinkProps = ToLinkProps | HrefLinkProps;

--- a/packages/strapi-design-system/src/LinkButton/LinkButton.tsx
+++ b/packages/strapi-design-system/src/LinkButton/LinkButton.tsx
@@ -35,12 +35,12 @@ interface SharedLinkProps extends BaseButtonProps {
 
 interface ToLinkProps extends SharedLinkProps {
   to: NavLinkProps['to'];
-  href: never;
+  href?: never;
 }
 
 interface HrefLinkProps extends SharedLinkProps {
   href: string;
-  to: never;
+  to?: never;
 }
 
 type LinkButtonProps = ToLinkProps | HrefLinkProps;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* some properties in types are `never` which want to be optional not required, because you can never make them pass

### Why is it needed?

* Issues using links with `href` vs `to`

### Related issue(s)/PR(s)

* discovered in #18209
