### PR TITLE
fix: make title optional

### DIFF
--- a/packages/strapi-design-system/src/Alert/Alert.tsx
+++ b/packages/strapi-design-system/src/Alert/Alert.tsx
@@ -81,7 +81,7 @@ export interface AlertProps extends BoxProps {
   /**
    * The title of the `Alert`.
    */
-  title: string;
+  title?: string;
   /**
    * Changes the element, as which a component will render (similar to styled-components).
    */
@@ -126,9 +126,11 @@ export const Alert = ({
         role={variant === 'danger' ? 'alert' : 'status'}
         width="100%"
       >
-        <Typography fontWeight="bold" textColor="neutral800" as={titleAs}>
-          {title}
-        </Typography>
+        {title && (
+          <Typography fontWeight="bold" textColor="neutral800" as={titleAs}>
+            {title}
+          </Typography>
+        )}
 
         <Typography as="p" textColor="neutral800">
           {children}


### PR DESCRIPTION
### What does it do?

Make the title property of the Alert component optional

### Why is it needed?

Because on the Strapi codebase is already being used without specifying the title. And during the migration from JS to TS the errors are starting to appear

### How to test it?

Use the Alert component and check that no title is required

