### PR TITLE
fix: remove static placeholder from SubNavHeader

### DIFF
--- a/.changeset/small-zebras-explain.md
+++ b/.changeset/small-zebras-explain.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+fix: removed static placeholder from subnavheader

--- a/packages/design-system/src/components/SubNav/SubNavHeader.tsx
+++ b/packages/design-system/src/components/SubNav/SubNavHeader.tsx
@@ -20,7 +20,7 @@ const CustomDivider = styled(Divider)`
 
 export interface SubNavHeaderProps
   extends Pick<TypographyProps<'h2'>, 'tag'>,
-    Partial<Pick<SearchbarProps, 'onClear' | 'onChange' | 'onSubmit'>> {
+    Partial<Pick<SearchbarProps, 'onClear' | 'onChange' | 'onSubmit' | 'placeholder'>> {
   id?: string;
   label: string;
   searchLabel?: string;
@@ -38,6 +38,7 @@ export const SubNavHeader = ({
   onClear = () => {},
   onSubmit = () => {},
   id,
+  placeholder,
 }: SubNavHeaderProps) => {
   const [isSearchOpen, setSearchOpen] = React.useState(false);
   const previousSearchOpenValue = usePrev(isSearchOpen);
@@ -83,7 +84,7 @@ export const SubNavHeader = ({
             name="searchbar"
             value={value}
             onChange={onChange}
-            placeholder="e.g: strapi-plugin-abcd"
+            placeholder={placeholder}
             onKeyDown={handleKeyDown}
             ref={searchRef}
             onBlur={handleBlur}


### PR DESCRIPTION
### What does it do?

User can pass a placeholder prop to SubNavHeader now.

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/design-system/issues/1201
