### PR TITLE
feat: export hooks from primitives & DS

### DIFF
--- a/.changeset/smart-buttons-do.md
+++ b/.changeset/smart-buttons-do.md
@@ -1,0 +1,6 @@
+---
+'@strapi/design-system': minor
+'@strapi/ui-primitives': minor
+---
+
+feat: export helpful hooks

--- a/packages/primitives/README.md
+++ b/packages/primitives/README.md
@@ -95,6 +95,23 @@ import { Select } from '@strapi/ui-primitives';
 };
 ```
 
+## Hook Documentation
+
+### useCallbackRef
+
+Converts a callback to a ref to avoid triggering re-renders when passed as a prop or avoid re-executing
+effects when passed as a dependency
+
+### useCollator
+
+Provides localized string collation for the current locale. Automatically updates when the locale changes,
+and handles caching of the collator for performance.
+
+### useFilter
+
+Provides localized string search functionality that is useful for filtering or matching items
+in a list. Options can be provided to adjust the sensitivity to case, diacritics, and other parameters.
+
 ## Contributing
 
 Please follow our [CONTRIBUTING](https://github.com/strapi/design-system/blob/main/CONTRIBUTING.md) guidelines.

--- a/packages/primitives/src/index.ts
+++ b/packages/primitives/src/index.ts
@@ -18,3 +18,5 @@ export * from './helpers/events';
  * Hooks
  * ---------------------------------------------------------------------------------------------*/
 export * from './hooks/useCallbackRef';
+export * from './hooks/useCollator';
+export * from './hooks/useFilter';

--- a/packages/strapi-design-system/src/index.ts
+++ b/packages/strapi-design-system/src/index.ts
@@ -67,3 +67,8 @@ export * from './Tooltip';
 export * from './Typography';
 export * from './VisuallyHidden';
 export * from './themes';
+
+export * from './hooks/useComposeRefs';
+export * from './hooks/useDateFormatter';
+
+export { useFilter, useCollator, type Filter, useCallbackRef, composeEventHandlers } from '@strapi/ui-primitives';


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* exports useCallbackRef, useCollator & useFilter from primitives
* exports useDateFormatter & useComposedRefs from design-system

### Why is it needed?

* we're gonna remove these from the helper-plugin and it makes sense to have a single source of truth, it feels appropriate that they're here.
