### PR TITLE
fix: SimpleMenu - trigger style props as "IconButton"

### DIFF
--- a/packages/strapi-design-system/src/IconButton/IconButton.tsx
+++ b/packages/strapi-design-system/src/IconButton/IconButton.tsx
@@ -106,6 +106,8 @@ export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
   },
 );
 
+IconButton.displayName = 'IconButton';
+
 const IconButtonWrapper = styled(BaseButton)<Required<Pick<IconButtonProps, 'size' | 'variant'>>>`
   background-color: ${({ theme, variant }) => {
     if (variant === VARIANT_SECONDARY) {
@@ -210,3 +212,5 @@ export const IconButtonGroup = styled(Flex)`
     }
   }
 `;
+
+IconButtonGroup.displayName = 'IconButtonGroup';

--- a/packages/strapi-design-system/src/v2/SimpleMenu/Menu.tsx
+++ b/packages/strapi-design-system/src/v2/SimpleMenu/Menu.tsx
@@ -29,6 +29,11 @@ interface TriggerProps extends ButtonProps {}
 
 const MenuTrigger = forwardRef<HTMLButtonElement, TriggerProps>(
   ({ size, endIcon = <CarretDown width={`${6 / 16}rem`} height={`${4 / 16}rem`} aria-hidden />, ...props }, ref) => {
+    const isSizeS = size === 'S';
+    const isIconButton = (props.as as any)?.displayName === 'IconButton';
+    const paddingY = isSizeS ? 1 : 2;
+    const paddingX = isSizeS ? 3 : 4;
+
     return (
       <DropdownMenu.Trigger asChild>
         <Button
@@ -36,10 +41,11 @@ const MenuTrigger = forwardRef<HTMLButtonElement, TriggerProps>(
           type="button"
           variant="ghost"
           endIcon={endIcon}
-          paddingTop={size === 'S' ? 1 : 2}
-          paddingBottom={size === 'S' ? 1 : 2}
-          paddingLeft={size === 'S' ? 3 : 4}
-          paddingRight={size === 'S' ? 3 : 4}
+          paddingTop={isIconButton ? '0' : paddingY}
+          paddingBottom={isIconButton ? '0' : paddingY}
+          paddingLeft={isIconButton ? '0' : paddingX}
+          paddingRight={isIconButton ? '0' : paddingX}
+          justifyContent={isIconButton ? 'center' : undefined}
           {...props}
         />
       </DropdownMenu.Trigger>


### PR DESCRIPTION
### What does it do?

Update the style props applied to the SimpleMenu/`MenuTrigger` component, in case of this trigger is used as a `IconButton`.

### Why is it needed?

To fix the problem that the SimpleMenu/`MenuTrigger`, when used as `IconButton`, is not showing the icon inside the button (due to the button-padding applied, not lefting any space to render the icon-svg into it).

### How to test it?

Running the Storybook locally, or checking the [online preview](https://design-system-git-fix-simple-menu-icon-button-strapijs.vercel.app/?path=/story/design-system-components-v2-simplemenu--with-icons).

Check that the `v2/SimpleMenu` is displaying the Icon inside the trigger-button, when using the combined props:
```tsx
<SimpleMenu as={IconButton} icon={<More />}>
  ...
</SimpleMenu>
```

### Related issue(s)/PR(s)

#1418 
