### PR TITLE
fix: typography hover style

### DIFF
--- a/.changeset/few-cameras-joke.md
+++ b/.changeset/few-cameras-joke.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+Fixed: Link doesn't show the hover color

--- a/packages/design-system/src/components/Link/Link.tsx
+++ b/packages/design-system/src/components/Link/Link.tsx
@@ -52,7 +52,9 @@ const LinkWrapper = styled<BaseLinkComponent>(BaseLink)`
   }
 
   &:hover {
-    color: ${({ theme }) => theme.colors.primary500};
+    span {
+      color: ${({ theme }) => theme.colors.primary500};
+    }
   }
 
   &:active {


### PR DESCRIPTION
### What does it do?

Fixed: Link doesn't show the hover color

### Related issue(s)/PR(s)

fixes https://github.com/strapi/design-system/issues/1525
