### PR TITLE
fix(design-system): main nav icons should be 1.6rem

### DIFF
--- a/.changeset/quick-buckets-grab.md
+++ b/.changeset/quick-buckets-grab.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+fix: main nav icon size was set to 1rem it should be 1.6rem

--- a/packages/strapi-design-system/src/MainNav/NavLink.tsx
+++ b/packages/strapi-design-system/src/MainNav/NavLink.tsx
@@ -10,13 +10,6 @@ import { Flex } from '../Flex';
 import { Tooltip } from '../Tooltip';
 import { Typography } from '../Typography';
 
-const IconBox = styled(Box)`
-  svg {
-    width: 1rem;
-    height: 1rem;
-  }
-`;
-
 const MainNavLinkWrapper = styled(BaseLink)`
   position: relative;
   text-decoration: none;
@@ -104,9 +97,9 @@ export const NavLink = React.forwardRef<HTMLAnchorElement, NavLinkProps>(
         <MainNavLinkWrapper ref={ref} {...props}>
           <Tooltip position="right" label={children}>
             <MainNavRow as="span" justifyContent="center">
-              <IconBox aria-hidden paddingRight={0} as="span">
+              <Box aria-hidden paddingRight={0} as="span">
                 {icon}
-              </IconBox>
+              </Box>
               {badgeContent && (
                 <CustomBadge condensed aria-label={badgeAriaLabel}>
                   {badgeContent}
@@ -122,9 +115,9 @@ export const NavLink = React.forwardRef<HTMLAnchorElement, NavLinkProps>(
       <MainNavLinkWrapper ref={ref} {...props}>
         <MainNavRow as="span" justifyContent="space-between">
           <Flex>
-            <IconBox aria-hidden paddingRight={3} as="span">
+            <Box aria-hidden paddingRight={3} as="span">
               {icon}
-            </IconBox>
+            </Box>
             <Typography>{children}</Typography>
           </Flex>
           {badgeContent && (


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* changes the icon size in `MainNav/NavLink` to be `1.6rem` instead of `1rem`

### Why is it needed?

* visual issue

### Related issue(s)/PR(s)

* related https://github.com/strapi/strapi/pull/20151
