### PR TITLE
fix: header layout height recalculation

### DIFF
--- a/packages/strapi-design-system/src/Layout/HeaderLayout.tsx
+++ b/packages/strapi-design-system/src/Layout/HeaderLayout.tsx
@@ -21,6 +21,7 @@ interface HeaderLayoutProps extends BaseHeaderLayoutProps {}
 
 export const HeaderLayout = (props: HeaderLayoutProps) => {
   const baseHeaderLayoutRef = useRef<HTMLDivElement>(null);
+  const stickyBaseHeaderLayoutRef = useRef<HTMLDivElement>(null);
   const [headerSize, setHeaderSize] = useState<DOMRect | null>(null);
 
   const [containerRef, isVisible] = useElementOnScreen<HTMLDivElement>({
@@ -29,9 +30,9 @@ export const HeaderLayout = (props: HeaderLayoutProps) => {
     threshold: 0,
   });
 
-  useResizeObserver(containerRef, () => {
-    if (containerRef.current) {
-      setHeaderSize(containerRef.current.getBoundingClientRect());
+  useResizeObserver(isVisible ? baseHeaderLayoutRef : stickyBaseHeaderLayoutRef, () => {
+    if (baseHeaderLayoutRef.current) {
+      setHeaderSize(baseHeaderLayoutRef.current.getBoundingClientRect());
     }
   });
 
@@ -39,7 +40,7 @@ export const HeaderLayout = (props: HeaderLayoutProps) => {
     if (baseHeaderLayoutRef.current) {
       setHeaderSize(baseHeaderLayoutRef.current.getBoundingClientRect());
     }
-  }, [baseHeaderLayoutRef]);
+  }, []);
 
   return (
     <>
@@ -47,7 +48,7 @@ export const HeaderLayout = (props: HeaderLayoutProps) => {
         {isVisible && <BaseHeaderLayout ref={baseHeaderLayoutRef} {...props} />}
       </div>
 
-      {!isVisible && <BaseHeaderLayout {...props} sticky width={headerSize?.width} />}
+      {!isVisible && <BaseHeaderLayout ref={stickyBaseHeaderLayoutRef} {...props} sticky width={headerSize?.width} />}
     </>
   );
 };


### PR DESCRIPTION
Fixes https://github.com/strapi/design-system/issues/1318

### What does it do?
- Recalculate height when the contents from `subtitle` prop change after the component is rendered

### Why is it needed?
- When the `subtitle` props change after the component has been rendered, the height is not recalculated that causing the contents to overlap

https://github.com/GitStartHQ/client-strapi-design-system/assets/22890925/5cbfdce9-300d-40d6-8545-e0330fd4b0dd


 

### How to test it?
1. Run the app `yarn develop`
2. Find  `HeaderLayout.stories.tsx`. and add the story below
```
const longText = `` // Add long text here

export const BaseWithoutNavActionWithControls = (props) => {
  const [text, setText] = useState('Text will change in 2s');

  useEffect(() => {
    setTimeout(() => {
      setText(longText);
    }, 2000);
  }, []);

  return (
    <Box background="neutral100">
      <HeaderLayout
        primaryAction={<Button startIcon={<Plus />}>{props.primaryButtonText}</Button>}
        secondaryAction={
          <Button variant={props.secondaryButtonVariant} startIcon={<Pencil />}>
            {props.secondaryButtonText}
          </Button>
        }
        title={props.title}
        subtitle={text}
        as="h2"
      />
      <Box background="#006b8bed">
        <p
          style={{
            height: '600px',
            fontSize: '3rem',
            textAlign: 'center',
            padding: '2rem',
            color: 'gray',
          }}
        >
          More contents here
        </p>
      </Box>
    </Box>
  );
};

BaseWithoutNavActionWithControls.args = {
  primaryButtonText: 'Add an entry',
  secondaryButtonText: 'Edit',
  secondaryButtonVariant: 'tertiary',
  title: 'Other CT',
  subtitle: '36 entries found',
};

```
3. Open the added story

## Demo

https://github.com/GitStartHQ/client-strapi-design-system/assets/22890925/fc411a9d-5cfb-4daa-935e-4daf3e5f89d0
