### PR TITLE
fix: menu item disabled style wrongly applied

### DIFF
--- a/.changeset/chatty-jokes-grow.md
+++ b/.changeset/chatty-jokes-grow.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+fix aria-disabled css rule on menu item

--- a/packages/design-system/src/components/SimpleMenu/Menu.tsx
+++ b/packages/design-system/src/components/SimpleMenu/Menu.tsx
@@ -180,7 +180,7 @@ const getOptionStyle = ({ theme }: { theme: DefaultTheme }) => css`
   border-radius: ${theme.borderRadius};
   padding: ${theme.spaces[2]} ${theme.spaces[4]};
 
-  &[aria-disabled] {
+  &[aria-disabled='true'] {
     cursor: not-allowed;
     color: ${theme.colors.neutral500};
   }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Extends the CSS rule in the Menu.Item in case the aria-disabled attribute has just a true value, otherwise the disabled state is applied even if the menu item is not disabled

### Why is it needed?

Otherwise for example when we use a NavLink in the Menu.Item the aria-disabled attribute is present even if it is false and with the old css rule the style is applied in both cases, true or false
An example in the CMS is this one
<img width="303" alt="Schermata 2024-07-19 alle 15 55 29" src="https://github.com/user-attachments/assets/80a93ebb-c248-4145-9d0b-340ab2900763">

### How to test it?

link this branch to your version of the CMS by following these instructions https://github.com/strapi/design-system/blob/main/CONTRIBUTING.md#example-steps

### Related issue(s)/PR(s)

fixes https://github.com/strapi/strapi/issues/20774
