### PR TITLE
enhancement: add xs size to status component

### DIFF
--- a/.changeset/chilly-trains-push.md
+++ b/.changeset/chilly-trains-push.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+add xs size to status component

--- a/docs/stories/Status.mdx
+++ b/docs/stories/Status.mdx
@@ -31,9 +31,13 @@ Use a Status sparingly within forms to give an important visual indication. Stat
 
 <Canvas of={StatusStories.Base} />
 
-### Size
+### Size S
 
 <Canvas of={StatusStories.SizeS} />
+
+### Size XS
+
+<Canvas of={StatusStories.SizeXS} />
 
 ## Props
 

--- a/docs/stories/Status.stories.tsx
+++ b/docs/stories/Status.stories.tsx
@@ -52,3 +52,27 @@ export const SizeS = {
 
   name: 'size S',
 } satisfies Story;
+
+export const SizeXS = {
+  render: () => (
+    <Flex direction="column" alignItems="stretch" gap={3}>
+      <Status variant="success" size="XS" showBullet={false}>
+        <Typography fontWeight="bold" textColor="success700">
+          Published
+        </Typography>
+      </Status>
+      <Status variant="secondary" size="XS" showBullet={false}>
+        <Typography fontWeight="bold" textColor="secondary700">
+          Draft
+        </Typography>
+      </Status>
+      <Status variant="alternative" size="XS" showBullet={false}>
+        <Typography fontWeight="bold" textColor="alternative700">
+          Updated
+        </Typography>
+      </Status>
+    </Flex>
+  ),
+
+  name: 'size XS',
+} satisfies Story;

--- a/packages/design-system/src/components/Status/Status.tsx
+++ b/packages/design-system/src/components/Status/Status.tsx
@@ -6,7 +6,7 @@ import { Box, BoxProps } from '../../primitives/Box';
 import { Flex } from '../../primitives/Flex';
 
 type StatusVariant = 'alternative' | 'danger' | 'neutral' | 'primary' | 'secondary' | 'success' | 'warning';
-type StatusSize = 'S' | 'M';
+type StatusSize = 'XS' | 'S' | 'M';
 
 interface StatusProps extends BoxProps {
   variant?: StatusVariant;
@@ -19,14 +19,26 @@ interface StatusProps extends BoxProps {
   children: React.ReactNode;
 }
 
+const getPadding = (size: StatusSize): { paddingX: BoxProps['paddingTop']; paddingY: BoxProps['paddingLeft'] } => {
+  if (size === 'XS') {
+    return { paddingX: '0.6rem', paddingY: '0.2rem' };
+  }
+
+  if (size === 'S') {
+    return { paddingX: 2, paddingY: 1 };
+  }
+
+  // Size M
+  return { paddingX: 5, paddingY: 4 };
+};
+
 const Status = ({ variant = 'primary', showBullet = true, size = 'M', children, ...props }: StatusProps) => {
   const backgroundColor = `${variant}100` satisfies keyof DefaultTheme['colors'];
   const borderColor = `${variant}200` satisfies keyof DefaultTheme['colors'];
   const bulletColor = `${variant}600` satisfies keyof DefaultTheme['colors'];
   const textColor = `${variant}600` satisfies keyof DefaultTheme['colors'];
 
-  const paddingX = size === 'S' ? 2 : 5;
-  const paddingY = size === 'S' ? 1 : 4;
+  const { paddingX, paddingY } = getPadding(size);
 
   return (
     <Box


### PR DESCRIPTION
### What does it do?

Adds a smaller XS variant to the Status component, in addition to the existing S and M versions
### Why is it needed?

We need this size to apply the designs of the document status, for both history and preview features in the CMS
### How to test it?

storybook link
