### PR TITLE
feat: add zIndex prop to Dialog

### DIFF
--- a/.changeset/spicy-items-wink.md
+++ b/.changeset/spicy-items-wink.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': minor
+---
+
+feat: add zIndex prop to Dialog

--- a/packages/strapi-design-system/src/Dialog/Dialog.tsx
+++ b/packages/strapi-design-system/src/Dialog/Dialog.tsx
@@ -34,7 +34,7 @@ export interface DialogProps extends BoxProps {
   isOpen: boolean;
 }
 
-export const Dialog = ({ onClose, title, as = 'h2', isOpen, id, ...props }: DialogProps) => {
+export const Dialog = ({ onClose, title, as = 'h2', isOpen, id, zIndex = 4, ...props }: DialogProps) => {
   const generatedId = useId(id);
 
   useLockScroll(isOpen);
@@ -47,7 +47,7 @@ export const Dialog = ({ onClose, title, as = 'h2', isOpen, id, ...props }: Dial
 
   return (
     <Portal>
-      <DialogWrapper padding={8} position="fixed" zIndex={4}>
+      <DialogWrapper padding={8} position="fixed" zIndex={zIndex}>
         <FocusTrap>
           <DismissibleLayer onEscapeKeyDown={onClose} onPointerDownOutside={onClose}>
             <DialogContainer


### PR DESCRIPTION
### What does it do?

- add a zIndex prop with default 4 

### Why is it needed?

- to give more controll

### How to test it?

- pass the prop and make sure the value comes through

### Related issue(s)/PR(s)


