### PR TITLE
fix: responsive breakpoint change for large screen

### DIFF
--- a/.changeset/weak-eels-jump.md
+++ b/.changeset/weak-eels-jump.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+fix: responsive breakpoint for large screens updated to 1080px as per design

--- a/docs/stories/Box.mdx
+++ b/docs/stories/Box.mdx
@@ -29,7 +29,7 @@ The `Box` component allows creation of containers according to the guidelines of
 Responsive styles allow you to specify different values for properties based on different screen sizes or breakpoints.
 The values are defined as an object or array and are applied using a `min-width` condition. If a value is not specified
 for a particular breakpoint, it will inherit the value from the previous breakpoint. The breakpoints are defined in
-theme as : `initial: 0px, small: 520px, medium: 768px, large: 1280px`.
+theme as : `initial: 0px, small: 520px, medium: 768px, large: 1080px`.
 
 <Canvas of={BoxStories.ResponsiveStyles} />
 

--- a/packages/design-system/src/helpers/__tests__/handleResponsiveValues.test.ts
+++ b/packages/design-system/src/helpers/__tests__/handleResponsiveValues.test.ts
@@ -72,7 +72,7 @@ describe('handleResponsiveValues', () => {
               margin-inline-end: 24px;
               margin-block-end: 24px;
               margin-inline-start: 24px; }
-              @media(min-width: 1280px){ padding-block-start: 16px;
+              @media(min-width: 1080px){ padding-block-start: 16px;
               padding-inline-end: 16px;
               padding-block-end: 16px;
               padding-inline-start: 16px;
@@ -126,7 +126,7 @@ describe('handleResponsiveValues', () => {
               padding-inline-end: 24px;
               padding-block-end: 1rem;
               padding-inline-start: 1rem; }
-              @media(min-width: 1280px){ padding-block-start: 16px;
+              @media(min-width: 1080px){ padding-block-start: 16px;
               padding-inline-end: 8px;
               padding-block-end: 16px;
               padding-inline-start: 16px; }"
@@ -160,7 +160,7 @@ describe('handleResponsiveValues', () => {
               margin-inline-end: 4px;
               margin-block-end: 8px;
               margin-inline-start: 4px; }
-              @media(min-width: 1280px){ padding-block-start: 24px;
+              @media(min-width: 1080px){ padding-block-start: 24px;
               padding-inline-end: 24px;
               padding-block-end: 24px;
               padding-inline-start: 24px;
@@ -192,7 +192,7 @@ describe('handleResponsiveValues', () => {
               margin-block-end: 8px;
               margin-inline-start: 4px;
               @media(min-width: 768px){ padding-block-start: 16px; }
-              @media(min-width: 1280px){ padding-block-start: 24px; }"
+              @media(min-width: 1080px){ padding-block-start: 24px; }"
           `);
     });
   });
@@ -230,7 +230,7 @@ describe('handleResponsiveValues', () => {
         @media(min-width: 520px){ background: #0c75af;
         color: pink; }
         @media(min-width: 768px){ background: #666687; }
-        @media(min-width: 1280px){ background: #32324d;
+        @media(min-width: 1080px){ background: #32324d;
         color: 3; }"
       `);
     });
@@ -258,7 +258,7 @@ describe('handleResponsiveValues', () => {
         "gap: 4px;
         @media(min-width: 520px){ gap: 8px; }
         @media(min-width: 768px){ gap: 12px; }
-        @media(min-width: 1280px){ gap: 24px; }"
+        @media(min-width: 1080px){ gap: 24px; }"
       `);
     });
   });
@@ -285,7 +285,7 @@ describe('handleResponsiveValues', () => {
         "font-size: 1.4rem;
         @media(min-width: 520px){ font-size: 1.6rem; }
         @media(min-width: 768px){ font-size: 14px; }
-        @media(min-width: 1280px){ font-size: 3.2rem; }"
+        @media(min-width: 1080px){ font-size: 3.2rem; }"
       `);
     });
   });
@@ -312,7 +312,7 @@ describe('handleResponsiveValues', () => {
         "font-weight: 400;
         @media(min-width: 520px){ font-weight: 500; }
         @media(min-width: 768px){ font-weight: 600; }
-        @media(min-width: 1280px){ font-weight: 850; }"
+        @media(min-width: 1080px){ font-weight: 850; }"
       `);
     });
   });
@@ -339,7 +339,7 @@ describe('handleResponsiveValues', () => {
         "line-height: 1.25;
         @media(min-width: 520px){ line-height: 1.22; }
         @media(min-width: 768px){ line-height: 1.33; }
-        @media(min-width: 1280px){ line-height: invalidValue; }"
+        @media(min-width: 1080px){ line-height: invalidValue; }"
       `);
     });
   });
@@ -366,7 +366,7 @@ describe('handleResponsiveValues', () => {
         "z-index: 100;
         @media(min-width: 520px){ z-index: 9; }
         @media(min-width: 768px){ z-index: 1000; }
-        @media(min-width: 1280px){ z-index: invalidValue; }"
+        @media(min-width: 1080px){ z-index: invalidValue; }"
       `);
     });
   });
@@ -396,7 +396,7 @@ describe('handleResponsiveValues', () => {
         "box-shadow: 0px 1px 4px rgba(33, 33, 52, 0.1);
         @media(min-width: 520px){ box-shadow: 0px 0px 6px rgba(76, 191, 255, 0.75); }
         @media(min-width: 768px){ box-shadow: 3; }
-        @media(min-width: 1280px){ box-shadow: 0px 1px 4px rgba(33, 33, 52, 0.1); }"
+        @media(min-width: 1080px){ box-shadow: 0px 1px 4px rgba(33, 33, 52, 0.1); }"
       `);
     });
   });

--- a/packages/design-system/src/primitives/Grid/Grid.tsx
+++ b/packages/design-system/src/primitives/Grid/Grid.tsx
@@ -47,8 +47,8 @@ type ItemProps<C extends React.ElementType = 'div'> = FlexProps<C> & {
 };
 
 const ItemImpl = forwardRef(
-  <C extends React.ElementType = 'div'>({ col, s, xs, ...props }: ItemProps<C>, forwardedRef: PolymorphicRef<C>) => (
-    <Item ref={forwardedRef} $col={col} $s={s} $xs={xs} {...props} />
+  <C extends React.ElementType = 'div'>({ col, s, xs, m, ...props }: ItemProps<C>, forwardedRef: PolymorphicRef<C>) => (
+    <Item ref={forwardedRef} $col={col} $s={s} $xs={xs} $m={m} {...props} />
   ),
 ) as ItemComponent;
 

--- a/packages/design-system/src/themes/common-theme.ts
+++ b/packages/design-system/src/themes/common-theme.ts
@@ -54,7 +54,7 @@ export const commonTheme: CommonTheme = {
     initial: '@media(min-width: 0px)',
     small: '@media(min-width: 520px)',
     medium: '@media(min-width: 768px)',
-    large: '@media(min-width: 1280px)',
+    large: '@media(min-width: 1080px)',
   },
   fontSizes: [`1.1rem`, `1.2rem`, `1.4rem`, '1.6rem', `1.8rem`, `3.2rem`],
   lineHeights: [1.14, 1.22, 1.25, 1.33, 1.43, 1.45, 1.5],


### PR DESCRIPTION
### What does it do?
With current breakpoint for large screen with `min-width:1280px`, its breaking CMS for the resolution 1280-1080px that is too soon than expected. After discussing with design its now updated to `min-width:1080px` for large screen.


### Related issue(s)/PR(s)
https://github.com/strapi/strapi/pull/20936#issuecomment-2285827184
