### PR TITLE
fix(design-system): typography props should extend ComponentProps

### DIFF
--- a/packages/strapi-design-system/src/Field/FieldLabel.tsx
+++ b/packages/strapi-design-system/src/Field/FieldLabel.tsx
@@ -7,7 +7,7 @@ import { Flex } from '../Flex';
 import { once } from '../helpers/deprecations';
 import { Typography, TypographyProps } from '../Typography';
 
-export interface FieldLabelProps extends TypographyProps<HTMLLabelElement> {
+export interface FieldLabelProps extends TypographyProps<'label'> {
   action?: ReactNode;
   /**
    * @preserve

--- a/packages/strapi-design-system/src/Typography/Typography.tsx
+++ b/packages/strapi-design-system/src/Typography/Typography.tsx
@@ -5,31 +5,28 @@ import styled, { CSSProperties, DefaultTheme } from 'styled-components';
 import { TEXT_VARIANTS } from './constants';
 import { ellipsisStyle, variantStyle } from './utils';
 import { extractStyleFromTheme } from '../helpers/theme';
+import { DefaultThemeOrCSSProp } from '../types';
 
 const transientProps: Partial<Record<keyof TypographyProps, boolean>> = {
   fontSize: true,
   fontWeight: true,
 };
 
-type DefaultThemeOrCSSProp<T extends keyof DefaultTheme, K extends keyof CSSProperties> =
-  | keyof DefaultTheme[T]
-  | CSSProperties[K];
-
-export interface TypographyProps<TElement extends HTMLElement = HTMLSpanElement>
-  extends React.HTMLAttributes<TElement> {
-  as?: string | React.ComponentType<any>;
-  forwardedAs?: string | React.ComponentType<any>;
-  children?: React.ReactNode;
-  ellipsis?: boolean;
-  fontSize?: keyof DefaultTheme['fontSizes'];
-  fontWeight?: keyof DefaultTheme['fontWeights'];
-  lineHeight?: DefaultThemeOrCSSProp<'lineHeights', 'lineHeight'>;
-  textAlign?: CSSProperties['textAlign'];
-  textColor?: keyof DefaultTheme['colors'];
-  textDecoration?: CSSProperties['textDecoration'];
-  textTransform?: CSSProperties['textTransform'];
-  variant?: (typeof TEXT_VARIANTS)[number];
-}
+export type TypographyProps<TElement extends keyof JSX.IntrinsicElements = 'span'> =
+  React.ComponentPropsWithoutRef<TElement> & {
+    as?: string | React.ComponentType<any>;
+    forwardedAs?: string | React.ComponentType<any>;
+    children?: React.ReactNode;
+    ellipsis?: boolean;
+    fontSize?: keyof DefaultTheme['fontSizes'];
+    fontWeight?: keyof DefaultTheme['fontWeights'];
+    lineHeight?: DefaultThemeOrCSSProp<'lineHeights', 'lineHeight'>;
+    textAlign?: CSSProperties['textAlign'];
+    textColor?: keyof DefaultTheme['colors'];
+    textDecoration?: CSSProperties['textDecoration'];
+    textTransform?: CSSProperties['textTransform'];
+    variant?: (typeof TEXT_VARIANTS)[number];
+  };
 
 export const Typography = styled.span.withConfig<TypographyProps>({
   shouldForwardProp: (prop, defPropValFN) => !transientProps[prop as keyof TypographyProps] && defPropValFN(prop),

--- a/packages/strapi-design-system/src/types.ts
+++ b/packages/strapi-design-system/src/types.ts
@@ -1,0 +1,7 @@
+import { CSSProperties } from 'react';
+
+import { DefaultTheme } from 'styled-components';
+
+export type DefaultThemeOrCSSProp<T extends keyof DefaultTheme, K extends keyof CSSProperties> =
+  | keyof DefaultTheme[T]
+  | CSSProperties[K];

--- a/packages/strapi-design-system/src/v2/SimpleMenu/Menu.tsx
+++ b/packages/strapi-design-system/src/v2/SimpleMenu/Menu.tsx
@@ -207,7 +207,7 @@ const OptionLink = styled(Link)`
  * MenuLabel
  * -----------------------------------------------------------------------------------------------*/
 
-interface LabelProps extends TypographyProps<HTMLSpanElement> {}
+interface LabelProps extends TypographyProps {}
 
 const MenuLabel = forwardRef<HTMLSpanElement, LabelProps>((props, ref) => (
   <DropdownMenu.Label asChild>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* change `TypographyProps` to extend `ComponentProps`

### Why is it needed?

* better than `HTMLAttributes`
* you couldn't pass `htmlFor` in this circumstance (where FieldLabel extends Typography):

```ts
interface FieldLabel extends TypographyProps<HTMLLabelElement> {
 // blah
}

<FieldLabel htmlFor="test" />
```
