### PR TITLE
fix: resolved the issue of select element missing scrollbar

### DIFF
--- a/packages/design-system/src/components/Select/SelectParts.tsx
+++ b/packages/design-system/src/components/Select/SelectParts.tsx
@@ -10,6 +10,7 @@ import { Flex, FlexComponent } from '../../primitives/Flex';
 import { Typography, TypographyComponent, TypographyProps } from '../../primitives/Typography';
 import { ANIMATIONS } from '../../styles/motion';
 import { inputFocusStyle } from '../../themes';
+import { ScrollArea } from '../../utilities/ScrollArea';
 import { Field, useField } from '../Field';
 
 /* -------------------------------------------------------------------------------------------------
@@ -196,7 +197,15 @@ const StyledValue = styled(Select.Value)`
  * SelectContent
  * -----------------------------------------------------------------------------------------------*/
 
-const SelectContent = styled(Select.Content)`
+const SelectContent = React.forwardRef<HTMLDivElement, ContentProps>((props, ref) => {
+  return (
+    <StyledContent ref={ref} {...props}>
+      <ScrollArea>{props.children}</ScrollArea>
+    </StyledContent>
+  );
+});
+
+const StyledContent = styled(Select.Content)`
   background: ${({ theme }) => theme.colors.neutral0};
   box-shadow: ${({ theme }) => theme.shadows.filterShadow};
   border: 1px solid ${({ theme }) => theme.colors.neutral150};


### PR DESCRIPTION
### What does it do?

This PR fixes the issue of select element missing scrollbar.

### Why is it needed?

To fix issue [22105](https://github.com/strapi/strapi/issues/22105): Select element is missing a scrollbar 

### How to test it?

1. Go to select component story of the storybook.
2. Now scrollbar will be visible and items can be scrolled using scrollbar.

### Related issue(s)/PR(s)

fixes [22105](https://github.com/strapi/strapi/issues/22105)
