### PR TITLE
fix(design-system): add CSS properties as a value for responsive values

### DIFF
--- a/.changeset/tough-laws-pay.md
+++ b/.changeset/tough-laws-pay.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+fix: box props can accept CSSProperties for repsonsive values

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ $RECYCLE.BIN/
 .idea
 nbproject
 .eslintcache
+.turbo
 
 
 ############################

--- a/packages/strapi-design-system/src/Box/Box.tsx
+++ b/packages/strapi-design-system/src/Box/Box.tsx
@@ -4,10 +4,7 @@ import styled, { CSSProperties, DefaultTheme } from 'styled-components';
 
 import handleResponsiveValues, { ResponsiveValue } from '../helpers/handleResponsiveValues';
 import { extractStyleFromTheme } from '../helpers/theme';
-
-type DefaultThemeOrCSSProp<T extends keyof DefaultTheme, K extends keyof CSSProperties> =
-  | keyof DefaultTheme[T]
-  | CSSProperties[K];
+import { DefaultThemeOrCSSProp } from '../types';
 
 export type BoxProps<TElement extends keyof JSX.IntrinsicElements = 'div'> = React.ComponentPropsWithoutRef<TElement> &
   Pick<
@@ -68,27 +65,27 @@ export type BoxProps<TElement extends keyof JSX.IntrinsicElements = 'div'> = Rea
     /**
      * Padding. Supports responsive values
      */
-    padding?: ResponsiveValue;
+    padding?: ResponsiveValue<'padding'>;
     /**
      * Padding bottom. Supports responsive values
      */
-    paddingBottom?: ResponsiveValue;
+    paddingBottom?: ResponsiveValue<'paddingBottom'>;
     /**
      * Padding left. Supports responsive values
      */
-    paddingLeft?: ResponsiveValue;
+    paddingLeft?: ResponsiveValue<'paddingLeft'>;
     /**
      * Padding right. Supports responsive values
      */
-    paddingRight?: ResponsiveValue;
+    paddingRight?: ResponsiveValue<'paddingRight'>;
     /**
      * Padding top. Supports responsive values
      */
-    paddingTop?: ResponsiveValue;
-    marginLeft?: ResponsiveValue;
-    marginBottom?: ResponsiveValue;
-    marginRight?: ResponsiveValue;
-    marginTop?: ResponsiveValue;
+    paddingTop?: ResponsiveValue<'paddingTop'>;
+    marginLeft?: ResponsiveValue<'marginLeft'>;
+    marginBottom?: ResponsiveValue<'marginBottom'>;
+    marginRight?: ResponsiveValue<'marginRight'>;
+    marginTop?: ResponsiveValue<'marginTop'>;
     /**
      * Shadow name (see `theme.shadows`)
      */

--- a/packages/strapi-design-system/src/helpers/handleResponsiveValues.ts
+++ b/packages/strapi-design-system/src/helpers/handleResponsiveValues.ts
@@ -1,4 +1,8 @@
+import type { CSSProperties } from 'react';
+
 import { DefaultTheme } from 'styled-components';
+
+import { DefaultThemeOrCSSProp } from '../types';
 
 interface ResponsiveValueObject {
   desktop?: keyof DefaultTheme['spaces'];
@@ -12,21 +16,40 @@ type ResponsiveValueTuple = [
   mobile?: keyof DefaultTheme['spaces'],
 ];
 
-export type ResponsiveValue = ResponsiveValueObject | keyof DefaultTheme['spaces'] | ResponsiveValueTuple;
+type ResponsiveCSSProperties = Pick<
+  CSSProperties,
+  | 'margin'
+  | 'marginLeft'
+  | 'marginRight'
+  | 'marginTop'
+  | 'marginBottom'
+  | 'padding'
+  | 'paddingLeft'
+  | 'paddingRight'
+  | 'paddingTop'
+  | 'paddingBottom'
+>;
+
+export type ResponsiveValue<TCSSProp extends keyof ResponsiveCSSProperties = any> =
+  | ResponsiveValueObject
+  | DefaultThemeOrCSSProp<'spaces', TCSSProp>
+  | ResponsiveValueTuple;
 
 /* eslint-disable consistent-return */
-const handleResponsiveValues = (property: string, value: ResponsiveValue | undefined, theme: DefaultTheme) => {
+const handleResponsiveValues = <TCSSProp extends keyof ResponsiveCSSProperties>(
+  property: string,
+  value: ResponsiveValue<TCSSProp> | undefined,
+  theme: DefaultTheme,
+) => {
   if (!value) {
     return undefined;
   }
 
-  let transformedArray: ResponsiveValueTuple = Array.isArray(value) ? value : [];
+  if (typeof value === 'object') {
+    const transformedArray: ResponsiveValueTuple = Array.isArray(value)
+      ? value
+      : [value?.desktop, value?.tablet, value?.mobile];
 
-  if (!Array.isArray(value) && typeof value === 'object') {
-    transformedArray = [value?.desktop, value?.tablet, value?.mobile];
-  }
-
-  if (transformedArray.length > 0) {
     const spaces = transformedArray.reduce((acc, curr, index) => {
       if (curr) {
         switch (index) {
@@ -48,7 +71,7 @@ const handleResponsiveValues = (property: string, value: ResponsiveValue | undef
   }
 
   // Fallback to the passed transformedArray when necessary
-  const realValue = theme.spaces[value as keyof DefaultTheme['spaces']] || value;
+  const realValue = theme.spaces[value as keyof DefaultTheme['spaces']] ?? value;
 
   return `${property}: ${realValue};`;
 };

--- a/packages/strapi-design-system/src/types.ts
+++ b/packages/strapi-design-system/src/types.ts
@@ -1,0 +1,7 @@
+import { CSSProperties } from 'react';
+
+import { DefaultTheme } from 'styled-components';
+
+export type DefaultThemeOrCSSProp<T extends keyof DefaultTheme, K extends keyof CSSProperties> =
+  | keyof DefaultTheme[T]
+  | CSSProperties[K];


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* changes `ResponsiveValue` to be union including `DefaultThemeOrCSSProp` because you can do `marginLeft="auto"` and that should be fine.

### Why is it needed?

* TS didn't reflect code power

### Related issue(s)/PR(s)

* found converting `NpsSurvey` to TS
