### PR TITLE
fix: icon color not changing on hover for links

### DIFF
--- a/.changeset/hip-sloths-occur.md
+++ b/.changeset/hip-sloths-occur.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': minor
+---
+
+Updated hover styles to apply correct color for text and SVG icons

--- a/packages/design-system/src/components/Link/Link.tsx
+++ b/packages/design-system/src/components/Link/Link.tsx
@@ -55,6 +55,10 @@ const LinkWrapper = styled<BaseLinkComponent>(BaseLink)`
     & > span {
       color: ${({ theme }) => theme.colors.primary500};
     }
+
+    svg path {
+      fill: ${({ theme }) => theme.colors.primary500};
+    }
   }
 
   &:active {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Fixes the hover behavior for link icons by applying the correct color to both text and SVG paths. Updated styles to use `color` for text and `fill` for SVG paths.

### Why is it needed?

The link icon color did not change on hover due to incorrect style rules. This fix ensures consistent hover feedback for better user experience.

### How to test it?

1. Navigate to the `Link` component in the Storybook design system site.
2. Hover over the link to observe the color change.
3. Verify that both the text and the SVG icon change to the desired primary color on hover.

Additionally, a video has been attached for visual reference, showcasing the changes and the expected behavior.

https://github.com/user-attachments/assets/b27d30df-6dd3-4f85-8d65-0082159cb7da

### Related issue(s)/PR(s)

Fixes #1825 
