### PR TITLE
fix(design-system): export some missing prop types

### DIFF
--- a/.changeset/cool-turkeys-judge.md
+++ b/.changeset/cool-turkeys-judge.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+fix(design-system): export some missing prop types

--- a/packages/strapi-design-system/src/Accordion/Accordion.tsx
+++ b/packages/strapi-design-system/src/Accordion/Accordion.tsx
@@ -32,7 +32,7 @@ const getBorder = ({ theme, expanded, variant, disabled, error }: GetBorderParam
   return `1px solid ${theme.colors.neutral100}`;
 };
 
-export const AccordionTypography = styled(Typography)``;
+const AccordionTypography = styled(Typography)``;
 
 type AccordionWrapperProps = Pick<AccordionProps, 'expanded' | 'disabled' | 'variant' | 'error'>;
 
@@ -60,10 +60,10 @@ const AccordionWrapper = styled(Box)<AccordionWrapperProps>`
   }
 `;
 
-export type AccordionSize = 'S' | 'M';
-export type AccordionVariant = 'primary' | 'secondary';
+type AccordionSize = 'S' | 'M';
+type AccordionVariant = 'primary' | 'secondary';
 
-export interface AccordionProps {
+interface AccordionProps {
   children: React.ReactNode;
   /**
    * If `true`, the accordion will be disabled.
@@ -112,7 +112,7 @@ export interface AccordionProps {
   variant?: AccordionVariant;
 }
 
-export const Accordion = ({
+const Accordion = ({
   children,
   disabled = false,
   error,
@@ -156,3 +156,6 @@ export const Accordion = ({
     </AccordionContext.Provider>
   );
 };
+
+export { Accordion, AccordionTypography };
+export type { AccordionProps, AccordionSize, AccordionVariant };

--- a/packages/strapi-design-system/src/Link/Link.tsx
+++ b/packages/strapi-design-system/src/Link/Link.tsx
@@ -62,7 +62,7 @@ interface HrefLinkProps extends SharedLinkProps {
 
 type LinkProps = ToLinkProps | HrefLinkProps;
 
-export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
+const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
   ({ children, href, to, disabled = false, startIcon, endIcon, ...restProps }, ref) => {
     const target = href ? '_blank' : undefined;
     const rel = href ? 'noreferrer noopener' : undefined;
@@ -101,3 +101,6 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
     );
   },
 );
+
+export { Link };
+export type { LinkProps, SharedLinkProps, ToLinkProps, HrefLinkProps };

--- a/packages/strapi-design-system/src/LinkButton/LinkButton.tsx
+++ b/packages/strapi-design-system/src/LinkButton/LinkButton.tsx
@@ -25,7 +25,7 @@ const LinkWrapper = styled(BaseButtonWrapper)<Required<Pick<LinkButtonProps, 'va
   ${getVariantStyle}
 `;
 
-interface SharedLinkProps extends BaseButtonProps {
+interface SharedLinkButtonProps extends BaseButtonProps {
   disabled?: boolean;
   endIcon?: React.ReactNode;
   size?: (typeof BUTTON_SIZES)[number];
@@ -33,19 +33,19 @@ interface SharedLinkProps extends BaseButtonProps {
   variant?: (typeof VARIANTS)[number];
 }
 
-interface ToLinkProps extends SharedLinkProps {
+interface ToLinkButtonProps extends SharedLinkButtonProps {
   to: NavLinkProps['to'];
   href?: never;
 }
 
-interface HrefLinkProps extends SharedLinkProps {
+interface HrefLinkButtonProps extends SharedLinkButtonProps {
   href: string;
   to?: never;
 }
 
-type LinkButtonProps = ToLinkProps | HrefLinkProps;
+type LinkButtonProps = ToLinkButtonProps | HrefLinkButtonProps;
 
-export const LinkButton = React.forwardRef<HTMLAnchorElement, LinkButtonProps>(
+const LinkButton = React.forwardRef<HTMLAnchorElement, LinkButtonProps>(
   ({ variant = 'default', startIcon, endIcon, disabled = false, children, size = 'S', href, to, ...props }, ref) => {
     const target = href ? '_blank' : undefined;
     const rel = href ? 'noreferrer noopener' : undefined;
@@ -87,3 +87,6 @@ export const LinkButton = React.forwardRef<HTMLAnchorElement, LinkButtonProps>(
     );
   },
 );
+
+export { LinkButton };
+export type { LinkButtonProps, SharedLinkButtonProps, ToLinkButtonProps, HrefLinkButtonProps };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* exports some of the missing prop types for components e.g. `link`

### Why is it needed?

* need them for TS building in the admin
