### PR TITLE
fix: modals broken in safari

### DIFF
--- a/.changeset/large-dots-cheer.md
+++ b/.changeset/large-dots-cheer.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+fix modals not displaying properly in safari

--- a/packages/design-system/src/utilities/ScrollArea/ScrollArea.tsx
+++ b/packages/design-system/src/utilities/ScrollArea/ScrollArea.tsx
@@ -32,7 +32,6 @@ const ScrollAreaImpl = React.forwardRef<ScrollAreaElement, ScrollAreaProps>(
 
 const ScrollAreaRoot = styled(ScrollArea.Root)`
   width: 100%;
-  height: 100%;
   overflow: hidden;
   display: flex;
 `;


### PR DESCRIPTION
### What does it do?

Fixes an issue where modals were not displaying their footer (when non scrollable) or their entire body (when scrollable) in Safari.

You can see the issue if you open the current Modal storybook in Safari:

![CleanShot 2024-07-24 at 12 15 53@2x](https://github.com/user-attachments/assets/714e4290-ef1d-4245-8a38-90e70c1dff14)
![CleanShot 2024-07-24 at 12 17 19@2x](https://github.com/user-attachments/assets/9cbdd659-040d-4bd7-af65-dba72635b0ff)

You can also see the issue in the CMS on v5/main using Safari. Try adding an asset to the media library, or replacing an asset, or adding a new field in the CTB, or editing an input in configure the view.

### How to test it?

You can test the fix from Storybook by checking the stories in my screenshots above in Safari. Also make sure that the scrolling works (you may need to shrink your browser height to see it)

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/20556