### PR TITLE
fix: multiple UI styling changes

### DIFF
--- a/.changeset/cool-carrots-explode.md
+++ b/.changeset/cool-carrots-explode.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+fix: multiple ui style fixes

--- a/.changeset/gorgeous-zoos-unite.md
+++ b/.changeset/gorgeous-zoos-unite.md
@@ -1,0 +1,5 @@
+---
+'@strapi/ui-primitives': patch
+---
+
+fix: combobox with no options handled

--- a/docs/stories/04-components/Field.stories.tsx
+++ b/docs/stories/04-components/Field.stories.tsx
@@ -1,18 +1,21 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { Field } from '@strapi/design-system';
-import { Search, Cross } from '@strapi/icons';
+import { Search, Cross, Earth } from '@strapi/icons';
 import { outdent } from 'outdent';
 
-interface Props extends Field.Props, Pick<Field.InputProps, 'type' | 'placeholder' | 'startAction' | 'endAction'> {
+interface Props
+  extends Field.Props,
+    Pick<Field.InputProps, 'type' | 'placeholder' | 'startAction' | 'endAction'>,
+    Pick<Field.LabelProps, 'action'> {
   label: string;
 }
 
 const meta: Meta<Props> = {
   title: 'Components/Field',
-  render: ({ label, placeholder, type, startAction, endAction, ...props }) => {
+  render: ({ label, placeholder, type, startAction, endAction, action, ...props }) => {
     return (
       <Field.Root {...props}>
-        <Field.Label>{label}</Field.Label>
+        <Field.Label action={action}>{label}</Field.Label>
         <Field.Input type={type} placeholder={placeholder} startAction={startAction} endAction={endAction} />
         <Field.Error />
         <Field.Hint />
@@ -59,6 +62,7 @@ export const Input = {
     type: 'password',
     label: 'New password',
     placeholder: 'Enter a new password',
+    required: true,
   },
   parameters: {
     docs: {
@@ -78,6 +82,11 @@ export const Error = {
   name: 'error',
   args: {
     error: 'This field is required',
+    action: (
+      <button aria-label="i18n" type="button">
+        <Earth aria-hidden />
+      </button>
+    ),
   },
   parameters: {
     docs: {

--- a/packages/design-system/src/components/Combobox/Combobox.test.tsx
+++ b/packages/design-system/src/components/Combobox/Combobox.test.tsx
@@ -147,6 +147,17 @@ describe('Combobox', () => {
       expect(getByRole('combobox')).toBeRequired();
     });
 
+    it('should handle noOptionsMessage prop correctly when there are no options to display', async () => {
+      const { getByRole, queryAllByRole, getByText, user } = render({
+        options: [],
+      });
+
+      await user.click(getByRole('combobox'));
+
+      expect(getByText('No results found')).toBeInTheDocument();
+      expect(queryAllByRole('option')).toHaveLength(0);
+    });
+
     it('should handle noOptionsMessage prop correctly', async () => {
       const { getByRole, queryAllByRole, getByText, user } = render({
         noOptionsMessage: (value) => `${value} is not an option`,

--- a/packages/design-system/src/components/Combobox/Combobox.tsx
+++ b/packages/design-system/src/components/Combobox/Combobox.tsx
@@ -223,9 +223,9 @@ const Combobox = React.forwardRef<ComboboxInputElement, ComboboxProps>(
         <Trigger $hasError={hasError} $size={size} className={className}>
           <Flex flex="1" tag="span" gap={3}>
             {startIcon ? (
-              <Box flex="0 0 1.6rem" tag="span" aria-hidden>
+              <Flex flex="0 0 1.6rem" tag="span" aria-hidden>
                 {startIcon}
-              </Box>
+              </Flex>
             ) : null}
             <TextInput
               placeholder={placeholder}
@@ -258,7 +258,7 @@ const Combobox = React.forwardRef<ComboboxInputElement, ComboboxProps>(
               </IconBox>
             ) : null}
             <DownIcon>
-              <CaretDown />
+              <CaretDown fill="neutral500" />
             </DownIcon>
           </Flex>
         </Trigger>
@@ -370,6 +370,7 @@ const DownIcon = styled(ComboboxPrimitive.Icon)`
   background: transparent;
   padding: 0;
   color: ${({ theme }) => theme.colors.neutral600};
+  display: flex;
 
   &[aria-disabled='true'] {
     cursor: inherit;

--- a/packages/design-system/src/components/Field/Field.tsx
+++ b/packages/design-system/src/components/Field/Field.tsx
@@ -80,9 +80,8 @@ const Label = React.forwardRef<HTMLLabelElement, LabelProps>(({ children, action
   }
 
   return (
-    <Typography
+    <TypographyLabel
       ref={composedRefs}
-      display="flex"
       variant="pi"
       textColor="neutral800"
       fontWeight="bold"
@@ -99,9 +98,13 @@ const Label = React.forwardRef<HTMLLabelElement, LabelProps>(({ children, action
         </Typography>
       )}
       {action && <LabelAction marginLeft={1}>{action}</LabelAction>}
-    </Typography>
+    </TypographyLabel>
   );
 });
+
+const TypographyLabel = styled(Typography)`
+  display: flex;
+`;
 
 const LabelAction = styled<FlexComponent>(Flex)`
   line-height: 0;

--- a/packages/design-system/src/components/IconButton/IconButton.tsx
+++ b/packages/design-system/src/components/IconButton/IconButton.tsx
@@ -103,12 +103,18 @@ const IconButtonWrapper = styled<FlexComponent<'button'>>(Flex)<IconButtonWrappe
   ${(props) =>
     props.$variant === 'tertiary'
       ? css`
-          color: ${props.theme.colors.neutral600};
+          color: ${props.theme.colors.neutral500};
         `
       : ''}
 
   &:hover {
     ${getHoverStyle}
+    ${(props) =>
+      props.$variant === 'tertiary'
+        ? css`
+            color: ${props.theme.colors.neutral600};
+          `
+        : ''}
   }
 
   &:active {

--- a/packages/design-system/src/components/Select/SelectParts.tsx
+++ b/packages/design-system/src/components/Select/SelectParts.tsx
@@ -109,6 +109,7 @@ const SelectTrigger = React.forwardRef<HTMLDivElement, TriggerProps>(
 
 const IconBox = styled<BoxComponent<'button'>>(Box)`
   border: none;
+  display: flex;
 
   svg {
     height: 1.1rem;
@@ -116,7 +117,7 @@ const IconBox = styled<BoxComponent<'button'>>(Box)`
   }
 
   svg path {
-    fill: ${({ theme }) => theme.colors.neutral600};
+    fill: ${({ theme }) => theme.colors.neutral500};
   }
 `;
 
@@ -144,7 +145,7 @@ const StyledTrigger = styled<FlexComponent>(Flex)<{
   }}
 
   &[aria-disabled='true'] {
-    color: ${(props) => props.theme.colors.neutral600};
+    color: ${(props) => props.theme.colors.neutral500};
   }
 
   /* Required to ensure the below inputFocusStyles are adhered too */
@@ -156,8 +157,9 @@ const StyledTrigger = styled<FlexComponent>(Flex)<{
 `;
 
 const DownIcon = styled(Select.Icon)`
+  display: flex;
   & > svg {
-    fill: ${({ theme }) => theme.colors.neutral600};
+    fill: ${({ theme }) => theme.colors.neutral500};
   }
 `;
 

--- a/packages/design-system/src/components/SimpleMenu/Menu.tsx
+++ b/packages/design-system/src/components/SimpleMenu/Menu.tsx
@@ -92,6 +92,7 @@ const MenuContent = React.forwardRef<HTMLDivElement, ContentProps>(
             shadow="filterShadow"
             maxHeight="15rem"
             padding={1}
+            marginTop={1}
             alignItems="flex-start"
             position="relative"
             overflow="auto"

--- a/packages/design-system/src/components/SimpleMenu/Menu.tsx
+++ b/packages/design-system/src/components/SimpleMenu/Menu.tsx
@@ -43,29 +43,21 @@ type TriggerPropsWithIconButton = TriggerPropsBase & {
 type TriggerProps = TriggerPropsWithButton | TriggerPropsWithIconButton;
 
 const MenuTrigger = React.forwardRef<HTMLButtonElement, TriggerProps>(
-  (
-    { label, size, endIcon = <CaretDown width="1.2rem" height="1.2rem" aria-hidden />, tag = Button, icon, ...rest },
-    ref,
-  ) => {
+  ({ label, endIcon = <CaretDown width="1.2rem" height="1.2rem" aria-hidden />, tag = Button, icon, ...rest }, ref) => {
     const props: ButtonProps = {
       ...rest,
       ref,
       type: 'button',
-      variant: 'ghost',
-      paddingTop: size === 'S' ? 1 : 2,
-      paddingBottom: size === 'S' ? 1 : 2,
-      paddingLeft: size === 'S' ? 3 : 4,
-      paddingRight: size === 'S' ? 3 : 4,
     };
 
     return (
       <DropdownMenu.Trigger asChild>
         {tag === IconButton ? (
-          <IconButton label={label as string} {...props}>
+          <IconButton label={label as string} variant="tertiary" {...props}>
             {icon}
           </IconButton>
         ) : (
-          <Button endIcon={endIcon} {...props} />
+          <Button endIcon={endIcon} variant="ghost" {...props} />
         )}
       </DropdownMenu.Trigger>
     );

--- a/packages/design-system/src/components/SimpleMenu/Menu.tsx
+++ b/packages/design-system/src/components/SimpleMenu/Menu.tsx
@@ -93,6 +93,7 @@ const MenuContent = React.forwardRef<HTMLDivElement, ContentProps>(
             maxHeight="15rem"
             padding={1}
             marginTop={1}
+            marginBottom={1}
             alignItems="flex-start"
             position="relative"
             overflow="auto"

--- a/packages/primitives/src/components/Combobox/Combobox.tsx
+++ b/packages/primitives/src/components/Combobox/Combobox.tsx
@@ -1199,8 +1199,6 @@ const ComboboxNoValueFound = React.forwardRef<HTMLDivElement, NoValueFoundProps>
     };
   }, [subscribe]);
 
-  if (items.length === 0) return null;
-
   if (autocomplete.type === 'none') {
     return null;
   }


### PR DESCRIPTION
### What does it do?

1. Field label style fixed
2. Tertiary Icon button `color: neutral500` and `hover-color: neutral600` updated as per design
3. Simple menu with `tag: IconButton` should have `tertiary` style applied
4. Select carret down `color: neutral500` fixed.
5. Combobox with no options provided should show default "No results found" value.


### Related issue(s)/PR(s)

Fixes: https://github.com/strapi/design-system/issues/1626
