### PR TITLE
fix: filters shouldn't be removed after clicking on filter tag

### DIFF
--- a/.changeset/swift-cycles-type.md
+++ b/.changeset/swift-cycles-type.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+fix: add click action on tag icon instead of on tag itself

--- a/docs/stories/Tag.mdx
+++ b/docs/stories/Tag.mdx
@@ -31,7 +31,15 @@ or removed from that place. They cannot exist on their own.
 
 <Canvas of={TagStories.Base} />
 
+### Disabled Tag
+
 <Canvas of={TagStories.Disabled} />
+
+### Filter Tag
+
+Tag can also be used as a filter with action to remove the filter
+
+<Canvas of={TagStories.Filter} />
 
 ## Props
 

--- a/docs/stories/Tag.stories.tsx
+++ b/docs/stories/Tag.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { Tag } from '@strapi/design-system';
-import { Information } from '@strapi/icons';
+import { Information, Cross } from '@strapi/icons';
 
 const meta: Meta<typeof Tag> = {
   title: 'Design System/Components/Tag',
@@ -23,4 +23,13 @@ export const Disabled = {
     </Tag>
   ),
   name: 'disabled',
+} satisfies Story;
+
+export const Filter = {
+  render: () => (
+    <Tag label="remove filter" icon={<Cross aria-hidden />} onClick={() => console.log('filter removed')}>
+      date is null
+    </Tag>
+  ),
+  name: 'filter',
 } satisfies Story;

--- a/packages/design-system/src/components/Tag/Tag.test.tsx
+++ b/packages/design-system/src/components/Tag/Tag.test.tsx
@@ -14,7 +14,7 @@ describe('Tag', () => {
   it('should render the children and icon as expected', () => {
     const { getByRole, container } = render();
 
-    expect(getByRole('button', { name: 'hello' })).toBeInTheDocument();
+    expect(getByRole('button')).toBeInTheDocument();
 
     // eslint-disable-next-line testing-library/no-container
     expect(container.querySelector('svg')).toMatchInlineSnapshot(`
@@ -44,12 +44,11 @@ describe('Tag', () => {
 
   it('should handle the disabled prop correctly', async () => {
     const onClick = jest.fn();
-    const { getByRole, user } = render({ disabled: true, onClick });
+    const { getByRole, getByLabelText, user } = render({ disabled: true, onClick, label: 'Clear' });
 
-    expect(getByRole('button', { name: 'hello' })).toBeDisabled();
-    expect(getByRole('button', { name: 'hello' })).toHaveAttribute('aria-disabled', 'true');
+    expect(getByRole('button')).toBeDisabled();
 
-    await user.click(getByRole('button', { name: 'hello' }));
+    await user.click(getByLabelText('Clear'));
 
     expect(onClick).not.toHaveBeenCalled();
   });

--- a/packages/design-system/src/components/Tag/Tag.test.tsx
+++ b/packages/design-system/src/components/Tag/Tag.test.tsx
@@ -35,9 +35,9 @@ describe('Tag', () => {
   it('should fire the onClick callback', async () => {
     const onClick = jest.fn();
 
-    const { getByRole, user } = render({ onClick });
+    const { getByLabelText, user } = render({ onClick, label: 'Clear' });
 
-    await user.click(getByRole('button', { name: 'hello' }));
+    await user.click(getByLabelText('Clear'));
 
     expect(onClick).toHaveBeenCalledTimes(1);
   });

--- a/packages/design-system/src/components/Tag/Tag.tsx
+++ b/packages/design-system/src/components/Tag/Tag.tsx
@@ -3,21 +3,32 @@ import * as React from 'react';
 import { styled } from 'styled-components';
 
 import { Box, type BoxComponent } from '../Box';
-import { Flex, FlexComponent, FlexProps } from '../Flex';
+import { Flex, FlexProps } from '../Flex';
 import { Typography, TypographyComponent } from '../Typography';
 
 const ButtonBox = styled<BoxComponent<'button'>>(Box)<{ $iconAction: boolean }>`
   display: inline-flex;
   border: none;
 
+  & > svg {
+    height: 0.8rem;
+    width: 0.8rem;
+  }
+
+  & > svg path {
+    fill: ${({ theme, ...p }) => (p['aria-disabled'] ? theme.colors.neutral600 : theme.colors.primary600)};
+  }
+
   &:hover {
     cursor: ${({ $iconAction }) => ($iconAction ? 'pointer' : 'initial')};
   }
 `;
 
-export interface TagProps extends FlexProps<'button'> {
+export interface TagProps extends Omit<FlexProps, 'onClick'> {
   icon: React.ReactNode;
   label?: string;
+  disabled?: boolean;
+  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
 export const Tag = ({ children, icon, label, disabled = false, onClick, ...props }: TagProps) => {
@@ -27,16 +38,12 @@ export const Tag = ({ children, icon, label, disabled = false, onClick, ...props
   };
 
   return (
-    <TagWrapper
-      tag="button"
+    <Flex
+      inline
       background={disabled ? 'neutral200' : 'primary100'}
       color={disabled ? 'neutral700' : 'primary600'}
       paddingLeft={3}
       paddingRight={1}
-      aria-disabled={disabled}
-      disabled={disabled}
-      borderWidth="1px"
-      borderStyle="solid"
       borderColor={disabled ? 'neutral300' : 'primary200'}
       hasRadius
       height="3.2rem"
@@ -45,23 +52,19 @@ export const Tag = ({ children, icon, label, disabled = false, onClick, ...props
       <TagText $disabled={disabled} variant="pi" fontWeight="bold">
         {children}
       </TagText>
-      <ButtonBox aria-label={label} padding={2} onClick={handleClick} $iconAction={!!onClick}>
+      <ButtonBox
+        tag="button"
+        disabled={disabled}
+        aria-label={label}
+        padding={2}
+        onClick={handleClick}
+        $iconAction={!!onClick}
+      >
         {icon}
       </ButtonBox>
-    </TagWrapper>
+    </Flex>
   );
 };
-
-const TagWrapper = styled<FlexComponent<'button'>>(Flex)`
-  & > div > svg {
-    height: 0.8rem;
-    width: 0.8rem;
-  }
-
-  & > svg path {
-    fill: ${({ theme, ...p }) => (p['aria-disabled'] ? theme.colors.neutral600 : theme.colors.primary600)};
-  }
-`;
 
 const TagText = styled<TypographyComponent>(Typography)<{ $disabled: boolean }>`
   color: inherit;

--- a/packages/design-system/src/components/Tag/Tag.tsx
+++ b/packages/design-system/src/components/Tag/Tag.tsx
@@ -28,7 +28,7 @@ export interface TagProps extends Omit<FlexProps, 'onClick'> {
   icon: React.ReactNode;
   label?: string;
   disabled?: boolean;
-  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
 export const Tag = ({ children, icon, label, disabled = false, onClick, ...props }: TagProps) => {

--- a/packages/design-system/src/components/Tag/Tag.tsx
+++ b/packages/design-system/src/components/Tag/Tag.tsx
@@ -2,14 +2,25 @@ import * as React from 'react';
 
 import { styled } from 'styled-components';
 
+import { Box, type BoxComponent } from '../Box';
 import { Flex, FlexComponent, FlexProps } from '../Flex';
 import { Typography, TypographyComponent } from '../Typography';
 
+const ButtonBox = styled<BoxComponent<'button'>>(Box)<{ $iconAction: boolean }>`
+  display: inline-flex;
+  border: none;
+
+  &:hover {
+    cursor: ${({ $iconAction }) => ($iconAction ? 'pointer' : 'initial')};
+  }
+`;
+
 export interface TagProps extends FlexProps<'button'> {
   icon: React.ReactNode;
+  label?: string;
 }
 
-export const Tag = ({ children, icon, disabled = false, onClick, ...props }: TagProps) => {
+export const Tag = ({ children, icon, label, disabled = false, onClick, ...props }: TagProps) => {
   const handleClick: React.MouseEventHandler<HTMLButtonElement> = (e) => {
     if (disabled || !onClick) return;
     onClick(e);
@@ -21,8 +32,7 @@ export const Tag = ({ children, icon, disabled = false, onClick, ...props }: Tag
       background={disabled ? 'neutral200' : 'primary100'}
       color={disabled ? 'neutral700' : 'primary600'}
       paddingLeft={3}
-      paddingRight={3}
-      onClick={handleClick}
+      paddingRight={1}
       aria-disabled={disabled}
       disabled={disabled}
       borderWidth="1px"
@@ -30,19 +40,20 @@ export const Tag = ({ children, icon, disabled = false, onClick, ...props }: Tag
       borderColor={disabled ? 'neutral300' : 'primary200'}
       hasRadius
       height="3.2rem"
-      gap={2}
       {...props}
     >
       <TagText $disabled={disabled} variant="pi" fontWeight="bold">
         {children}
       </TagText>
-      {icon}
+      <ButtonBox aria-label={label} padding={2} onClick={handleClick} $iconAction={!!onClick}>
+        {icon}
+      </ButtonBox>
     </TagWrapper>
   );
 };
 
 const TagWrapper = styled<FlexComponent<'button'>>(Flex)`
-  & > svg {
+  & > div > svg {
     height: 0.8rem;
     width: 0.8rem;
   }

--- a/packages/design-system/src/components/Tag/Tag.tsx
+++ b/packages/design-system/src/components/Tag/Tag.tsx
@@ -55,6 +55,7 @@ export const Tag = ({ children, icon, label, disabled = false, onClick, ...props
       <ButtonBox
         tag="button"
         disabled={disabled}
+        aria-disabled={disabled}
         aria-label={label}
         padding={2}
         onClick={handleClick}


### PR DESCRIPTION
### What does it do?

Filter click action passed on icon instead of tag itself, adjusted styles to show cursor pointer on hover

### Why is it needed?

filters shouldn't be removed after clicking on filter tag

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/design-system/issues/679
