### PR TITLE
fix: Added skipAutoFocus on focusTrap

### DIFF
--- a/.changeset/slimy-tables-explain.md
+++ b/.changeset/slimy-tables-explain.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': minor
+---
+
+Fix: Added skipAutoFocus on focusTrap component

--- a/docs/stories/FocusTrap.stories.tsx
+++ b/docs/stories/FocusTrap.stories.tsx
@@ -18,11 +18,16 @@ export const Base = {
   name: 'base',
 } satisfies Story;
 
-const TrappedComponent = ({ onClose }) => {
+export const WithoutAutoFocus = {
+  render: () => <ExampleComponent skipAutoFocus />,
+  name: 'withoutAutoFocus',
+} satisfies Story;
+
+const TrappedComponent = ({ onClose, skipAutoFocus }) => {
   const [newLastVisible, setNewLastVisible] = useState(false);
 
   return (
-    <FocusTrap onEscape={onClose}>
+    <FocusTrap onEscape={onClose} skipAutoFocus={skipAutoFocus}>
       <Box background="neutral0" padding={4} hasRadius style={{ width: '600px' }}>
         <Flex direction="column" alignItems="center" gap={4}>
           <Flex justifyContent="space-between">
@@ -59,13 +64,13 @@ const TrappedComponent = ({ onClose }) => {
   );
 };
 
-export const ExampleComponent = () => {
+export const ExampleComponent = ({ skipAutoFocus = false }) => {
   const [visible, setVisible] = useState(false);
 
   return (
     <Box background="neutral150" padding={10}>
       <Flex direction="column" alignItems="center" gap={2}>
-        {visible && <TrappedComponent onClose={() => setVisible(false)} />}
+        {visible && <TrappedComponent onClose={() => setVisible(false)} skipAutoFocus={skipAutoFocus} />}
         <Box background="neutral0" padding={4} hasRadius style={{ width: '600px' }}>
           <Typography variant="beta" as="h2">
             Outside the trap!

--- a/packages/strapi-design-system/src/FocusTrap/FocusTrap.tsx
+++ b/packages/strapi-design-system/src/FocusTrap/FocusTrap.tsx
@@ -12,9 +12,11 @@ export interface FocusTrapProps extends HTMLAttributes<HTMLDivElement> {
    * A boolean value to define whether the focus should be restored or not.
    */
   restoreFocus?: boolean;
+  // Skip focusing default first element if user needs to set it manually
+  skipAutoFocus?: boolean;
 }
 
-export const FocusTrap = ({ onEscape, restoreFocus = true, ...props }: FocusTrapProps) => {
+export const FocusTrap = ({ onEscape, restoreFocus = true, skipAutoFocus = false, ...props }: FocusTrapProps) => {
   const trappedRef = useRef<HTMLDivElement>(null!);
 
   /**
@@ -38,7 +40,7 @@ export const FocusTrap = ({ onEscape, restoreFocus = true, ...props }: FocusTrap
    * Sends the focus to the first element of the focus trap tree
    */
   useEffect(() => {
-    if (!trappedRef.current) return;
+    if (!trappedRef.current || skipAutoFocus) return;
 
     const focusableChildren = getFocusableNodes(trappedRef.current);
 
@@ -51,7 +53,7 @@ export const FocusTrap = ({ onEscape, restoreFocus = true, ...props }: FocusTrap
         '[FocusTrap]: it seems there are no focusable elements in the focus trap tree. Make sure there s at least one.',
       );
     }
-  }, []);
+  }, [skipAutoFocus]);
 
   const handleKeyDown: KeyboardEventHandler<HTMLDivElement> = (e) => {
     if (e.key === KeyboardKeys.ESCAPE && onEscape) {


### PR DESCRIPTION
### What does it do?

Added **skipAutoFocus** on focusTrap to set focus manually

### Why is it needed?

To edit blocks input in fullscreen/expanded mode, user need focus on the blocks-input instead of the default first element of editor toolbar

### How to test it?

Added a story without auto focus to test 
