### PR TITLE
fix: 修复在页面没有滚动条时，Tooltip位置出现偏移的问题

### DIFF
--- a/packages/strapi-design-system/src/Tooltip/Tooltip.tsx
+++ b/packages/strapi-design-system/src/Tooltip/Tooltip.tsx
@@ -15,6 +15,7 @@ const TooltipWrapper = styled(Box)<{ visible: boolean }>`
   /* z-index exist because of its position inside Modals */
   z-index: 4;
   display: ${({ visible }) => (visible ? 'revert' : 'none')};
+  top: 0;
 `;
 
 export interface TooltipProps extends Omit<BoxProps<'div'>, 'position'> {


### PR DESCRIPTION
### What does it do?

Fixed an issue where the position of the tooltip shifted when the hover was first placed on the icon without a scroll bar on the page.

Adjusted the CSS style to ensure that the tooltip performs consistently on the first hover and subsequent hovers.

### Why is it needed?

The previous issue resulted in poor user experience, as the offset of the tooltip position when the hover is first placed on the icon can cause confusion.

This modification fixes this issue and improves the usability of the user interface.

### How to test it?

Open the application on a page without a scroll bar, Please refer to the demo document address:

https://api-0khig.strapidemo.com/admin/plugins/content-type-builder/content-types/api::place.place

Try hovering on the icon for the first time and observe if the position of the tooltip is correct.

Hover again on the icon and check if there is no positional offset.

### Related issue(s)/PR(s)

Fixed: https://github.com/strapi/design-system/issues/1420
