### PR TITLE
Fix: Date picker selected date highlight issue

### DIFF
--- a/.changeset/few-lions-clean.md
+++ b/.changeset/few-lions-clean.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+fix: date picker selected date highlight

--- a/packages/strapi-design-system/src/DatePicker/DatePicker.tsx
+++ b/packages/strapi-design-system/src/DatePicker/DatePicker.tsx
@@ -1156,10 +1156,12 @@ interface CalendarCellProps extends BoxProps<'td'> {
 
 const DatePickerCalendarCell = React.forwardRef<DatePickerCalendarCellElement, CalendarCellProps>(
   ({ date, startDate, disabled, ...props }, forwardedRef) => {
-    const { timeZone, locale, calendarDate, onValueChange, onOpenChange, onTextValueChange, onCalendarDateChange } =
+    const { timeZone, locale, value, onValueChange, onOpenChange, onTextValueChange, onCalendarDateChange } =
       useDatePickerContext(DATE_PICKER_CALEDNAR_CELL_NAME);
 
-    const isSelected = isSameDay(calendarDate, date);
+    const todayDate = today('UTC');
+    const selectedDate = value || todayDate;
+    const isSelected = isSameDay(selectedDate, date);
 
     const dateFormatter = useDateFormatter(locale, {
       weekday: 'long',


### PR DESCRIPTION
### What does it do?

Fixes the issue in DatePicker, where it highlights the current day but it highlights it for every month
https://strapi-inc.atlassian.net/browse/CS-677

### How to test it?

On month switch, it should not show the same day hightlighted for each month.
