### PR TITLE
fix: added cursor pointer for checkbox and pre-filled list

### DIFF
--- a/.changeset/sweet-timers-help.md
+++ b/.changeset/sweet-timers-help.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': major
+---
+
+patch for hovering effect

--- a/.changeset/sweet-timers-help.md
+++ b/.changeset/sweet-timers-help.md
@@ -1,5 +1,5 @@
 ---
-'@strapi/design-system': major
+'@strapi/design-system': patch
 ---
 
 patch for hovering effect

--- a/packages/design-system/src/components/Checkbox/Checkbox.tsx
+++ b/packages/design-system/src/components/Checkbox/Checkbox.tsx
@@ -74,6 +74,7 @@ const CheckboxRoot = styled(Checkbox.Root)`
   align-items: center;
   // this ensures the checkbox is always a square even in flex-containers.
   flex: 0 0 2rem;
+  cursor: pointer;
 
   &[data-state='checked'],
   &[data-state='indeterminate'] {

--- a/packages/design-system/src/components/Checkbox/Checkbox.tsx
+++ b/packages/design-system/src/components/Checkbox/Checkbox.tsx
@@ -51,26 +51,15 @@ const CheckboxEl = React.forwardRef<CheckboxElement, CheckboxElProps>(
     const composedRefs = useComposedRefs(checkboxRef, forwardedRef);
 
     return (
-      // <CheckboxWrapper>
       <CheckboxRoot ref={composedRefs} checked={checked} onCheckedChange={setChecked} {...props}>
         <Checkbox.Indicator style={{ display: 'inline-flex' }}>
           {checked === true ? <CheckIcon width="1.6rem" fill="neutral0" /> : null}
           {checked === 'indeterminate' ? <Minus fill="neutral0" /> : null}
         </Checkbox.Indicator>
       </CheckboxRoot>
-      // </CheckboxWrapper>
     );
   },
 );
-
-// const CheckboxWrapper = styled.div`
-//   position: relative;
-//   width: 44px;
-//   height: 44px;
-//   display: inline-flex;
-//   justify-content: center;
-//   align-items: center;
-// `;
 
 const CheckboxRoot = styled(Checkbox.Root)`
   background: ${(props) => props.theme.colors.neutral0};

--- a/packages/design-system/src/components/Checkbox/Checkbox.tsx
+++ b/packages/design-system/src/components/Checkbox/Checkbox.tsx
@@ -52,10 +52,10 @@ const CheckboxEl = React.forwardRef<CheckboxElement, CheckboxElProps>(
 
     return (
       <CheckboxRoot ref={composedRefs} checked={checked} onCheckedChange={setChecked} {...props}>
-        <Checkbox.Indicator style={{ display: 'inline-flex' }}>
+        <CheckboxIndicator style={{ display: 'inline-flex', pointerEvents: 'auto' }} forceMount>
           {checked === true ? <CheckIcon width="1.6rem" fill="neutral0" /> : null}
           {checked === 'indeterminate' ? <Minus fill="neutral0" /> : null}
-        </Checkbox.Indicator>
+        </CheckboxIndicator>
       </CheckboxRoot>
     );
   },
@@ -74,7 +74,6 @@ const CheckboxRoot = styled(Checkbox.Root)`
   align-items: center;
   // this ensures the checkbox is always a square even in flex-containers.
   flex: 0 0 2rem;
-  cursor: pointer;
 
   &[data-state='checked'],
   &[data-state='indeterminate'] {
@@ -84,7 +83,6 @@ const CheckboxRoot = styled(Checkbox.Root)`
 
   &[data-disabled] {
     background-color: ${(props) => props.theme.colors.neutral200};
-    cursor: not-allowed;
   }
 
   /* increase target size for touch devices https://www.w3.org/WAI/WCAG21/Understanding/target-size.html */
@@ -96,10 +94,16 @@ const CheckboxRoot = styled(Checkbox.Root)`
     transform: translate(-50%, -50%);
     width: 100%;
     height: 100%;
+    z-index: -1;
     min-width: 44px;
     min-height: 44px;
-    pointer-events: none;
   }
+`;
+
+const CheckboxIndicator = styled(Checkbox.Indicator)`
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
 `;
 
 /* -------------------------------------------------------------------------------------------------

--- a/packages/design-system/src/components/Checkbox/Checkbox.tsx
+++ b/packages/design-system/src/components/Checkbox/Checkbox.tsx
@@ -51,15 +51,26 @@ const CheckboxEl = React.forwardRef<CheckboxElement, CheckboxElProps>(
     const composedRefs = useComposedRefs(checkboxRef, forwardedRef);
 
     return (
+      // <CheckboxWrapper>
       <CheckboxRoot ref={composedRefs} checked={checked} onCheckedChange={setChecked} {...props}>
         <Checkbox.Indicator style={{ display: 'inline-flex' }}>
           {checked === true ? <CheckIcon width="1.6rem" fill="neutral0" /> : null}
           {checked === 'indeterminate' ? <Minus fill="neutral0" /> : null}
         </Checkbox.Indicator>
       </CheckboxRoot>
+      // </CheckboxWrapper>
     );
   },
 );
+
+// const CheckboxWrapper = styled.div`
+//   position: relative;
+//   width: 44px;
+//   height: 44px;
+//   display: inline-flex;
+//   justify-content: center;
+//   align-items: center;
+// `;
 
 const CheckboxRoot = styled(Checkbox.Root)`
   background: ${(props) => props.theme.colors.neutral0};
@@ -84,6 +95,7 @@ const CheckboxRoot = styled(Checkbox.Root)`
 
   &[data-disabled] {
     background-color: ${(props) => props.theme.colors.neutral200};
+    cursor: not-allowed;
   }
 
   /* increase target size for touch devices https://www.w3.org/WAI/WCAG21/Understanding/target-size.html */
@@ -97,6 +109,7 @@ const CheckboxRoot = styled(Checkbox.Root)`
     height: 100%;
     min-width: 44px;
     min-height: 44px;
+    pointer-events: none;
   }
 `;
 

--- a/packages/design-system/src/components/Select/SelectParts.tsx
+++ b/packages/design-system/src/components/Select/SelectParts.tsx
@@ -260,6 +260,7 @@ const itemStyles = css`
   &:focus-visible {
     outline: none;
     background-color: ${({ theme }) => theme.colors.primary100};
+    cursor: pointer;
   }
 `;
 

--- a/packages/design-system/src/components/Select/SelectParts.tsx
+++ b/packages/design-system/src/components/Select/SelectParts.tsx
@@ -143,6 +143,7 @@ const StyledTrigger = styled<FlexComponent>(Flex)<{
         `;
     }
   }}
+  cursor: pointer;
 
   &[aria-disabled='true'] {
     color: ${(props) => props.theme.colors.neutral500};


### PR DESCRIPTION
What does it do?
Fixed the Media Library's missing cursor pointers issue on the filters

Why is it needed?
To fix issue https://github.com/strapi/design-system/issues/1791: Media Library missing cursor pointers on the filters

How to test it?

- Open the Media Library
- Hover over the filters, it should show the cursor pointers.

Related issue(s)/PR(s)
https://github.com/strapi/design-system/issues/1791