### PR TITLE
fix: CSSProperties on BoxProps should be optional

### DIFF
--- a/packages/strapi-design-system/src/Box/Box.tsx
+++ b/packages/strapi-design-system/src/Box/Box.tsx
@@ -7,19 +7,21 @@ import { extractStyleFromTheme } from '../helpers/theme';
 import { DefaultThemeOrCSSProp } from '../types';
 
 export type BoxProps<TElement extends keyof JSX.IntrinsicElements = 'div'> = React.ComponentPropsWithoutRef<TElement> &
-  Pick<
-    CSSProperties,
-    | 'pointerEvents'
-    | 'display'
-    | 'position'
-    | 'zIndex'
-    | 'overflow'
-    | 'cursor'
-    | 'transition'
-    | 'transform'
-    | 'animation'
-    | 'textAlign'
-    | 'textTransform'
+  Partial<
+    Pick<
+      CSSProperties,
+      | 'pointerEvents'
+      | 'display'
+      | 'position'
+      | 'zIndex'
+      | 'overflow'
+      | 'cursor'
+      | 'transition'
+      | 'transform'
+      | 'animation'
+      | 'textAlign'
+      | 'textTransform'
+    >
   > & {
     /**
      * JavaScript hover handler


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Makes `CSSProperties` on `BoxProps` optional.

### Why is it needed?

When using any child element of `Box`, e.g. `Alert`, `Grid`, `Button`, etc. in typescript, `tsc` produces errors saying that various properties are missing, e.g.:

```
error TS2740: Type '{ children: string; variant: "secondary"; loading: boolean; onClick: () => Promise<void>; }' is missing the following properties from type 'ButtonProps': cursor, display, overflow, pointerEvents, and 7 more.

98   <Button variant='secondary' loading={isUploadingData} onClick={handleUploadData}>

error TS2740: Type '{ children: string; }' is missing the following properties from type 'AlertProps': closeLabel, cursor, display, overflow, and 8 more.

328      <Alert>Regenerate data with new added attributes</Alert>
```

### Related issue(s)/PR(s)

Please see related Issue https://github.com/strapi/design-system/issues/1704
