### PR TITLE
bug: clean search bar

### DIFF
--- a/.changeset/hungry-adults-promise.md
+++ b/.changeset/hungry-adults-promise.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+cleaner search bar

--- a/packages/design-system/src/components/Searchbar/Searchbar.tsx
+++ b/packages/design-system/src/components/Searchbar/Searchbar.tsx
@@ -24,7 +24,6 @@ const SearchIcon = styled(Search)`
 
 const SearchbarWrapper = styled.div`
   border-radius: ${({ theme }) => theme.borderRadius};
-  box-shadow: ${({ theme }) => theme.shadows.filterShadow};
   border: 1px solid ${({ theme }) => theme.colors.neutral150}
 
   &:focus-within {

--- a/packages/design-system/src/components/Searchbar/Searchbar.tsx
+++ b/packages/design-system/src/components/Searchbar/Searchbar.tsx
@@ -11,20 +11,21 @@ import { Field } from '../Field';
 const CloseIcon = styled(Cross)`
   font-size: 0.5rem;
   path {
-    fill: ${({ theme }) => theme.colors.neutral400};
+    fill: ${({ theme }) => theme.colors.neutral500};
   }
 `;
 
 const SearchIcon = styled(Search)`
-  font-size: 0.8rem;
+  font-size: 1rem;
   path {
-    fill: ${({ theme }) => theme.colors.neutral800};
+    fill: ${({ theme }) => theme.colors.neutral500};
   }
 `;
 
 const SearchbarWrapper = styled.div`
   border-radius: ${({ theme }) => theme.borderRadius};
   box-shadow: ${({ theme }) => theme.shadows.filterShadow};
+  border: 1px solid ${({ theme }) => theme.colors.neutral150}
 
   &:focus-within {
     ${SearchIcon} {
@@ -34,7 +35,14 @@ const SearchbarWrapper = styled.div`
 `;
 
 const SearchbarInput = styled(Field.Input)`
-  border: 1px solid transparent;
+  border: 1px solid ${({ theme }) => theme.colors.neutral150}
+  height: 32px;
+  padding: 0 8px;
+  color: ${({ theme }) => theme.colors.neutral800};
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.neutral500};
+  }
 
   &:hover {
     button {

--- a/packages/design-system/src/components/Searchbar/Searchbar.tsx
+++ b/packages/design-system/src/components/Searchbar/Searchbar.tsx
@@ -35,8 +35,8 @@ const SearchbarWrapper = styled.div`
 
 const SearchbarInput = styled(Field.Input)`
   border: 1px solid ${({ theme }) => theme.colors.neutral150}
-  height: 32px;
-  padding: 0 8px;
+  height: 16px;
+  padding: 0 0 0 8px;
   color: ${({ theme }) => theme.colors.neutral800};
 
   &::placeholder {

--- a/packages/design-system/src/components/Searchbar/Searchbar.tsx
+++ b/packages/design-system/src/components/Searchbar/Searchbar.tsx
@@ -80,6 +80,7 @@ export const Searchbar = React.forwardRef<HTMLInputElement, SearchbarProps>(
           </VisuallyHidden>
 
           <SearchbarInput
+            size="S"
             ref={actualRef}
             value={value}
             startAction={<SearchIcon aria-hidden />}


### PR DESCRIPTION
### What does it do?
This PR updates the search bar component to match the design system specifications by:
- Adjusted the search icon size to 16px and color to Neutral500
- Set input height to 32px with 8px padding
- Updated placeholder text color to Neutral500
- Refined the border and focus states for better consistency
- Removed excess shadow for cleaner appearance
- Fixed layout shift issues between collapsed and expanded states

### Why is it needed?
As reported in issue #1832, the current search bar implementation had several visual inconsistencies:
- The search bar caused layout shifts when opened due to mismatched sizes with surrounding 32px elements
- Visual appearance didn't match the design system (icon colors, shadow, borders)
- Dark mode colors were incorrect
- The transition between states wasn't smooth

Describe the issue you are solving.

### How to test it?
[bug-cleaner-search-bar.webm](https://github.com/user-attachments/assets/5c09324a-ba98-416a-b672-c18f74ab0f47)


### Related issue(s)/PR(s)

#1832 

