### PR TITLE
fix: pass menu separator ref

### DIFF
--- a/.changeset/popular-terms-remain.md
+++ b/.changeset/popular-terms-remain.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+fix: pass menu separator ref

--- a/packages/design-system/src/components/SimpleMenu/Menu.tsx
+++ b/packages/design-system/src/components/SimpleMenu/Menu.tsx
@@ -250,9 +250,9 @@ const StyledSeparator = styled(Box)`
   }
 `;
 
-const MenuSeparator = React.forwardRef<HTMLDivElement, SeparatorProps>((props: SeparatorProps) => (
+const MenuSeparator = React.forwardRef<HTMLDivElement, SeparatorProps>((props: SeparatorProps, ref) => (
   <DropdownMenu.Separator {...props} asChild>
-    <StyledSeparator height="1px" shrink={0} background="neutral150" />
+    <StyledSeparator height="1px" shrink={0} background="neutral150" ref={ref} />
   </DropdownMenu.Separator>
 ));
 


### PR DESCRIPTION
### What does it do?

Attaches forwardRef's ref in simple menu separator

### Why is it needed?

Forward ref wasn't doing anything, and more importantly it was breaking the unit tests of the CMS because of this error:

>Warning: forwardRef render functions accept exactly two parameters: props and ref. Did you forget to use the ref parameter?

### Related issue(s)/PR(s)

was missing in #1846 
