### PR TITLE
feat: add menu separator component

### DIFF
--- a/.changeset/bright-grapes-juggle.md
+++ b/.changeset/bright-grapes-juggle.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+feat: add menu separator component

--- a/docs/stories/SimpleMenu.mdx
+++ b/docs/stories/SimpleMenu.mdx
@@ -97,6 +97,7 @@ const MyMenu = () => {
       <Menu.Trigger>Actions</Menu.Trigger>
       <Menu.Content>
         <Menu.Item onSelect={() => console.log('opening')}>Open</MenuItem>
+        <Menu.Separator />
         <Menu.Item disabled onSelect={() => console.log('cloning')}>
           Clone
         </Menu.Item>
@@ -123,6 +124,8 @@ const MyMenu = () => {
 ### Item
 
 <ArgTypes of={Menu.Item} />
+
+### Separator
 
 ### Label
 

--- a/docs/stories/SimpleMenu.stories.tsx
+++ b/docs/stories/SimpleMenu.stories.tsx
@@ -69,6 +69,7 @@ export const NestedMenu = {
           <Menu.Label>Category 1</Menu.Label>
           <MenuItem onSelect={() => console.log('adding component 1')}>Component 1</MenuItem>
           <MenuItem onSelect={() => console.log('adding component 2')}>Component 2</MenuItem>
+          <Menu.Separator />
           <Menu.Label>Category 2</Menu.Label>
           <MenuItem onSelect={() => console.log('adding component 3')}>Component 3</MenuItem>
         </Menu.SubContent>

--- a/packages/design-system/src/components/SimpleMenu/Menu.tsx
+++ b/packages/design-system/src/components/SimpleMenu/Menu.tsx
@@ -234,6 +234,28 @@ const OptionLink = styled(Link)`
 `;
 
 /* -------------------------------------------------------------------------------------------------
+ * MenuSeparator
+ * -----------------------------------------------------------------------------------------------*/
+
+interface SeparatorProps extends DropdownMenu.DropdownMenuSeparatorProps {}
+
+const StyledSeparator = styled(Box)`
+  /* Negative horizontal margin to compensate Menu.Content's padding */
+  margin: ${({ theme }) => theme.spaces[1]} -${({ theme }) => theme.spaces[1]};
+  width: calc(100% + ${({ theme }) => theme.spaces[2]});
+  /* Hide separator if there's nothing above in the menu */
+  &:first-child {
+    display: none;
+  }
+`;
+
+const MenuSeparator = React.forwardRef<HTMLDivElement, SeparatorProps>((props: SeparatorProps) => (
+  <DropdownMenu.Separator {...props} asChild>
+    <StyledSeparator height="1px" shrink={0} background="neutral150" />
+  </DropdownMenu.Separator>
+));
+
+/* -------------------------------------------------------------------------------------------------
  * MenuLabel
  * -----------------------------------------------------------------------------------------------*/
 
@@ -323,12 +345,13 @@ const Root = MenuRoot;
 const Trigger = MenuTrigger;
 const Content = MenuContent;
 const Item = MenuItem;
+const Separator = MenuSeparator;
 const Label = MenuLabel;
 const SubRoot = MenuSubRoot;
 const SubTrigger = MenuSubTrigger;
 const SubContent = MenuSubContent;
 
-export { Root, Trigger, Content, Item, Label, SubRoot, SubTrigger, SubContent };
+export { Root, Trigger, Content, Item, Separator, Label, SubRoot, SubTrigger, SubContent };
 export type {
   TriggerProps,
   ContentProps,


### PR DESCRIPTION
### What does it do?

Exports a styled version of Radix's DropdownMenu.Separator component.
### Why is it needed?

It's needed in the designs:

![screenshot 2025-01-31 at 18 07 07@2x](https://github.com/user-attachments/assets/901d1317-fb3f-4bbf-b718-fab75682bc9f)

### How to test it?

See the example in the nested menu storybook
