### PR TITLE
fix: added cursor pointer for checkbox and pre-filled list

### DIFF
--- a/packages/design-system/src/components/Checkbox/Checkbox.tsx
+++ b/packages/design-system/src/components/Checkbox/Checkbox.tsx
@@ -74,6 +74,7 @@ const CheckboxRoot = styled(Checkbox.Root)`
   align-items: center;
   // this ensures the checkbox is always a square even in flex-containers.
   flex: 0 0 2rem;
+  cursor: pointer;
 
   &[data-state='checked'],
   &[data-state='indeterminate'] {

--- a/packages/design-system/src/components/Select/SelectParts.tsx
+++ b/packages/design-system/src/components/Select/SelectParts.tsx
@@ -143,6 +143,7 @@ const StyledTrigger = styled<FlexComponent>(Flex)<{
         `;
     }
   }}
+  cursor: pointer;
 
   &[aria-disabled='true'] {
     color: ${(props) => props.theme.colors.neutral500};


### PR DESCRIPTION
What does it do?
Fixed the Media Library's missing cursor pointers issue on the filters and checkbox

Why is it needed?
To fix issue https://github.com/strapi/design-system/issues/1791: Media Library missing cursor pointers on the filters and checkbox

How to test it?

- Open the Media Library
- Hover over the filters, it should show the cursor pointers.

Related issue(s)/PR(s)
https://github.com/strapi/design-system/issues/1791