### PR TITLE
fix: add gap inside SubNavHeader

### DIFF
--- a/.changeset/six-pans-sip.md
+++ b/.changeset/six-pans-sip.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+fixed SubNavHeader not applying space between label and search icon

--- a/packages/design-system/src/components/SubNav/SubNavHeader.tsx
+++ b/packages/design-system/src/components/SubNav/SubNavHeader.tsx
@@ -103,7 +103,7 @@ export const SubNavHeader = ({
 
   return (
     <Flex direction="column" alignItems="flex-start" paddingLeft={6} paddingTop={6} paddingBottom={2} paddingRight={4}>
-      <Flex justifyContent="space-between" alignItems="flex-start">
+      <Flex justifyContent="space-between" alignItems="flex-start" width="100%" gap={2}>
         <Typography variant="beta" tag={tag}>
           {label}
         </Typography>


### PR DESCRIPTION
### What does it do?

Adds a gap between the SubNavHeader label and search icon



### Why is it needed?

Because it looked like this:
<img width="293" alt="CleanShot 2024-06-25 at 16 46 39@2x" src="https://github.com/strapi/design-system/assets/8087692/7d8ad6fa-c3cf-4ad3-875c-56cab40031d8">

The space-between was ignored because the element itself was shrunk by the parent flex, and there was no gap defined
