### PR TITLE
fix: TabGroup react to changes of the initialSelectedTabIndex value

### DIFF
--- a/.changeset/tiny-birds-tell.md
+++ b/.changeset/tiny-birds-tell.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': minor
+---
+
+Fix: Added useEffect on TabGroup component

--- a/packages/strapi-design-system/src/Tabs/TabGroup.tsx
+++ b/packages/strapi-design-system/src/Tabs/TabGroup.tsx
@@ -21,6 +21,10 @@ export const TabGroup = React.forwardRef<
 
   const [selectedTabIndex, setSelectedTabIndex] = React.useState(initialSelectedTabIndex);
 
+  React.useEffect(() => {
+    setSelectedTabIndex(initialSelectedTabIndex);
+  }, [initialSelectedTabIndex]);
+
   React.useImperativeHandle(ref, () => ({
     _handlers: { setSelectedTabIndex },
   }));


### PR DESCRIPTION
### What does it do?

It solves an issue we had in the TabGroup inside the CMS used in the Markeplace and Content Releases, it doesn't react to the changes of the initialSelectedTabIndex prop

### Why is it needed?

Because for example when you try to use the browser back button or you click on the side bar menu on the left the tabs are not updated with the current selection

### How to test it?

Link this DS version to your CMS and try to, for example, to the Marketplace page admin/marketplace
- then click on the tab Providers
- then use the Back button of the browser you need to see the Plugins tab selected instead of the Providers one
