### PR TITLE
fix: combobox primitive empty state when autocomplete is none

### DIFF
--- a/.changeset/blue-humans-sin.md
+++ b/.changeset/blue-humans-sin.md
@@ -1,0 +1,5 @@
+---
+'@strapi/ui-primitives': major
+---
+
+fixes the combobox primitive empty state when autocomplete is set to none

--- a/packages/primitives/src/components/Combobox/Combobox.test.tsx
+++ b/packages/primitives/src/components/Combobox/Combobox.test.tsx
@@ -965,5 +965,26 @@ describe('Combobox', () => {
 
       expect(getByRole('option')).toBeInTheDocument();
     });
+
+    it('should not render the "no result found." when the autocomplete is set to none and options are not empty', async () => {
+      const { getByRole, queryByText, user } = render({
+        autocomplete: 'none',
+      });
+
+      await user.click(getByRole('combobox'));
+
+      expect(queryByText('No value found')).not.toBeInTheDocument();
+    });
+
+    it('should render the "no result found." when the autocomplete is set to none and options are empty', async () => {
+      const { getByRole, getByText, user } = render({
+        options: [],
+        autocomplete: 'none',
+      });
+
+      await user.click(getByRole('combobox'));
+
+      expect(getByText('No value found')).toBeInTheDocument();
+    });
   });
 });

--- a/packages/primitives/src/components/Combobox/Combobox.tsx
+++ b/packages/primitives/src/components/Combobox/Combobox.tsx
@@ -1199,6 +1199,8 @@ const ComboboxNoValueFound = React.forwardRef<HTMLDivElement, NoValueFoundProps>
     };
   }, [subscribe]);
 
+  if (autocomplete.type === 'none' && items.length > 0) return null;
+
   if (
     autocomplete.type === 'list' &&
     autocomplete.filter === 'startsWith' &&


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

This PR fixes the existing issue that always renders the `No result found` (empty state) of the combobox when autocomplete is set to off.

### Why is it needed?

Avoid rendering the `No result found` at the end of the option list (when `autocomplete = none`) which is the case in all Strapi Cloud combobox.

### How to test it?

Added new unit tests to handle this use case

### Related issue(s)/PR(s)

https://github.com/strapi/design-system/issues/1803