### PR TITLE
chore: standardise forwardRefs across components

### DIFF
--- a/.changeset/rotten-eagles-matter.md
+++ b/.changeset/rotten-eagles-matter.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': minor
+---
+
+chore: standardise forwardRefs across components

--- a/packages/design-system/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/design-system/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -21,25 +21,27 @@ export interface BreadcrumbsProps extends FlexProps {
   label?: string;
 }
 
-export const Breadcrumbs = ({ label, children, ...props }: BreadcrumbsProps) => {
-  const childrenArray = React.Children.toArray(children);
+export const Breadcrumbs = React.forwardRef<HTMLDivElement, BreadcrumbsProps>(
+  ({ label, children, ...props }, forwardedRef) => {
+    const childrenArray = React.Children.toArray(children);
 
-  return (
-    <Box aria-label={label} tag="nav" {...props}>
-      <AlignedList tag="ol">
-        {React.Children.map(childrenArray, (child, index) => {
-          const shouldDisplayDivider = childrenArray.length > 1 && index + 1 < childrenArray.length;
+    return (
+      <Box aria-label={label} tag="nav" {...props} ref={forwardedRef}>
+        <AlignedList tag="ol">
+          {React.Children.map(childrenArray, (child, index) => {
+            const shouldDisplayDivider = childrenArray.length > 1 && index + 1 < childrenArray.length;
 
-          return (
-            <Flex inline tag="li">
-              {child}
-              {shouldDisplayDivider && <Divider />}
-            </Flex>
-          );
-        })}
-      </AlignedList>
-    </Box>
-  );
-};
+            return (
+              <Flex inline tag="li">
+                {child}
+                {shouldDisplayDivider && <Divider />}
+              </Flex>
+            );
+          })}
+        </AlignedList>
+      </Box>
+    );
+  },
+);
 
 Breadcrumbs.displayName = 'Breadcrumbs';

--- a/packages/design-system/src/components/Breadcrumbs/Crumb.tsx
+++ b/packages/design-system/src/components/Breadcrumbs/Crumb.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import { Box } from '../Box';
 import { Typography, TypographyProps } from '../Typography';
 
@@ -5,18 +7,20 @@ export interface CrumbProps extends TypographyProps {
   isCurrent?: boolean;
 }
 
-export const Crumb = ({ children, isCurrent = false, ...props }: CrumbProps) => (
-  <Box paddingLeft={2} paddingRight={2} paddingTop={1} paddingBottom={1}>
-    <Typography
-      variant="pi"
-      textColor="neutral800"
-      fontWeight={isCurrent ? 'bold' : 'regular'}
-      aria-current={isCurrent}
-      {...props}
-    >
-      {children}
-    </Typography>
-  </Box>
+export const Crumb = React.forwardRef<HTMLDivElement, CrumbProps>(
+  ({ children, isCurrent = false, ...props }, forwardedRef) => (
+    <Box paddingLeft={2} paddingRight={2} paddingTop={1} paddingBottom={1} ref={forwardedRef}>
+      <Typography
+        variant="pi"
+        textColor="neutral800"
+        fontWeight={isCurrent ? 'bold' : 'regular'}
+        aria-current={isCurrent}
+        {...props}
+      >
+        {children}
+      </Typography>
+    </Box>
+  ),
 );
 
 Crumb.displayName = 'Crumb';

--- a/packages/design-system/src/components/Breadcrumbs/CrumbLink.tsx
+++ b/packages/design-system/src/components/Breadcrumbs/CrumbLink.tsx
@@ -19,6 +19,10 @@ const StyledLink = styled(BaseLink)`
   }
 `;
 
-export const CrumbLink = ({ children, ...props }: BaseLinkProps) => <StyledLink {...props}>{children}</StyledLink>;
+export const CrumbLink = React.forwardRef<HTMLAnchorElement, BaseLinkProps>(({ children, ...props }, forwardedRef) => (
+  <StyledLink ref={forwardedRef} {...props}>
+    {children}
+  </StyledLink>
+));
 
 CrumbLink.displayName = 'CrumbLink';

--- a/packages/design-system/src/components/Breadcrumbs/CrumbSimpleMenu.tsx
+++ b/packages/design-system/src/components/Breadcrumbs/CrumbSimpleMenu.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { styled } from 'styled-components';
 
-import { SimpleMenu, SimpleMenuProps } from '../SimpleMenu';
+import { SimpleMenu, type SimpleMenuProps } from '../SimpleMenu';
 
 const StyledButton = styled(SimpleMenu)`
   padding: ${({ theme }) => `${theme.spaces[1]} ${theme.spaces[2]}`};
@@ -20,10 +20,12 @@ export interface CrumbSimpleMenuProps extends SimpleMenuProps {
   endIcon?: React.ReactNode;
 }
 
-export const CrumbSimpleMenu = ({ children, ...props }: CrumbSimpleMenuProps) => (
-  <StyledButton endIcon={null} size="S" {...props}>
-    {children}
-  </StyledButton>
+export const CrumbSimpleMenu = React.forwardRef<HTMLButtonElement, CrumbSimpleMenuProps>(
+  ({ children, ...props }, forwardedRef) => (
+    <StyledButton ref={forwardedRef} endIcon={null} size="S" {...props}>
+      {children}
+    </StyledButton>
+  ),
 );
 
 CrumbSimpleMenu.displayName = 'CrumbSimpleMenu';

--- a/packages/design-system/src/components/Card/Card.tsx
+++ b/packages/design-system/src/components/Card/Card.tsx
@@ -9,7 +9,7 @@ export interface CardProps extends BoxProps {
   id?: string;
 }
 
-export const Card = ({ id, ...props }: CardProps) => {
+export const Card = React.forwardRef<HTMLDivElement, CardProps>(({ id, ...props }, forwardedRef) => {
   const generatedId = useId(id);
 
   const context = React.useMemo(() => ({ id: generatedId }), [generatedId]);
@@ -17,6 +17,7 @@ export const Card = ({ id, ...props }: CardProps) => {
   return (
     <CardContext.Provider value={context}>
       <Box
+        ref={forwardedRef}
         id={id}
         tabIndex={0}
         hasRadius
@@ -31,4 +32,4 @@ export const Card = ({ id, ...props }: CardProps) => {
       />
     </CardContext.Provider>
   );
-};
+});

--- a/packages/design-system/src/components/Card/CardAction.tsx
+++ b/packages/design-system/src/components/Card/CardAction.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import { styled } from 'styled-components';
 
 import { PropsToTransientProps } from '../../types';
@@ -9,9 +11,9 @@ type CardActionProps = Omit<FlexProps<'div'>, 'direction' | 'gap' | 'position'> 
   position: CardActionPosition;
 };
 
-const CardActionImpl = ({ position, ...restProps }: CardActionProps) => {
-  return <CardAction $position={position} {...restProps} direction="row" gap={2} />;
-};
+const CardActionImpl = React.forwardRef<HTMLDivElement, CardActionProps>(({ position, ...restProps }, forwardedRef) => {
+  return <CardAction ref={forwardedRef} $position={position} {...restProps} direction="row" gap={2} />;
+});
 
 const CardAction = styled<FlexComponent>(Flex)<PropsToTransientProps<CardActionProps>>`
   position: absolute;

--- a/packages/design-system/src/components/Card/CardCheckbox.tsx
+++ b/packages/design-system/src/components/Card/CardCheckbox.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import { Checkbox, CheckboxProps } from '../Checkbox';
 
 import { CardAction } from './CardAction';
@@ -5,15 +7,15 @@ import { useCard } from './CardContext';
 
 interface CardCheckboxProps extends CheckboxProps {}
 
-const CardCheckbox = (props: CardCheckboxProps) => {
+const CardCheckbox = React.forwardRef<HTMLButtonElement, CardCheckboxProps>((props, forwardedRef) => {
   const { id } = useCard();
 
   return (
     <CardAction position="start">
-      <Checkbox aria-labelledby={`${id}-title`} {...props} />
+      <Checkbox aria-labelledby={`${id}-title`} {...props} ref={forwardedRef} />
     </CardAction>
   );
-};
+});
 
 export { CardCheckbox };
 export type { CardCheckboxProps };

--- a/packages/design-system/src/components/EmptyStateLayout/EmptyStateLayout.tsx
+++ b/packages/design-system/src/components/EmptyStateLayout/EmptyStateLayout.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import { styled } from 'styled-components';
 
 import { Box, BoxComponent } from '../Box';
@@ -16,35 +18,32 @@ const EmptyStateIconWrapper = styled<BoxComponent>(Box)`
   }
 `;
 
-export const EmptyStateLayout = ({
-  icon,
-  content,
-  action,
-  hasRadius = true,
-  shadow = 'tableShadow',
-}: EmptyStateLayoutProps) => {
-  return (
-    <Flex
-      alignItems="center"
-      direction="column"
-      padding={11}
-      background="neutral0"
-      hasRadius={hasRadius}
-      shadow={shadow}
-    >
-      {icon ? (
-        <EmptyStateIconWrapper paddingBottom={6} aria-hidden>
-          {icon}
-        </EmptyStateIconWrapper>
-      ) : null}
+export const EmptyStateLayout = React.forwardRef<HTMLDivElement, EmptyStateLayoutProps>(
+  ({ icon, content, action, hasRadius = true, shadow = 'tableShadow' }: EmptyStateLayoutProps, forwardedRef) => {
+    return (
+      <Flex
+        ref={forwardedRef}
+        alignItems="center"
+        direction="column"
+        padding={11}
+        background="neutral0"
+        hasRadius={hasRadius}
+        shadow={shadow}
+      >
+        {icon ? (
+          <EmptyStateIconWrapper paddingBottom={6} aria-hidden>
+            {icon}
+          </EmptyStateIconWrapper>
+        ) : null}
 
-      <Box paddingBottom={4}>
-        <Typography variant="delta" tag="p" textAlign="center" textColor="neutral600">
-          {content}
-        </Typography>
-      </Box>
+        <Box paddingBottom={4}>
+          <Typography variant="delta" tag="p" textAlign="center" textColor="neutral600">
+            {content}
+          </Typography>
+        </Box>
 
-      {action}
-    </Flex>
-  );
-};
+        {action}
+      </Flex>
+    );
+  },
+);

--- a/packages/design-system/src/components/Popover/Popover.tsx
+++ b/packages/design-system/src/components/Popover/Popover.tsx
@@ -4,6 +4,7 @@ import * as Popover from '@radix-ui/react-popover';
 import { styled } from 'styled-components';
 
 import { stripReactIdOfColon } from '../../helpers/strings';
+import { useComposedRefs } from '../../hooks/useComposeRefs';
 import { useId } from '../../hooks/useId';
 import { useIntersection } from '../../hooks/useIntersection';
 import { ANIMATIONS } from '../../styles/motion';
@@ -86,24 +87,27 @@ interface ScrollAreaImplProps extends ScrollAreaProps {
   onReachEnd?: (entry: IntersectionObserverEntry) => void;
 }
 
-const ScrollAreaImpl = ({ children, intersectionId, onReachEnd, ...props }: ScrollAreaImplProps) => {
-  const popoverRef = React.useRef<HTMLDivElement>(null!);
+const ScrollAreaImpl = React.forwardRef<HTMLDivElement, ScrollAreaImplProps>(
+  ({ children, intersectionId, onReachEnd, ...props }, forwardedRef) => {
+    const popoverRef = React.useRef<HTMLDivElement>(null!);
+    const composedRef = useComposedRefs(popoverRef, forwardedRef);
 
-  const generatedIntersectionId = useId();
-  useIntersection(popoverRef, onReachEnd ?? (() => {}), {
-    selectorToWatch: `#${stripReactIdOfColon(generatedIntersectionId)}`,
-    skipWhen: !intersectionId || !onReachEnd,
-  });
+    const generatedIntersectionId = useId();
+    useIntersection(popoverRef, onReachEnd ?? (() => {}), {
+      selectorToWatch: `#${stripReactIdOfColon(generatedIntersectionId)}`,
+      skipWhen: !intersectionId || !onReachEnd,
+    });
 
-  return (
-    <PopoverScrollArea ref={popoverRef} {...props}>
-      {children}
-      {intersectionId && onReachEnd && (
-        <Box id={stripReactIdOfColon(generatedIntersectionId)} width="100%" height="1px" />
-      )}
-    </PopoverScrollArea>
-  );
-};
+    return (
+      <PopoverScrollArea ref={composedRef} {...props}>
+        {children}
+        {intersectionId && onReachEnd && (
+          <Box id={stripReactIdOfColon(generatedIntersectionId)} width="100%" height="1px" />
+        )}
+      </PopoverScrollArea>
+    );
+  },
+);
 
 const PopoverScrollArea = styled(ScrollArea)`
   height: 20rem;

--- a/packages/design-system/src/components/RawTable/RawCell.tsx
+++ b/packages/design-system/src/components/RawTable/RawCell.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { getFocusableNodes, getFocusableNodesWithKeyboardNav } from '../../helpers/getFocusableNodes';
 import { KeyboardKeys } from '../../helpers/keyboardKeys';
+import { useComposedRefs } from '../../hooks/useComposeRefs';
 import { useIsomorphicLayoutEffect } from '../../hooks/useIsomorphicLayoutEffect';
 import { Box, BoxProps } from '../Box';
 
@@ -20,162 +21,165 @@ interface RawTdProps extends BoxProps<'td' | 'th'> {
   };
 }
 
-const RawTd = ({ coords = { col: 0, row: 0 }, tag = 'td', ...props }: RawTdProps) => {
-  const tdRef = React.useRef<HTMLTableCellElement>(null!);
-  const { rowIndex, colIndex, setTableValues } = useTable();
-  const [isActive, setIsActive] = React.useState(false);
+const RawTd = React.forwardRef<HTMLTableCellElement, RawTdProps>(
+  ({ coords = { col: 0, row: 0 }, tag = 'td', ...props }, forwardedRef) => {
+    const tdRef = React.useRef<HTMLTableCellElement>(null!);
+    const composedRef = useComposedRefs(forwardedRef, tdRef);
+    const { rowIndex, colIndex, setTableValues } = useTable();
+    const [isActive, setIsActive] = React.useState(false);
 
-  const handleKeyDown: React.KeyboardEventHandler<HTMLTableCellElement> = (e) => {
-    const focusableNodes = getFocusableNodes(tdRef.current, true);
+    const handleKeyDown: React.KeyboardEventHandler<HTMLTableCellElement> = (e) => {
+      const focusableNodes = getFocusableNodes(tdRef.current, true);
 
-    /**
-     * If the cell does not have focusable children or if it has focusable children
-     * without keyboard navigation, we should not run the handler.
-     */
-    if (
-      focusableNodes.length === 0 ||
-      (focusableNodes.length === 1 && getFocusableNodesWithKeyboardNav(focusableNodes).length === 0)
-    ) {
-      return;
       /**
-       * This allows cells that **only** have buttons in them to still be
-       * navigable with the keyboard arrow keys (left / right) as if they were grid cells.
-       *
-       * If there are nextNodes (next child node) then we stop the table's keyboard navigation
-       * handlers from happening.
+       * If the cell does not have focusable children or if it has focusable children
+       * without keyboard navigation, we should not run the handler.
        */
-    }
-    if (focusableNodes.length > 1 && !focusableNodes.find((node) => node.tagName !== 'BUTTON')) {
-      e.preventDefault();
-      const focussedButtonIndex = focusableNodes.findIndex((node) => node === document.activeElement);
-
-      if (e.key === KeyboardKeys.RIGHT) {
-        const nextNode = focusableNodes[focussedButtonIndex + 1];
-
-        if (nextNode) {
-          e.stopPropagation();
-          nextNode.focus();
-        }
-      } else if (e.key === KeyboardKeys.LEFT) {
-        const nextNode = focusableNodes[focussedButtonIndex - 1];
-
-        if (nextNode) {
-          e.stopPropagation();
-          nextNode.focus();
-        }
+      if (
+        focusableNodes.length === 0 ||
+        (focusableNodes.length === 1 && getFocusableNodesWithKeyboardNav(focusableNodes).length === 0)
+      ) {
+        return;
+        /**
+         * This allows cells that **only** have buttons in them to still be
+         * navigable with the keyboard arrow keys (left / right) as if they were grid cells.
+         *
+         * If there are nextNodes (next child node) then we stop the table's keyboard navigation
+         * handlers from happening.
+         */
       }
+      if (focusableNodes.length > 1 && !focusableNodes.find((node) => node.tagName !== 'BUTTON')) {
+        e.preventDefault();
+        const focussedButtonIndex = focusableNodes.findIndex((node) => node === document.activeElement);
 
-      return;
-    }
+        if (e.key === KeyboardKeys.RIGHT) {
+          const nextNode = focusableNodes[focussedButtonIndex + 1];
 
-    const isEnterKey = e.key === KeyboardKeys.ENTER;
+          if (nextNode) {
+            e.stopPropagation();
+            nextNode.focus();
+          }
+        } else if (e.key === KeyboardKeys.LEFT) {
+          const nextNode = focusableNodes[focussedButtonIndex - 1];
 
-    if (isEnterKey && !isActive) {
-      setIsActive(true);
-      /**
-       * Cells should be "escapeable" with the escape key or enter key
-       */
-    } else if ((e.key === KeyboardKeys.ESCAPE || isEnterKey) && isActive) {
-      /**
-       * It's expected behaviour that the cell can't be escaped with `enter` if
-       * the element that is focussed is an anchor tag.
-       */
-      if (isEnterKey && document.activeElement?.tagName === 'A') {
+          if (nextNode) {
+            e.stopPropagation();
+            nextNode.focus();
+          }
+        }
+
         return;
       }
 
-      setIsActive(false);
-      tdRef.current.focus();
-    } else if (isActive) {
-      /**
-       * This stops the table navigation from working
-       */
-      e.stopPropagation();
-    }
-  };
+      const isEnterKey = e.key === KeyboardKeys.ENTER;
 
-  const isFocused = rowIndex === coords.row - 1 && colIndex === coords.col - 1;
-
-  /**
-   * Handles tabindex of the rendered cell element
-   */
-  useIsomorphicLayoutEffect(() => {
-    const focusableNodes = getFocusableNodes(tdRef.current, true);
-
-    /**
-     * We should focus the cell if there are no focussable children inside
-     * If there is only one focusable child and it has it's own keyboard navigation
-     * Or if there is more than one focusable child unless those children
-     * are exclusively buttons.
-     */
-    if (
-      focusableNodes.length === 0 ||
-      (focusableNodes.length === 1 && getFocusableNodesWithKeyboardNav(focusableNodes).length !== 0) ||
-      (focusableNodes.length > 1 && Boolean(focusableNodes.find((node) => node.tagName !== 'BUTTON')))
-    ) {
-      tdRef.current.setAttribute('tabIndex', !isActive && isFocused ? '0' : '-1');
-
-      focusableNodes.forEach((node, index) => {
-        node.setAttribute('tabIndex', isActive ? '0' : '-1');
-
+      if (isEnterKey && !isActive) {
+        setIsActive(true);
         /**
-         * When a cell is active we want to focus the
-         * first focusable element simulating a focus trap
+         * Cells should be "escapeable" with the escape key or enter key
          */
-        if (isActive && index === 0) {
-          node.focus();
+      } else if ((e.key === KeyboardKeys.ESCAPE || isEnterKey) && isActive) {
+        /**
+         * It's expected behaviour that the cell can't be escaped with `enter` if
+         * the element that is focussed is an anchor tag.
+         */
+        if (isEnterKey && document.activeElement?.tagName === 'A') {
+          return;
         }
-      });
-    } else {
-      focusableNodes.forEach((node) => {
-        node.setAttribute('tabIndex', isFocused ? '0' : '-1');
-      });
-    }
-  }, [isActive, isFocused]);
 
-  const handleFocusableNodeFocus = React.useCallback(() => {
-    const focusableNodes = getFocusableNodes(tdRef.current, true);
-
-    /**
-     * If there's 1 or more focusable children and at least one has keyboard navigation
-     * or the children are exclusively button elements the cell should be using the "active" system
-     */
-    if (
-      focusableNodes.length >= 1 &&
-      (getFocusableNodesWithKeyboardNav(focusableNodes).length !== 0 ||
-        !focusableNodes.find((node) => node.tagName !== 'BUTTON'))
-    ) {
-      setIsActive(true);
-    }
-    /**
-     * This function is wrapped in `useCallback` so we can safely
-     * assume that the reference will not change
-     */
-    setTableValues({ rowIndex: coords.row - 1, colIndex: coords.col - 1 });
-  }, [coords, setTableValues]);
-
-  /**
-   * This handles the case where you click on a focusable
-   * node that has it's own keyboard nav (e.g. Input)
-   */
-  useIsomorphicLayoutEffect(() => {
-    const cell = tdRef.current;
-    const focusableNodes = getFocusableNodes(cell, true);
-
-    focusableNodes.forEach((node) => {
-      node.addEventListener('focus', handleFocusableNodeFocus);
-    });
-
-    return () => {
-      const focusableNodes = getFocusableNodes(cell, true);
-      focusableNodes.forEach((node) => {
-        node.removeEventListener('focus', handleFocusableNodeFocus);
-      });
+        setIsActive(false);
+        tdRef.current.focus();
+      } else if (isActive) {
+        /**
+         * This stops the table navigation from working
+         */
+        e.stopPropagation();
+      }
     };
-  }, [handleFocusableNodeFocus]);
 
-  return <Box role="gridcell" tag={tag} ref={tdRef} onKeyDown={handleKeyDown} {...props} />;
-};
+    const isFocused = rowIndex === coords.row - 1 && colIndex === coords.col - 1;
+
+    /**
+     * Handles tabindex of the rendered cell element
+     */
+    useIsomorphicLayoutEffect(() => {
+      const focusableNodes = getFocusableNodes(tdRef.current, true);
+
+      /**
+       * We should focus the cell if there are no focussable children inside
+       * If there is only one focusable child and it has it's own keyboard navigation
+       * Or if there is more than one focusable child unless those children
+       * are exclusively buttons.
+       */
+      if (
+        focusableNodes.length === 0 ||
+        (focusableNodes.length === 1 && getFocusableNodesWithKeyboardNav(focusableNodes).length !== 0) ||
+        (focusableNodes.length > 1 && Boolean(focusableNodes.find((node) => node.tagName !== 'BUTTON')))
+      ) {
+        tdRef.current.setAttribute('tabIndex', !isActive && isFocused ? '0' : '-1');
+
+        focusableNodes.forEach((node, index) => {
+          node.setAttribute('tabIndex', isActive ? '0' : '-1');
+
+          /**
+           * When a cell is active we want to focus the
+           * first focusable element simulating a focus trap
+           */
+          if (isActive && index === 0) {
+            node.focus();
+          }
+        });
+      } else {
+        focusableNodes.forEach((node) => {
+          node.setAttribute('tabIndex', isFocused ? '0' : '-1');
+        });
+      }
+    }, [isActive, isFocused]);
+
+    const handleFocusableNodeFocus = React.useCallback(() => {
+      const focusableNodes = getFocusableNodes(tdRef.current, true);
+
+      /**
+       * If there's 1 or more focusable children and at least one has keyboard navigation
+       * or the children are exclusively button elements the cell should be using the "active" system
+       */
+      if (
+        focusableNodes.length >= 1 &&
+        (getFocusableNodesWithKeyboardNav(focusableNodes).length !== 0 ||
+          !focusableNodes.find((node) => node.tagName !== 'BUTTON'))
+      ) {
+        setIsActive(true);
+      }
+      /**
+       * This function is wrapped in `useCallback` so we can safely
+       * assume that the reference will not change
+       */
+      setTableValues({ rowIndex: coords.row - 1, colIndex: coords.col - 1 });
+    }, [coords, setTableValues]);
+
+    /**
+     * This handles the case where you click on a focusable
+     * node that has it's own keyboard nav (e.g. Input)
+     */
+    useIsomorphicLayoutEffect(() => {
+      const cell = tdRef.current;
+      const focusableNodes = getFocusableNodes(cell, true);
+
+      focusableNodes.forEach((node) => {
+        node.addEventListener('focus', handleFocusableNodeFocus);
+      });
+
+      return () => {
+        const focusableNodes = getFocusableNodes(cell, true);
+        focusableNodes.forEach((node) => {
+          node.removeEventListener('focus', handleFocusableNodeFocus);
+        });
+      };
+    }, [handleFocusableNodeFocus]);
+
+    return <Box role="gridcell" tag={tag} ref={composedRef} onKeyDown={handleKeyDown} {...props} />;
+  },
+);
 
 /* -------------------------------------------------------------------------------------------------
  * RawTh

--- a/packages/design-system/src/components/RawTable/RawTable.tsx
+++ b/packages/design-system/src/components/RawTable/RawTable.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { KeyboardKeys } from '../../helpers/keyboardKeys';
+import { useComposedRefs } from '../../hooks/useComposeRefs';
 
 import { focusFocusable } from './focusFocusable';
 import { RawTableContext } from './RawTableContext';
@@ -13,124 +14,120 @@ export interface RawTableProps extends React.TableHTMLAttributes<HTMLTableElemen
   rowCount: number;
 }
 
-export const RawTable = ({
-  colCount,
-  rowCount,
-  jumpStep = 3,
-  initialCol = 0,
-  initialRow = 0,
-  ...props
-}: RawTableProps) => {
-  const tableRef = React.useRef(null);
-  const mountedRef = React.useRef(false);
-  /**
-   * Rows will always have n+1 line because of the <tr><th></th></tr> elements
-   */
-  const [rowIndex, setRowIndex] = React.useState(initialRow);
-  const [colIndex, setColIndex] = React.useState(initialCol);
+export const RawTable = React.forwardRef<HTMLTableElement, RawTableProps>(
+  ({ colCount, rowCount, jumpStep = 3, initialCol = 0, initialRow = 0, ...props }, forwardedRef) => {
+    const tableRef = React.useRef<HTMLTableElement>(null);
+    const mountedRef = React.useRef(false);
+    const composedRef = useComposedRefs(tableRef, forwardedRef);
+    /**
+     * Rows will always have n+1 line because of the <tr><th></th></tr> elements
+     */
+    const [rowIndex, setRowIndex] = React.useState(initialRow);
+    const [colIndex, setColIndex] = React.useState(initialCol);
 
-  const setTableValues = React.useCallback(({ colIndex, rowIndex }) => {
-    setColIndex(colIndex);
-    setRowIndex(rowIndex);
-  }, []);
+    const setTableValues = React.useCallback(({ colIndex, rowIndex }) => {
+      setColIndex(colIndex);
+      setRowIndex(rowIndex);
+    }, []);
 
-  React.useEffect(() => {
-    if (mountedRef.current) {
-      focusFocusable(tableRef.current);
-    }
-
-    if (!mountedRef.current) {
-      mountedRef.current = true;
-    }
-  }, [colIndex, rowIndex]);
-
-  const handleKeyDown = (e) => {
-    switch (e.key) {
-      case KeyboardKeys.RIGHT: {
-        e.preventDefault();
-        setColIndex((prevColIndex) => (prevColIndex < colCount - 1 ? prevColIndex + 1 : prevColIndex));
-
-        break;
+    React.useEffect(() => {
+      if (mountedRef.current) {
+        focusFocusable(tableRef.current);
       }
 
-      case KeyboardKeys.LEFT: {
-        e.preventDefault();
-        setColIndex((prevColIndex) => (prevColIndex > 0 ? prevColIndex - 1 : prevColIndex));
-
-        break;
+      if (!mountedRef.current) {
+        mountedRef.current = true;
       }
+    }, [colIndex, rowIndex]);
 
-      case KeyboardKeys.UP: {
-        e.preventDefault();
-        setRowIndex((prevRowIndex) => (prevRowIndex > 0 ? prevRowIndex - 1 : prevRowIndex));
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLTableElement>) => {
+      switch (e.key) {
+        case KeyboardKeys.RIGHT: {
+          e.preventDefault();
+          setColIndex((prevColIndex) => (prevColIndex < colCount - 1 ? prevColIndex + 1 : prevColIndex));
 
-        break;
-      }
-
-      case KeyboardKeys.DOWN: {
-        e.preventDefault();
-        setRowIndex((prevRowIndex) => (prevRowIndex < rowCount - 1 ? prevRowIndex + 1 : prevRowIndex));
-
-        break;
-      }
-
-      case KeyboardKeys.HOME: {
-        e.preventDefault();
-
-        if (e.ctrlKey) {
-          setRowIndex(0);
+          break;
         }
 
-        setColIndex(0);
+        case KeyboardKeys.LEFT: {
+          e.preventDefault();
+          setColIndex((prevColIndex) => (prevColIndex > 0 ? prevColIndex - 1 : prevColIndex));
 
-        break;
-      }
-
-      case KeyboardKeys.END: {
-        e.preventDefault();
-
-        if (e.ctrlKey) {
-          setRowIndex(rowCount - 1);
+          break;
         }
 
-        setColIndex(colCount - 1);
+        case KeyboardKeys.UP: {
+          e.preventDefault();
+          setRowIndex((prevRowIndex) => (prevRowIndex > 0 ? prevRowIndex - 1 : prevRowIndex));
 
-        break;
+          break;
+        }
+
+        case KeyboardKeys.DOWN: {
+          e.preventDefault();
+          setRowIndex((prevRowIndex) => (prevRowIndex < rowCount - 1 ? prevRowIndex + 1 : prevRowIndex));
+
+          break;
+        }
+
+        case KeyboardKeys.HOME: {
+          e.preventDefault();
+
+          if (e.ctrlKey) {
+            setRowIndex(0);
+          }
+
+          setColIndex(0);
+
+          break;
+        }
+
+        case KeyboardKeys.END: {
+          e.preventDefault();
+
+          if (e.ctrlKey) {
+            setRowIndex(rowCount - 1);
+          }
+
+          setColIndex(colCount - 1);
+
+          break;
+        }
+
+        case KeyboardKeys.PAGE_DOWN: {
+          e.preventDefault();
+
+          setRowIndex((prevRowIndex) => (prevRowIndex + jumpStep < rowCount ? prevRowIndex + jumpStep : rowCount - 1));
+
+          break;
+        }
+
+        case KeyboardKeys.PAGE_UP: {
+          e.preventDefault();
+
+          setRowIndex((prevRowIndex) => (prevRowIndex - jumpStep > 0 ? prevRowIndex - jumpStep : 0));
+
+          break;
+        }
+
+        default:
+          break;
       }
+    };
 
-      case KeyboardKeys.PAGE_DOWN: {
-        e.preventDefault();
+    const context = React.useMemo(() => ({ rowIndex, colIndex, setTableValues }), [colIndex, rowIndex, setTableValues]);
 
-        setRowIndex((prevRowIndex) => (prevRowIndex + jumpStep < rowCount ? prevRowIndex + jumpStep : rowCount - 1));
-
-        break;
-      }
-
-      case KeyboardKeys.PAGE_UP: {
-        e.preventDefault();
-
-        setRowIndex((prevRowIndex) => (prevRowIndex - jumpStep > 0 ? prevRowIndex - jumpStep : 0));
-
-        break;
-      }
-
-      default:
-        break;
-    }
-  };
-
-  const context = React.useMemo(() => ({ rowIndex, colIndex, setTableValues }), [colIndex, rowIndex, setTableValues]);
-
-  return (
-    <RawTableContext.Provider value={context}>
-      <table
-        role="grid"
-        ref={tableRef}
-        aria-rowcount={rowCount}
-        aria-colcount={colCount}
-        onKeyDown={handleKeyDown}
-        {...props}
-      />
-    </RawTableContext.Provider>
-  );
-};
+    return (
+      <RawTableContext.Provider value={context}>
+        <table
+          role="grid"
+          ref={composedRef}
+          aria-rowcount={rowCount}
+          aria-colcount={colCount}
+          onKeyDown={handleKeyDown}
+          {...props}
+        />
+      </RawTableContext.Provider>
+    );
+  },
+);

--- a/packages/design-system/src/components/SimpleMenu/SimpleMenu.tsx
+++ b/packages/design-system/src/components/SimpleMenu/SimpleMenu.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { stripReactIdOfColon } from '../../helpers/strings';
+import { useComposedRefs } from '../../hooks/useComposeRefs';
 import { useId } from '../../hooks/useId';
 import { useIntersection } from '../../hooks/useIntersection';
 
@@ -23,51 +24,57 @@ interface SimpleMenuProps
   onReachEnd?: (entry: IntersectionObserverEntry) => void;
 }
 
-const SimpleMenu = ({ children, onOpen, onClose, popoverPlacement, onReachEnd, ...props }: SimpleMenuProps) => {
-  /**
-   * Used for the intersection observer
-   */
-  const contentRef = React.useRef<HTMLDivElement>(null);
-
-  const [internalIsOpen, setInternalIsOpen] = React.useState(false);
-
-  const handleReachEnd = (entry: IntersectionObserverEntry) => {
-    if (onReachEnd) {
-      onReachEnd(entry);
-    }
-  };
-
-  const handleOpenChange = (isOpen: boolean) => {
-    if (isOpen && typeof onOpen === 'function') {
-      onOpen();
-    } else if (!isOpen && typeof onClose === 'function') {
-      onClose();
-    }
-
-    setInternalIsOpen(isOpen);
-  };
-
-  const generatedId = useId();
-  const intersectionId = `intersection-${stripReactIdOfColon(generatedId)}`;
-
-  useIntersection(contentRef, handleReachEnd, {
-    selectorToWatch: `#${intersectionId}`,
+const SimpleMenu = React.forwardRef<HTMLButtonElement, SimpleMenuProps>(
+  ({ children, onOpen, onClose, popoverPlacement, onReachEnd, ...props }, forwardedRef) => {
+    const triggerRef = React.useRef<HTMLButtonElement>(null);
+    const composedRef = useComposedRefs(forwardedRef, triggerRef);
     /**
-     * We need to know when the select is open because only then will viewportRef
-     * not be null. Because it uses a portal that (sensibly) is not mounted 24/7.
+     * Used for the intersection observer
      */
-    skipWhen: !internalIsOpen,
-  });
+    const contentRef = React.useRef<HTMLDivElement>(null);
 
-  return (
-    <Menu.Root onOpenChange={handleOpenChange}>
-      <Menu.Trigger {...props}>{props.label}</Menu.Trigger>
-      <Menu.Content intersectionId={intersectionId} popoverPlacement={popoverPlacement}>
-        {children}
-      </Menu.Content>
-    </Menu.Root>
-  );
-};
+    const [internalIsOpen, setInternalIsOpen] = React.useState(false);
+
+    const handleReachEnd = (entry: IntersectionObserverEntry) => {
+      if (onReachEnd) {
+        onReachEnd(entry);
+      }
+    };
+
+    const handleOpenChange = (isOpen: boolean) => {
+      if (isOpen && typeof onOpen === 'function') {
+        onOpen();
+      } else if (!isOpen && typeof onClose === 'function') {
+        onClose();
+      }
+
+      setInternalIsOpen(isOpen);
+    };
+
+    const generatedId = useId();
+    const intersectionId = `intersection-${stripReactIdOfColon(generatedId)}`;
+
+    useIntersection(contentRef, handleReachEnd, {
+      selectorToWatch: `#${intersectionId}`,
+      /**
+       * We need to know when the select is open because only then will viewportRef
+       * not be null. Because it uses a portal that (sensibly) is not mounted 24/7.
+       */
+      skipWhen: !internalIsOpen,
+    });
+
+    return (
+      <Menu.Root onOpenChange={handleOpenChange}>
+        <Menu.Trigger ref={composedRef} {...props}>
+          {props.label}
+        </Menu.Trigger>
+        <Menu.Content ref={contentRef} intersectionId={intersectionId} popoverPlacement={popoverPlacement}>
+          {children}
+        </Menu.Content>
+      </Menu.Root>
+    );
+  },
+);
 
 const MenuItem = Menu.Item;
 type MenuItemProps = Menu.ItemProps;

--- a/packages/design-system/src/components/Table/Cell.tsx
+++ b/packages/design-system/src/components/Table/Cell.tsx
@@ -26,21 +26,21 @@ export interface ThProps extends RawTdProps {
   action?: React.ReactNode;
 }
 
-export const Th = ({ children, action, ...props }: ThProps) => {
+export const Th = React.forwardRef<HTMLTableCellElement, ThProps>(({ children, action, ...props }, forwardedRef) => {
   return (
-    <CellWrapper color="neutral600" as={RawTh} {...props}>
+    <CellWrapper color="neutral600" as={RawTh} ref={forwardedRef} {...props}>
       <Flex>
         {children}
         {action}
       </Flex>
     </CellWrapper>
   );
-};
+});
 
-export const Td = ({ children, ...props }: RawTdProps) => {
+export const Td = React.forwardRef<HTMLTableCellElement, RawTdProps>(({ children, ...props }, forwardedRef) => {
   return (
-    <CellWrapper color="neutral800" {...props}>
+    <CellWrapper color="neutral800" ref={forwardedRef} {...props}>
       {children}
     </CellWrapper>
   );
-};
+});

--- a/packages/design-system/src/components/Table/Table.tsx
+++ b/packages/design-system/src/components/Table/Table.tsx
@@ -52,7 +52,7 @@ export interface TableProps extends RawTableProps {
   footer?: React.ReactNode;
 }
 
-export const Table = ({ footer, ...props }: TableProps) => {
+export const Table = React.forwardRef<HTMLTableElement, TableProps>(({ footer, ...props }, forwardedRef) => {
   const tableRef = React.useRef<HTMLDivElement>(null!);
   const [overflowing, setOverflowing] = React.useState<Overflowing>();
 
@@ -86,10 +86,10 @@ export const Table = ({ footer, ...props }: TableProps) => {
     <TableContainer shadow="tableShadow" hasRadius background="neutral0">
       <TableBox $overflowing={overflowing} position="relative">
         <ScrollContainer ref={tableRef} onScroll={handleScroll} paddingLeft={6} paddingRight={6}>
-          <TableWrapper {...props} />
+          <TableWrapper ref={forwardedRef} {...props} />
         </ScrollContainer>
       </TableBox>
       {footer}
     </TableContainer>
   );
-};
+});


### PR DESCRIPTION
### What does it do?

Standardising forwardRefs across components, so added forward refs to interactive and actionable components.

### Why is it needed?

Currently, a lot of components don’t have forwardRef some do, and it applies to the input field of that component, some edge cases use imperativeHandle e.g. TextInput, realistically we should add forwardRef to all the components in some capacity, [Ref](https://strapi-inc.atlassian.net/browse/DX-1182).
