### PR TITLE
fix(icons): dont use rem sizes on width and height properties

### DIFF
--- a/.changeset/afraid-crews-dream.md
+++ b/.changeset/afraid-crews-dream.md
@@ -1,0 +1,5 @@
+---
+'@strapi/icons': patch
+---
+
+fix: dont use rem for width and height on SVG attributes

--- a/packages/strapi-design-system/src/ModalLayout/__tests__/__snapshots__/ModalLayout.test.tsx.snap
+++ b/packages/strapi-design-system/src/ModalLayout/__tests__/__snapshots__/ModalLayout.test.tsx.snap
@@ -428,9 +428,9 @@ exports[`ModalLayout should render component and match snapshot 1`] = `
                     aria-hidden="true"
                     fill="currentColor"
                     focusable="false"
-                    height="1.6rem"
+                    height="16"
                     viewBox="0 0 32 32"
-                    width="1.6rem"
+                    width="16"
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path

--- a/packages/strapi-design-system/src/Tag/__tests__/Tag.test.tsx
+++ b/packages/strapi-design-system/src/Tag/__tests__/Tag.test.tsx
@@ -19,9 +19,9 @@ describe('Tag', () => {
     expect(container.querySelector('svg')).toMatchInlineSnapshot(`
       <svg
         fill="currentColor"
-        height="1.6rem"
+        height="16"
         viewBox="0 0 32 32"
-        width="1.6rem"
+        width="16"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path

--- a/packages/strapi-icons/svgr.icons.config.js
+++ b/packages/strapi-icons/svgr.icons.config.js
@@ -1,7 +1,7 @@
 // https://react-svgr.com/docs/options/
 module.exports = {
   dimensions: true,
-  icon: '1.6rem',
+  icon: 16,
   svgProps: { fill: '{fill}', stroke: '{stroke}' },
   jsxRuntime: 'automatic',
   outDir: './src/icons',

--- a/packages/strapi-icons/svgr.symbols.config.js
+++ b/packages/strapi-icons/svgr.symbols.config.js
@@ -1,7 +1,7 @@
 // https://react-svgr.com/docs/options/
 module.exports = {
   dimensions: true,
-  icon: '1.6rem',
+  icon: 16,
   jsxRuntime: 'automatic',
   outDir: './src/symbols',
   ref: true,

--- a/turbo.json
+++ b/turbo.json
@@ -7,8 +7,8 @@
     },
     "@strapi/icons#build": {
       "dependsOn": ["^build"],
-      "inputs": ["assets/**", ".svgrrc", "src/index.ts"],
-      "outputs": ["dist/**", "src/**"]
+      "inputs": ["assets/**", "src/index.ts", "src/symbols-index.ts", "svgr.*.config.js"],
+      "outputs": ["dist/**", "src/icons/*", "src/symbols/*"]
     },
     "clean": {
       "cache": false,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* icons by default at 16 as a number not in rem.

### Related issue(s)/PR(s)

* resolves #1707 
