### PR TITLE
Fix: Disable datepicker selection for min and max date

### DIFF
--- a/.changeset/mighty-hats-complain.md
+++ b/.changeset/mighty-hats-complain.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': minor
+---
+
+fix: Datepicker disable selection for min and max date

--- a/packages/strapi-design-system/src/DatePicker/DatePicker.tsx
+++ b/packages/strapi-design-system/src/DatePicker/DatePicker.tsx
@@ -1038,6 +1038,7 @@ const DatePickerCalendar = React.forwardRef<HTMLDivElement, CalendarProps>(
                       aria-colindex={index + 1}
                       date={date}
                       startDate={startDate}
+                      disabled={minDate.compare(date) > 0 || date.compare(maxDate) > 0}
                     />
                   ) : (
                     <Cell aria-colindex={index + 1} />
@@ -1150,10 +1151,11 @@ type DatePickerCalendarCellElement = HTMLTableCellElement;
 interface CalendarCellProps extends BoxProps<'td'> {
   date: CalendarDate;
   startDate: CalendarDate;
+  disabled: boolean;
 }
 
 const DatePickerCalendarCell = React.forwardRef<DatePickerCalendarCellElement, CalendarCellProps>(
-  ({ date, startDate, ...props }, forwardedRef) => {
+  ({ date, startDate, disabled, ...props }, forwardedRef) => {
     const { timeZone, locale, calendarDate, onValueChange, onOpenChange, onTextValueChange, onCalendarDateChange } =
       useDatePickerContext(DATE_PICKER_CALEDNAR_CELL_NAME);
 
@@ -1214,6 +1216,7 @@ const DatePickerCalendarCell = React.forwardRef<DatePickerCalendarCellElement, C
           onTextValueChange(textValueFormatter.format(date.toDate(timeZone)));
           onOpenChange(false);
         })}
+        aria-disabled={disabled}
       >
         <Typography variant="pi" textColor={textColor}>
           {formattedDate}
@@ -1228,12 +1231,18 @@ const Cell = styled(Box)`
   padding: ${7 / 16}rem;
   // Trick to prevent the outline from overflowing because of the general outline-offset
   outline-offset: -2px !important;
+  &[aria-disabled='true'] {
+    pointer-events: none;
+    opacity: 0.5;
+  }
 
-  &:hover {
-    background: ${({ theme }) => theme.colors.primary100};
+  &[aria-disabled='false'] {
+    &:hover {
+      background: ${({ theme }) => theme.colors.primary100};
 
-    & > ${Typography} {
-      color: ${({ theme }) => theme.colors.primary600};
+      & > ${Typography} {
+        color: ${({ theme }) => theme.colors.primary600};
+      }
     }
   }
 `;

--- a/packages/strapi-design-system/src/DatePicker/__tests__/DatePicker.spec.tsx
+++ b/packages/strapi-design-system/src/DatePicker/__tests__/DatePicker.spec.tsx
@@ -463,6 +463,28 @@ describe('DatePicker', () => {
       expect(queryByRole('option', { name: '2014' })).not.toBeInTheDocument();
     });
 
+    it('should limit the date selection to given min date', async () => {
+      const { getByRole, user } = render({
+        minDate: new Date('Mon Sep 04 2020'),
+        initialDate: new Date('Sep 04 2020'),
+      });
+
+      await user.click(getByRole('combobox', { name: 'date picker' }));
+      expect(getByRole('gridcell', { name: 'Thursday, 3 September 2020' })).toHaveAttribute('aria-disabled', 'true');
+      expect(getByRole('gridcell', { name: 'Saturday, 5 September 2020' })).toHaveAttribute('aria-disabled', 'false');
+    });
+
+    it('should limit the date selection to given max date', async () => {
+      const { getByRole, user } = render({
+        maxDate: new Date('Mon Sep 04 2020'),
+        initialDate: new Date('Sep 04 2020'),
+      });
+
+      await user.click(getByRole('combobox', { name: 'date picker' }));
+      expect(getByRole('gridcell', { name: 'Thursday, 3 September 2020' })).toHaveAttribute('aria-disabled', 'false');
+      expect(getByRole('gridcell', { name: 'Saturday, 5 September 2020' })).toHaveAttribute('aria-disabled', 'true');
+    });
+
     it('should set the initial calendar date to the minimum date if today is before that date', async () => {
       const { getByRole, user } = render({
         minDate: new Date('Sep 04 4000'),


### PR DESCRIPTION
### What does it do?

Disables datepicker selection for given min and max date, unit tests added.

### How to test it?

Please check respective story.
