### PR TITLE
chore: remove combobox useEffect used to trigger handleTextValueChange

### DIFF
--- a/packages/strapi-design-system/src/Combobox/Combobox.tsx
+++ b/packages/strapi-design-system/src/Combobox/Combobox.tsx
@@ -191,15 +191,6 @@ export const ComboboxInput = React.forwardRef<ComboboxInputElement, ComboboxInpu
       skipWhen: !internalIsOpen,
     });
 
-    React.useEffect(() => {
-      /**
-       * When the value prop changes "externally" update the text input value too
-       */
-      handleTextValueChange(value || '');
-
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [value]);
-
     const hintId = `${generatedId}-hint`;
     const errorId = `${generatedId}-error`;
 

--- a/packages/strapi-design-system/src/Combobox/__tests__/Combobox.spec.tsx
+++ b/packages/strapi-design-system/src/Combobox/__tests__/Combobox.spec.tsx
@@ -71,19 +71,6 @@ describe('Combobox', () => {
     expect(getByRole('combobox')).toHaveValue('Strawberry 2');
   });
 
-  it('should correctly change the rendered text value of the combobox when the value prop changes externally', async () => {
-    const onTextValueChange = jest.fn();
-    const { rerender } = renderRTL(<Component options={defaultOptions} onTextValueChange={onTextValueChange} />);
-
-    expect(onTextValueChange).toHaveBeenCalledTimes(1);
-    expect(onTextValueChange).toHaveBeenCalledWith('');
-
-    rerender(<Component options={defaultOptions} onTextValueChange={onTextValueChange} value="bagel" />);
-
-    expect(onTextValueChange).toHaveBeenCalledTimes(2);
-    expect(onTextValueChange).toHaveBeenCalledWith('bagel');
-  });
-
   describe('callbacks', () => {
     it('should fire onChange only when the value is changed not when the input does', async () => {
       const onChange = jest.fn();


### PR DESCRIPTION
### What does it do?

Manually revert changes done in [#1381](https://github.com/strapi/design-system/pull/1381)

### Why is it needed?

Becaus [#1381](https://github.com/strapi/design-system/pull/1381) fixes the behavior explained there but also introduces a new issue:

- When the value and the rendered text are not the same (e.g. `{ value: 'FR', label: 'France'}`) and the option "France" is clicked, the rendered value is `FR` instead of `France` until the input is focus out

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
