### PR TITLE
Optional iconProps can be passed to Accordions

### DIFF
--- a/.changeset/stale-apes-approve.md
+++ b/.changeset/stale-apes-approve.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': minor
+---
+
+pass props to icons in accordion triggers

--- a/packages/design-system/src/components/Accordion/Accordion.tsx
+++ b/packages/design-system/src/components/Accordion/Accordion.tsx
@@ -121,11 +121,12 @@ interface TriggerProps extends Omit<RadixAccordion.AccordionTriggerProps, 'asChi
    */
   caretPosition?: 'left' | 'right';
   description?: string;
-  icon?: React.ElementType;
+  icon?: React.ElementType<React.SVGProps<SVGSVGElement>>;
+  iconProps?: React.SVGProps<SVGSVGElement>;
 }
 
 const Trigger = React.forwardRef<TriggerElement, TriggerProps>(
-  ({ caretPosition = 'left', description, icon: Icon, children, ...restProps }, forwardedRef) => {
+  ({ caretPosition = 'left', description, icon: Icon, iconProps, children, ...restProps }, forwardedRef) => {
     const { size } = useAccordion('Trigger');
 
     return (
@@ -138,7 +139,7 @@ const Trigger = React.forwardRef<TriggerElement, TriggerProps>(
         <Flex tag="span" gap={2}>
           {Icon && size === 'S' ? (
             <IconBox>
-              <Icon />
+              <Icon {...iconProps} />
             </IconBox>
           ) : null}
           <Flex alignItems="flex-start" direction="column" tag="span" ref={forwardedRef}>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Adds an optional prop 'iconProps' to the Accordion component

### Why is it needed?

So we can modify the icon, e.g. add a fill color to it

This came up when converting the SEO plugin to v5 through https://github.com/strapi/strapi-plugin-seo/pull/76


### Related issue(s)/PR(s)

DX-1693
