### PR TITLE
fix(design-system): checkbox svg need quotes to work correctly

### DIFF
--- a/.changeset/brave-chefs-behave.md
+++ b/.changeset/brave-chefs-behave.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+fix: checkbox svg needs quote marks around to work

--- a/packages/strapi-design-system/src/BaseCheckbox/BaseCheckbox.tsx
+++ b/packages/strapi-design-system/src/BaseCheckbox/BaseCheckbox.tsx
@@ -32,7 +32,7 @@ const CheckboxInput = styled.input`
       content: '';
       display: block;
       position: relative;
-      background: url(${checkmarkIcon}) no-repeat no-repeat center center;
+      background: ${() => `url("${checkmarkIcon}") no-repeat no-repeat center center`};
       width: 10px;
       height: 10px;
       left: 50%;
@@ -41,7 +41,7 @@ const CheckboxInput = styled.input`
     }
 
     &:disabled:after {
-      background: url(${checkmarkIconDisabled}) no-repeat no-repeat center center;
+      background: ${() => `url("${checkmarkIconDisabled}") no-repeat no-repeat center center`};
     }
   }
 

--- a/packages/strapi-design-system/src/Select/MultiSelect.tsx
+++ b/packages/strapi-design-system/src/Select/MultiSelect.tsx
@@ -289,7 +289,7 @@ const CheckMark = styled(Box)<CheckMarkProps>`
     css`
       &::after {
         content: '';
-        background: url(${checkmarkIcon}) no-repeat no-repeat center center;
+        background: ${() => `url("${checkmarkIcon}") no-repeat no-repeat center center`};
         width: 100%;
         height: 100%;
         position: absolute;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* adds quote marks to where we inline the string from the checkbox asset import

### Why is it needed?

* the CSS comes out incorrectly resulting in no checks in the CMS

### Related issue(s)/PR(s)

* mentioned in https://github.com/strapi/strapi/pull/19136#issuecomment-1881242950
