### PR TITLE
fix: move the Modal Content inside the Overlay component and change the background rule of the Overlay

### DIFF
--- a/.changeset/short-pets-attack.md
+++ b/.changeset/short-pets-attack.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': minor
+---
+
+fixed Modal Content scroll issues

--- a/.changeset/short-pets-attack.md
+++ b/.changeset/short-pets-attack.md
@@ -1,5 +1,5 @@
 ---
-'@strapi/design-system': minor
+'@strapi/design-system': patch
 ---
 
 fixed Modal Content scroll issues

--- a/packages/design-system/src/components/Modal/Modal.tsx
+++ b/packages/design-system/src/components/Modal/Modal.tsx
@@ -4,6 +4,7 @@ import * as Dialog from '@radix-ui/react-dialog';
 import { Cross } from '@strapi/icons';
 import { styled } from 'styled-components';
 
+import { setOpacity } from '../../helpers/setOpacity';
 import { ANIMATIONS } from '../../styles/motion';
 import { ScrollArea, ScrollAreaProps } from '../../utilities/ScrollArea';
 import { Flex, type FlexComponent, type FlexProps } from '../Flex';
@@ -41,18 +42,18 @@ interface ContentProps extends Dialog.DialogContentProps {}
 const Content = React.forwardRef<ContentElement, ContentProps>((props, forwardedRef) => {
   return (
     <Dialog.Portal>
-      <Overlay />
-      <ContentImpl ref={forwardedRef} {...props} />
+      <Overlay>
+        <ContentImpl ref={forwardedRef} {...props} />
+      </Overlay>
     </Dialog.Portal>
   );
 });
 
 const Overlay = styled(Dialog.Overlay)`
-  background-color: ${(props) => props.theme.colors.neutral800};
+  background: ${(props) => setOpacity(props.theme.colors.neutral800, 0.2)};
   position: fixed;
   inset: 0;
   z-index: ${(props) => props.theme.zIndices.overlay};
-  opacity: 0.2;
 
   @media (prefers-reduced-motion: no-preference) {
     animation: ${ANIMATIONS.overlayFadeIn} ${(props) => props.theme.motion.timings['200']}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

It fixes the wrong behaviour in the Modal Content component, the children components are not scrollable, I moved the ContentImpl as a child of the Overlay component and I changed the background rule in the Overlay style to don't affect the opacity of the Overlay children

### Why is it needed?

Because otherwise scrolling is not working for example in dropdown used in the Modal body.
Here an example of the issue

https://github.com/strapi/design-system/assets/2589748/f6177b1d-1de9-459b-be63-5e46fcba7c26

and here the solution

https://github.com/strapi/design-system/assets/2589748/b47e2a95-1624-4195-b844-dc7f22a9583d

### How to test it?

You can test the solution directly in the Modal DS storybook https://64f9707bb212b1f1332bfd97-ehiswajggi.chromatic.com/?path=/story/components-modal--base

### Related issue(s)/PR(s)

fixes https://github.com/strapi/strapi/issues/20599
