### PR TITLE
fix(Menu): add disabled prop to menu trigger not applied through asChild

### DIFF
--- a/.changeset/grumpy-peaches-design.md
+++ b/.changeset/grumpy-peaches-design.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+add disabled prop to menu trigger not applied through asChild

--- a/packages/design-system/src/components/SimpleMenu/Menu.test.tsx
+++ b/packages/design-system/src/components/SimpleMenu/Menu.test.tsx
@@ -49,6 +49,7 @@ describe('Menu', () => {
 
     expect(getByRole('button', { name: 'Actions' })).toBeInTheDocument();
     expect(getByRole('button', { name: 'Actions' })).toHaveAttribute('aria-disabled', 'true');
+    expect(getByRole('button', { name: 'Actions' })).toBeDisabled();
 
     await user.click(getByRole('button', { name: 'Actions' }));
 

--- a/packages/design-system/src/components/SimpleMenu/Menu.test.tsx
+++ b/packages/design-system/src/components/SimpleMenu/Menu.test.tsx
@@ -5,11 +5,12 @@ import { Menu } from './SimpleMenu';
 interface ComponentProps {
   onAction1Select?: Menu.ItemProps['onSelect'];
   onSubmenuAction1Select?: Menu.ItemProps['onSelect'];
+  disabled?: Menu.TriggerProps['disabled'];
 }
 
-const Component = ({ onAction1Select, onSubmenuAction1Select }: ComponentProps) => (
+const Component = ({ onAction1Select, onSubmenuAction1Select, disabled }: ComponentProps) => (
   <Menu.Root>
-    <Menu.Trigger>Actions</Menu.Trigger>
+    <Menu.Trigger disabled={disabled}>Actions</Menu.Trigger>
     <Menu.Content>
       <Menu.Item onSelect={onAction1Select}>Action 1</Menu.Item>
       <Menu.Item isLink href="/home">
@@ -41,6 +42,17 @@ describe('Menu', () => {
     expect(queryByRole('menu')).not.toBeInTheDocument();
     expect(getByRole('button', { name: 'Actions' })).toHaveAttribute('aria-expanded', 'false');
     expect(getByRole('button', { name: 'Actions' })).toHaveAttribute('aria-haspopup', 'menu');
+  });
+
+  it('should disable the menu', async () => {
+    const { getByRole, user } = render({ disabled: true });
+
+    expect(getByRole('button', { name: 'Actions' })).toBeInTheDocument();
+    expect(getByRole('button', { name: 'Actions' })).toHaveAttribute('aria-disabled', 'true');
+
+    await user.click(getByRole('button', { name: 'Actions' }));
+
+    expect(getByRole('button', { name: 'Actions' })).toHaveAttribute('aria-expanded', 'false');
   });
 
   it('should open the menu when the trigger is clicked', async () => {

--- a/packages/design-system/src/components/SimpleMenu/Menu.tsx
+++ b/packages/design-system/src/components/SimpleMenu/Menu.tsx
@@ -52,7 +52,7 @@ const MenuTrigger = React.forwardRef<HTMLButtonElement, TriggerProps>(
     };
 
     return (
-      <DropdownMenu.Trigger asChild>
+      <DropdownMenu.Trigger asChild disabled={props.disabled}>
         {tag === IconButton ? (
           <IconButton label={label as string} variant="tertiary" {...props}>
             {icon}


### PR DESCRIPTION
### What does it do?

- Pass the disabled prop to the Radix dropdown 

### Why is it needed?

- The prop is not passed through with `asChild` as expected. Currently no Menu.Trigger can be disabled.

### How to test it?

- Test it in the CMS with yarn link (there is no Storybook for this component)
