### PR TITLE
chore: use the default github secret for changeset

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,7 @@
   "commit": false,
   "changelog": ["@changesets/changelog-github", { "repo": "strapi/design-system" }],
   "access": "public",
-  "baseBranch": "develop",
+  "baseBranch": "main",
   "fixed": [["@strapi/*"]],
   "ignore": ["@strapi/design-system-docs"],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {

--- a/.changeset/slimy-shirts-cover.md
+++ b/.changeset/slimy-shirts-cover.md
@@ -1,0 +1,7 @@
+---
+'@strapi/design-system': patch
+'@strapi/icons': patch
+'@strapi/ui-primitives': patch
+---
+
+change github action to use default github secret

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release:
     name: Release
@@ -49,7 +53,7 @@ jobs:
           commit: 'chore: version packages for release'
           title: 'chore: version packages for release'
         env:
-          GITHUB_TOKEN: ${{ secrets.CHANGESETS_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   find_package_version:


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Changesets github action has been failing with a 403 using the env var:
GITHUB_TOKEN: ${{ secrets.CHANGESETS_GITHUB_TOKEN }}

This PR changes the release yaml to use the repository default so the github actions runner can create the commits, branches and pull requests that it needs

