### PR TITLE
fix: carousel input ui

### DIFF
--- a/.changeset/smart-cheetahs-complain.md
+++ b/.changeset/smart-cheetahs-complain.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+fix carousel input icons

--- a/packages/design-system/src/components/CarouselInput/Carousel.tsx
+++ b/packages/design-system/src/components/CarouselInput/Carousel.tsx
@@ -102,13 +102,13 @@ export const Carousel = React.forwardRef<CarouselElement, CarouselProps>(
               <>
                 <CarouselAction tag="button" onClick={onPrevious} $area="startAction" ref={prevActionRef} type="button">
                   <AccessibleIcon label={previousLabel}>
-                    <ChevronLeft width="6px" height="10px" fill="neutral600" />
+                    <ChevronLeft width="1.6rem" height="1.6rem" fill="neutral600" />
                   </AccessibleIcon>
                 </CarouselAction>
 
                 <CarouselAction tag="button" onClick={onNext} $area="endAction" ref={nextActionRef} type="button">
                   <AccessibleIcon label={nextLabel}>
-                    <ChevronRight width="6px" height="10px" fill="neutral600" />
+                    <ChevronRight width="1.6rem" height="1.6rem" fill="neutral600" />
                   </AccessibleIcon>
                 </CarouselAction>
               </>

--- a/packages/design-system/src/components/CarouselInput/CarouselActions.tsx
+++ b/packages/design-system/src/components/CarouselInput/CarouselActions.tsx
@@ -12,6 +12,7 @@ export const CarouselActions = ({ horizontal = true, ...props }: CarouselActions
     position="absolute"
     width="100%"
     bottom={1}
+    gap={1}
     {...props}
   />
 );


### PR DESCRIPTION
### What does it do?
Changes on the carousel input:
- Makes the chevron icons bigger
- Adds a gap in between the floating icons

https://strapi-inc.atlassian.net/browse/CS-1071
