### PR TITLE
fix: link hover color 

### DIFF
--- a/.changeset/metal-poems-type.md
+++ b/.changeset/metal-poems-type.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+fix: link hover color apply to its label and not to children

--- a/packages/design-system/src/components/Link/Link.tsx
+++ b/packages/design-system/src/components/Link/Link.tsx
@@ -52,7 +52,7 @@ const LinkWrapper = styled<BaseLinkComponent>(BaseLink)`
   }
 
   &:hover {
-    span {
+    & > span {
       color: ${({ theme }) => theme.colors.primary500};
     }
   }


### PR DESCRIPTION
### What does it do?

Apply link hover color to its label and not to children

### Why is it needed?

In CMS, where we are using `Link` component as a wrapper with children inside it, its causing hover style to apply to all its span elements unnecessarily.
