### PR TITLE
fix: modal footer issues

### DIFF
--- a/.changeset/lazy-kiwis-protect.md
+++ b/.changeset/lazy-kiwis-protect.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+change modal content height and max height

--- a/packages/design-system/src/components/Modal/Modal.tsx
+++ b/packages/design-system/src/components/Modal/Modal.tsx
@@ -63,8 +63,8 @@ const Overlay = styled(Dialog.Overlay)`
 
 const ContentImpl = styled(Dialog.Content)`
   max-width: 83rem;
-  max-height: 80vh;
-  height: min-content;
+  max-height: 90vh;
+  height: auto;
   width: 60%;
   overflow: hidden;
   margin: 0 auto;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Change some height rules (height and min-height in the Modal.Content) to solve issues with some browser or some modals truncated for example for DZ

### Why is it needed?

For some browsers or some views the footer part is hidden or truncated, for example
This happens in the Create Collection/Component modal in Safari and other browsers
<img width="866" alt="Schermata 2024-07-18 alle 15 40 00" src="https://github.com/user-attachments/assets/0c24b2cb-bf6d-4012-bb7f-36fbf82f67bd">

and this one in the DZ modal
<img width="905" alt="Schermata 2024-07-18 alle 15 41 17" src="https://github.com/user-attachments/assets/a050f661-d681-4e6e-be8f-87a00f1572fe">

### How to test it?

link this branch to your version of the CMS by following these instructions https://github.com/strapi/design-system/blob/main/CONTRIBUTING.md#example-steps

### Related issue(s)/PR(s)

fixes https://github.com/strapi/strapi/issues/20574
