### PR TITLE
fix(design-system): codemirror packages that aren't in package.json are declared as external

### DIFF
--- a/.changeset/large-tigers-hope.md
+++ b/.changeset/large-tigers-hope.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+fix(design-system): codemirror packages that aren't in package.json are declared as external

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,6 +161,19 @@ if we're already in pre-release mode, this is fine and you should continue.
 
 We recommend you use [`yalc`](https://github.com/wclr/yalc). If you're working in a monorepo setup (e.g. the Strapi monorepo), then ensure you use the `--pure` option and follow the [advanced guide](https://github.com/wclr/yalc#use-with-yarnpnpm-workspaces). This works a lot better than `yarn link`.
 
+### Example steps
+
+These steps assume you're in the root of the design-system project and on MacOS and adding to the Strapi Monorepo (a normal use case).
+
+```shell
+cd packages/strapi-design-system # this could be icons too if you preferred.
+yalc publish
+cd ../../your-strapi-repo
+yalc add @strapi/design-system --pure
+```
+
+You'll then want to add `.yalc/*` to your workspaces entry in the package.json. You should not commit the changes these steps occur on the target repo (in this case, the Strapi Monorepo).
+
 ### If You've Found a Bug
 
 We are using [GitHub Issues](https://github.com/strapi/design-system/issues) to manage our public bugs. We keep a close

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,35 +159,7 @@ if we're already in pre-release mode, this is fine and you should continue.
 
 ## Linking the design system
 
-### Strapi monorepo
-
-To link the design system to the Strapi monorepo follow the steps outlined in the [contributor documentation](https://contributor.strapi.io/core/admin/link-strapi-design-system)
-
-### React application
-
-In your local copy of the design system run `yarn build` to generate the bundle.
-
-In your application, link your local copy of the design system with [`yarn link`](https://yarnpkg.com/cli/link):
-
-```
-yarn link -r ../<relative-path-to-strapi-design-system>
-```
-
-You can also link a local copy of a specific package. For example, if you want to link the package strapi-design-system, you can run:
-
-```
-yarn link -r ../<relative-path-to-strapi-design-system>/packages/strapi-design-system
-```
-
-You should also remove the webpack alias for `@strapi/design-system` in the Strapi monorepo at `packages/core/admin/webpack.alias.js`
-
-Your application should now be using your local copy of the design system.
-
-To revert back to the released version of the design system use [`yarn unlink`](https://yarnpkg.com/cli/unlink#usage):
-
-```
-yarn unlink ../<relative-path-to-strapi-design-system>
-```
+We recommend you use [`yalc`](https://github.com/wclr/yalc). If you're working in a monorepo setup (e.g. the Strapi monorepo), then ensure you use the `--pure` option and follow the [advanced guide](https://github.com/wclr/yalc#use-with-yarnpnpm-workspaces). This works a lot better than `yarn link`.
 
 ### If You've Found a Bug
 

--- a/packages/strapi-design-system/packup.config.ts
+++ b/packages/strapi-design-system/packup.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from '@strapi/pack-up';
+
+export default defineConfig({
+  externals: ['@codemirror/state', '@codemirror/view'],
+});

--- a/packages/strapi-design-system/src/JSONInput/JSONInput.tsx
+++ b/packages/strapi-design-system/src/JSONInput/JSONInput.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { jsonParseLinter, json } from '@codemirror/lang-json';
-import { ViewUpdate } from '@codemirror/view';
+import type { ViewUpdate } from '@codemirror/view';
 import { useCodeMirror, ReactCodeMirrorRef, ReactCodeMirrorProps } from '@uiw/react-codemirror';
 import styled from 'styled-components';
 

--- a/packages/strapi-design-system/src/JSONInput/utils/decorationExtension.ts
+++ b/packages/strapi-design-system/src/JSONInput/utils/decorationExtension.ts
@@ -1,4 +1,4 @@
-import { StateField, StateEffect, Range } from '@codemirror/state';
+import { StateField, StateEffect, type Range } from '@codemirror/state';
 import { EditorView, Decoration } from '@codemirror/view';
 
 // Effects can be attached to transactions to communicate with the extension


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

* finds the codemirror deps we access but aren't declared in the package.json and make them external to avoid being bundled

### Why is it needed?

* JSON fields crash the strapi app because we load more than one version of codemirror state

### Related issue(s)/PR(s)

* resolves #1706
