### PR TITLE
Feat: new filter "contains" is added on combobox for autocomplete type:list

### DIFF
--- a/.changeset/tasty-cars-hide.md
+++ b/.changeset/tasty-cars-hide.md
@@ -1,0 +1,5 @@
+---
+'@strapi/ui-primitives': minor
+---
+
+Feat: new filter "contains" is added on combobox for autocomplete type:list

--- a/docs/stories/Combobox.mdx
+++ b/docs/stories/Combobox.mdx
@@ -55,7 +55,7 @@ still pass an `onCreateOption` callback to handle the creation of the new option
 ### Autocomplete settings
 
 By default, the combobox uses both inline and list autocomplete, however you can change this behaviour
-to only be `list` or `none`. If you set the autocomplete mode to `none`, the first matching option will
+to only be `list (filter: startswith)`, `list (filter: contains)` or `none`. If you set the autocomplete mode to `none`, the first matching option will
 be visually focussed
 
 <Canvas of={ComboboxStories.Autocomplete} />

--- a/docs/stories/Combobox.stories.tsx
+++ b/docs/stories/Combobox.stories.tsx
@@ -184,12 +184,12 @@ export const Creatable = {
   name: 'creatable',
 } satisfies Story;
 
-type TAutocomplete = 'none' | 'list' | 'both' | { type: 'list'; filter: 'startsWith' | 'contains' };
+type Autocomplete = 'none' | 'list' | 'both' | { type: 'list'; filter: 'startsWith' | 'contains' };
 
 export const Autocomplete = {
   render: () => {
     const [value, setValue] = useState('');
-    const [autocompleteMode, setAutocompleteMode] = useState<TAutocomplete>('both');
+    const [autocompleteMode, setAutocompleteMode] = useState<Autocomplete>('both');
 
     const handleChange = (value) => {
       if (value === 'list-contains') {

--- a/docs/stories/Combobox.stories.tsx
+++ b/docs/stories/Combobox.stories.tsx
@@ -184,10 +184,18 @@ export const Creatable = {
   name: 'creatable',
 } satisfies Story;
 
+type TAutocomplete = 'none' | 'list' | 'both' | { type: 'list'; filter: 'startsWith' | 'contains' };
+
 export const Autocomplete = {
   render: () => {
     const [value, setValue] = useState('');
-    const [autocompleteMode, setAutocompleteMode] = useState('both');
+    const [autocompleteMode, setAutocompleteMode] = useState<TAutocomplete>('both');
+
+    const handleChange = (value) => {
+      if (value === 'list-contains') {
+        setAutocompleteMode({ type: 'list', filter: 'contains' });
+      } else setAutocompleteMode(value);
+    };
 
     return (
       <Flex direction="column" alignItems="stretch" gap={11}>
@@ -207,9 +215,10 @@ export const Autocomplete = {
           <ComboboxOption value="orange">Orange</ComboboxOption>
           <ComboboxOption value="strawberry">Strawberry</ComboboxOption>
         </Combobox>
-        <SingleSelect label="Autocomplete Mode" value={autocompleteMode} onValueChange={setAutocompleteMode}>
+        <SingleSelect label="Autocomplete Mode" value={autocompleteMode} onValueChange={handleChange}>
           <SingleSelectOption value="both">both</SingleSelectOption>
-          <SingleSelectOption value="list">list</SingleSelectOption>
+          <SingleSelectOption value="list">list (filter: startsWith)</SingleSelectOption>
+          <SingleSelectOption value="list-contains">list (filter: contains)</SingleSelectOption>
           <SingleSelectOption value="none">none</SingleSelectOption>
         </SingleSelect>
       </Flex>

--- a/docs/stories/primitives/Combobox.mdx
+++ b/docs/stories/primitives/Combobox.mdx
@@ -22,9 +22,20 @@ import { Combobox } from '@strapi/ui-primitives';
 
 ### With List Autocomplete
 
+Default `autocomplete="list"` filters text by matching starting character, recently we have introduced filter by options `startsWith`,`contains`,
+so we can also say `autocomplete={{type: 'list', filter: 'startsWith'}}`
+
 <Canvas of={ComboboxStories.ListAutocomplete} />
 
+### With List Autocomplete "contains"
+
+To filter list by substring value we have `autocomplete={{type: 'list', filter: 'contains'}}`
+
+<Canvas of={ComboboxStories.ListContainsAutocomplete} />
+
 ### With Both Autocomplete
+
+For `autocomplete = "both"`, only default filter is available `autocomplete={{type: 'both', filter: 'startsWith'}}`, filter by `contains` is not supported.
 
 NOTE! If you opt to control the `textValue` yourself whilst using `autocomplete === "both"` e.g. to add a clear button,
 then you will also need to control the `filterValue` as well.

--- a/docs/stories/primitives/Combobox.stories.tsx
+++ b/docs/stories/primitives/Combobox.stories.tsx
@@ -65,26 +65,32 @@ export const ListAutocomplete = {
       <Combobox.Portal>
         <Combobox.Content>
           <Combobox.Viewport>
-            <Combobox.Item value="1">
-              <Combobox.ItemText>Option 1</Combobox.ItemText>
+            <Combobox.Item value="mango">
+              <Combobox.ItemText>Mango</Combobox.ItemText>
               <Combobox.ItemIndicator>
                 <Check />
               </Combobox.ItemIndicator>
             </Combobox.Item>
-            <Combobox.Item value="2">
-              <Combobox.ItemText>Option 2</Combobox.ItemText>
+            <Combobox.Item value="apple">
+              <Combobox.ItemText>Apple</Combobox.ItemText>
               <Combobox.ItemIndicator>
                 <Check />
               </Combobox.ItemIndicator>
             </Combobox.Item>
-            <Combobox.Item value="3">
-              <Combobox.ItemText>Option 3</Combobox.ItemText>
+            <Combobox.Item value="Banana">
+              <Combobox.ItemText>Banana</Combobox.ItemText>
               <Combobox.ItemIndicator>
                 <Check />
               </Combobox.ItemIndicator>
             </Combobox.Item>
-            <Combobox.Item value="4">
-              <Combobox.ItemText>Option 4</Combobox.ItemText>
+            <Combobox.Item value="papaya">
+              <Combobox.ItemText>Papaya</Combobox.ItemText>
+              <Combobox.ItemIndicator>
+                <Check />
+              </Combobox.ItemIndicator>
+            </Combobox.Item>
+            <Combobox.Item value="avocado">
+              <Combobox.ItemText>Avocado</Combobox.ItemText>
               <Combobox.ItemIndicator>
                 <Check />
               </Combobox.ItemIndicator>
@@ -110,25 +116,31 @@ export const BothAutocomplete = {
         <Combobox.Content>
           <Combobox.Viewport>
             <Combobox.Item value="1">
-              <Combobox.ItemText>Option 1</Combobox.ItemText>
-              <Combobox.ItemIndicator>
-                <Check />
-              </Combobox.ItemIndicator>
-            </Combobox.Item>
-            <Combobox.Item value="2">
-              <Combobox.ItemText>Option 2</Combobox.ItemText>
-              <Combobox.ItemIndicator>
-                <Check />
-              </Combobox.ItemIndicator>
-            </Combobox.Item>
-            <Combobox.Item value="3">
-              <Combobox.ItemText>Option 3</Combobox.ItemText>
+              <Combobox.ItemText>Banana</Combobox.ItemText>
               <Combobox.ItemIndicator>
                 <Check />
               </Combobox.ItemIndicator>
             </Combobox.Item>
             <Combobox.Item value="4">
-              <Combobox.ItemText>Option 4</Combobox.ItemText>
+              <Combobox.ItemText>Apples</Combobox.ItemText>
+              <Combobox.ItemIndicator>
+                <Check />
+              </Combobox.ItemIndicator>
+            </Combobox.Item>
+            <Combobox.Item value="2">
+              <Combobox.ItemText>Oranges</Combobox.ItemText>
+              <Combobox.ItemIndicator>
+                <Check />
+              </Combobox.ItemIndicator>
+            </Combobox.Item>
+            <Combobox.Item value="3">
+              <Combobox.ItemText>Kiwis</Combobox.ItemText>
+              <Combobox.ItemIndicator>
+                <Check />
+              </Combobox.ItemIndicator>
+            </Combobox.Item>
+            <Combobox.Item value="5">
+              <Combobox.ItemText>Avocado</Combobox.ItemText>
               <Combobox.ItemIndicator>
                 <Check />
               </Combobox.ItemIndicator>
@@ -141,6 +153,56 @@ export const BothAutocomplete = {
   ),
 
   name: 'Both Autocomplete',
+} satisfies Story;
+
+export const ListContainsAutocomplete = {
+  render: () => (
+    <Combobox.Root autocomplete={{ type: 'list', filter: 'contains' }}>
+      <Combobox.Trigger>
+        <Combobox.TextInput placeholder="Pick me" />
+        <Combobox.Icon />
+      </Combobox.Trigger>
+      <Combobox.Portal>
+        <Combobox.Content>
+          <Combobox.Viewport>
+            <Combobox.Item value="1">
+              <Combobox.ItemText>Banana</Combobox.ItemText>
+              <Combobox.ItemIndicator>
+                <Check />
+              </Combobox.ItemIndicator>
+            </Combobox.Item>
+            <Combobox.Item value="4">
+              <Combobox.ItemText>Apples</Combobox.ItemText>
+              <Combobox.ItemIndicator>
+                <Check />
+              </Combobox.ItemIndicator>
+            </Combobox.Item>
+            <Combobox.Item value="2">
+              <Combobox.ItemText>Oranges</Combobox.ItemText>
+              <Combobox.ItemIndicator>
+                <Check />
+              </Combobox.ItemIndicator>
+            </Combobox.Item>
+            <Combobox.Item value="3">
+              <Combobox.ItemText>Kiwis</Combobox.ItemText>
+              <Combobox.ItemIndicator>
+                <Check />
+              </Combobox.ItemIndicator>
+            </Combobox.Item>
+            <Combobox.Item value="5">
+              <Combobox.ItemText>Avocado</Combobox.ItemText>
+              <Combobox.ItemIndicator>
+                <Check />
+              </Combobox.ItemIndicator>
+            </Combobox.Item>
+            <Combobox.NoValueFound>No value</Combobox.NoValueFound>
+          </Combobox.Viewport>
+        </Combobox.Content>
+      </Combobox.Portal>
+    </Combobox.Root>
+  ),
+
+  name: 'List Contains Autocomplete',
 } satisfies Story;
 
 export const CreateCustomValues = {

--- a/packages/primitives/src/components/Combobox/Combobox.tsx
+++ b/packages/primitives/src/components/Combobox/Combobox.tsx
@@ -54,16 +54,16 @@ interface CreateData extends Data {
   type: 'create';
 }
 
-type TAutocompleteObject =
+type AutocompleteObject =
   | { type: 'none'; filter?: never }
   | { type: 'list'; filter: 'contains' | 'startsWith' }
   | { type: 'both'; filter: 'startsWith' };
 
-type TAutocomplete = 'none' | 'list' | 'both' | TAutocompleteObject;
+type Autocomplete = 'none' | 'list' | 'both' | AutocompleteObject;
 
 type ComboboxContextValue = {
   allowCustomValue: boolean;
-  autocomplete: TAutocompleteObject;
+  autocomplete: AutocompleteObject;
   contentId: string;
   disabled?: boolean;
   locale: string;
@@ -93,7 +93,7 @@ const [ComboboxProvider, useComboboxContext] = createContext<ComboboxContextValu
 
 interface RootProps {
   allowCustomValue?: boolean;
-  autocomplete?: TAutocomplete;
+  autocomplete?: Autocomplete;
   children?: React.ReactNode;
   defaultOpen?: boolean;
   defaultValue?: string;
@@ -122,7 +122,7 @@ const ComboboxProviders = ({ children }: { children: React.ReactNode }) => (
   </PopperPrimitive.Root>
 );
 
-const formatAutocomplete = (autocomplete: TAutocomplete) => {
+const formatAutocomplete = (autocomplete: Autocomplete) => {
   if (typeof autocomplete === 'string') {
     if (autocomplete === 'none') {
       return {
@@ -227,7 +227,7 @@ const Combobox = (props: RootProps) => {
     [autocomplete, setTextValue, viewport, visuallyFocussedItem, value],
   );
 
-  const autocompleteObject: TAutocompleteObject = formatAutocomplete(autocomplete);
+  const autocompleteObject: AutocompleteObject = formatAutocomplete(autocomplete);
 
   React.useEffect(() => {
     if (autocomplete !== 'both') {
@@ -1339,8 +1339,8 @@ export type {
   ItemIndicatorProps,
   NoValueFoundProps,
   CreateItemProps,
-  TAutocomplete,
-  TAutocompleteObject,
+  Autocomplete,
+  AutocompleteObject,
 };
 
 /**

--- a/packages/primitives/src/components/Combobox/Combobox.tsx
+++ b/packages/primitives/src/components/Combobox/Combobox.tsx
@@ -55,7 +55,7 @@ interface CreateData extends Data {
 }
 
 type TAutocompleteObject =
-  | { type: 'none'; filter?: undefined }
+  | { type: 'none'; filter?: never }
   | { type: 'list'; filter: 'contains' | 'startsWith' }
   | { type: 'both'; filter: 'startsWith' };
 


### PR DESCRIPTION
### What does it do?

Till now we were filtering by default matching starting character and autocomplete accepted values were: "none", "list", "both". Now we have added a new option `contains` to filter by substring. 

However `filter:'contains'` option is only available on `autocomplete='list'` as having for `autocomplete="both"` would not work as expected. Also to have backward compatibility and for consistency across all supported filter types, we are introducing object counterparts of existing types.

### Why is it needed?
Filtering by substring is required in timezone dropdown in scheduling releases as TZ starts with UTC and not actual TZ value.

### How to test it?

You can test newly added filter option in storybook under `primitives/combobox` as well as `DS/combobox` component