### PR TITLE
bug: typo on SimpleMenu

### DIFF
--- a/packages/design-system/src/components/SimpleMenu/Menu.tsx
+++ b/packages/design-system/src/components/SimpleMenu/Menu.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
-import { CaretDown, ChevronRight } from '@strapi/icons';
+import { CarretDown, ChevronRight } from '@strapi/icons';
 import { styled, css, type DefaultTheme } from 'styled-components';
 
 import { extractStyleFromTheme } from '../../helpers/theme';
@@ -44,7 +44,7 @@ type TriggerPropsWithIconButton = TriggerPropsBase & {
 type TriggerProps = TriggerPropsWithButton | TriggerPropsWithIconButton;
 
 const MenuTrigger = React.forwardRef<HTMLButtonElement, TriggerProps>(
-  ({ label, endIcon = <CaretDown width="1.2rem" height="1.2rem" aria-hidden />, tag = Button, icon, ...rest }, ref) => {
+  ({ label, endIcon = <CarretDown width="1.2rem" height="1.2rem" aria-hidden />, tag = Button, icon, ...rest }, ref) => {
     const props: ButtonProps = {
       ...rest,
       ref,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

This pull request fixes a typo in the import of the `CaretDown` icon from the `@strapi/icons` package. The correct import should use `CarretDown` (with two `r`) to align with the icon name in the package.

### Why is it needed?

The incorrect import of `CaretDown` causes an error when the `@strapi/design-system` package is used, as the icon name does not match the actual export from `@strapi/icons`. Fixing this ensures compatibility and proper functionality of the design system components.

### How to test it?

1. Install the updated version of the `@strapi/design-system` package.
2. Verify that the components using `CarretDown` render correctly without errors.
3. Run the project's tests to ensure no other functionality is impacted.

### Related issue(s)/PR(s)

No related issue has been reported, but this PR directly addresses the typo causing the issue.
