### PR TITLE
feat: add onCloseAutoFocus to Menu.Content

### DIFF
--- a/.changeset/little-turtles-wait.md
+++ b/.changeset/little-turtles-wait.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+feat: add onCloseAutoFocus to Menu.Content

--- a/packages/design-system/src/components/SimpleMenu/Menu.tsx
+++ b/packages/design-system/src/components/SimpleMenu/Menu.tsx
@@ -69,13 +69,14 @@ const MenuTrigger = React.forwardRef<HTMLButtonElement, TriggerProps>(
  * MenuContent
  * -----------------------------------------------------------------------------------------------*/
 
-interface ContentProps extends FlexProps<'div'> {
-  intersectionId?: string;
-  popoverPlacement?: `${NonNullable<DropdownMenu.DropdownMenuContentProps['side']>}-${NonNullable<DropdownMenu.DropdownMenuContentProps['align']>}`;
-}
+type ContentProps = FlexProps<'div'> &
+  Pick<DropdownMenu.DropdownMenuContentProps, 'onCloseAutoFocus'> & {
+    intersectionId?: string;
+    popoverPlacement?: `${NonNullable<DropdownMenu.DropdownMenuContentProps['side']>}-${NonNullable<DropdownMenu.DropdownMenuContentProps['align']>}`;
+  };
 
 const MenuContent = React.forwardRef<HTMLDivElement, ContentProps>(
-  ({ children, intersectionId, popoverPlacement = 'bottom-start', ...props }, ref) => {
+  ({ children, intersectionId, onCloseAutoFocus, popoverPlacement = 'bottom-start', ...props }, ref) => {
     const [side, align] = popoverPlacement.split('-') as [
       DropdownMenu.DropdownMenuContentProps['side'],
       DropdownMenu.DropdownMenuContentProps['align'],
@@ -83,7 +84,7 @@ const MenuContent = React.forwardRef<HTMLDivElement, ContentProps>(
 
     return (
       <DropdownMenu.Portal>
-        <DropdownMenuContent align={align} side={side} loop asChild>
+        <DropdownMenuContent align={align} side={side} loop onCloseAutoFocus={onCloseAutoFocus} asChild>
           <Viewport
             ref={ref}
             direction="column"


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Exposes Radix's onCloseAutoFocus prop on the Menu.Content component.

### Why is it needed?

It's necessary to bring the focus back to the blocks editor in the CMS after a menu item is selected in the toolbar. 

### Related issue(s)/PR(s)

We did the same thing for Select in #1371, it worked nicely.