### PR TITLE
fix: combobox with no options and autocomplete none

### DIFF
--- a/.changeset/weak-clouds-breathe.md
+++ b/.changeset/weak-clouds-breathe.md
@@ -1,0 +1,5 @@
+---
+'@strapi/ui-primitives': patch
+---
+
+fix: combobox with no options and autocomplete none, show nooptions value passed instead of null

--- a/packages/primitives/src/components/Combobox/Combobox.tsx
+++ b/packages/primitives/src/components/Combobox/Combobox.tsx
@@ -1199,10 +1199,6 @@ const ComboboxNoValueFound = React.forwardRef<HTMLDivElement, NoValueFoundProps>
     };
   }, [subscribe]);
 
-  if (autocomplete.type === 'none') {
-    return null;
-  }
-
   if (
     autocomplete.type === 'list' &&
     autocomplete.filter === 'startsWith' &&


### PR DESCRIPTION
### What does it do?
Combobox with no options and `autocomplete: none` , no options value should be displayed.

### Related issue(s)/PR(s)

https://github.com/strapi/design-system/issues/1626
