### PR TITLE
feat(Menu): add start and end icons to MenuItem

### DIFF
--- a/.changeset/stale-clouds-divide.md
+++ b/.changeset/stale-clouds-divide.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': minor
+---
+
+add start and end icons to MenuItem

--- a/docs/stories/SimpleMenu.stories.tsx
+++ b/docs/stories/SimpleMenu.stories.tsx
@@ -17,8 +17,10 @@ type Story = StoryObj<typeof SimpleMenu>;
 export const Basic = {
   render: () => (
     <SimpleMenu label="Actions">
-      <MenuItem onSelect={() => console.log('opening')}>Open</MenuItem>
-      <MenuItem disabled onSelect={() => console.log('cloning')}>
+      <MenuItem startIcon={<Bell />} onSelect={() => console.log('opening')}>
+        Open
+      </MenuItem>
+      <MenuItem endIcon={<Bell />} disabled onSelect={() => console.log('cloning')}>
         Clone
       </MenuItem>
       <MenuItem onSelect={() => console.log('editing')}>Edit</MenuItem>

--- a/packages/design-system/src/components/SimpleMenu/Menu.test.tsx
+++ b/packages/design-system/src/components/SimpleMenu/Menu.test.tsx
@@ -1,3 +1,4 @@
+import { Bell } from '@strapi/icons';
 import { render as renderRTL } from '@test/utils';
 
 import { Menu } from './SimpleMenu';
@@ -12,7 +13,9 @@ const Component = ({ onAction1Select, onSubmenuAction1Select, disabled }: Compon
   <Menu.Root>
     <Menu.Trigger disabled={disabled}>Actions</Menu.Trigger>
     <Menu.Content>
-      <Menu.Item onSelect={onAction1Select}>Action 1</Menu.Item>
+      <Menu.Item startIcon={<Bell />} endIcon={<Bell />} onSelect={onAction1Select}>
+        Action 1
+      </Menu.Item>
       <Menu.Item isLink href="/home">
         Action 2
       </Menu.Item>
@@ -94,6 +97,16 @@ describe('Menu', () => {
 
       expect(getByRole('menuitem', { name: 'Action 3' })).toBeInTheDocument();
       expect(getByRole('menuitem', { name: 'Action 3' })).toHaveAttribute('target', '_blank');
+    });
+
+    it('should render start and end icons', async () => {
+      const { getByRole, user } = render();
+
+      await user.click(getByRole('button', { name: 'Actions' }));
+
+      expect(getByRole('menuitem', { name: 'Action 1' })).toBeInTheDocument();
+      expect(getByRole('menuitem', { name: 'Action 1' }).children[0]).toBeInstanceOf(SVGElement);
+      expect(getByRole('menuitem', { name: 'Action 1' }).children[2]).toBeInstanceOf(SVGElement);
     });
 
     it('should allow navigating through the list of items with the arrow keys', async () => {

--- a/packages/design-system/src/components/SimpleMenu/Menu.test.tsx
+++ b/packages/design-system/src/components/SimpleMenu/Menu.test.tsx
@@ -105,8 +105,8 @@ describe('Menu', () => {
       await user.click(getByRole('button', { name: 'Actions' }));
 
       expect(getByRole('menuitem', { name: 'Action 1' })).toBeInTheDocument();
-      expect(getByRole('menuitem', { name: 'Action 1' }).children[0]).toBeInstanceOf(SVGElement);
-      expect(getByRole('menuitem', { name: 'Action 1' }).children[2]).toBeInstanceOf(SVGElement);
+      expect(getByRole('menuitem', { name: 'Action 1' }).children[0]).toHaveAttribute('aria-hidden', 'true');
+      expect(getByRole('menuitem', { name: 'Action 1' }).children[2]).toHaveAttribute('aria-hidden', 'true');
     });
 
     it('should allow navigating through the list of items with the arrow keys', async () => {

--- a/packages/design-system/src/components/SimpleMenu/Menu.tsx
+++ b/packages/design-system/src/components/SimpleMenu/Menu.tsx
@@ -178,7 +178,13 @@ const MenuItem = ({ onSelect, disabled = false, isLink, startIcon, endIcon, isEx
   return (
     <DropdownMenu.Item asChild onSelect={onSelect} disabled={disabled}>
       {isLink || isExternal ? (
-        <OptionLink color="neutral800" {...props} isExternal={isExternal ?? false}>
+        <OptionLink
+          color="neutral800"
+          startIcon={startIcon}
+          endIcon={endIcon}
+          {...props}
+          isExternal={isExternal ?? false}
+        >
           <Typography>{props.children}</Typography>
         </OptionLink>
       ) : (

--- a/packages/design-system/src/components/SimpleMenu/Menu.tsx
+++ b/packages/design-system/src/components/SimpleMenu/Menu.tsx
@@ -174,11 +174,11 @@ type ItemProps<TComponent extends React.ComponentType = typeof BaseLink> =
   | ItemInternalLinkProps<TComponent>
   | ItemExternalLinkProps;
 
-const MenuItem = ({ onSelect, disabled = false, isLink, ...props }: ItemProps) => {
+const MenuItem = ({ onSelect, disabled = false, isLink, startIcon, endIcon, isExternal, ...props }: ItemProps) => {
   return (
     <DropdownMenu.Item asChild onSelect={onSelect} disabled={disabled}>
-      {isLink || props.isExternal ? (
-        <OptionLink color="neutral800" {...props} isExternal={props.isExternal ?? false}>
+      {isLink || isExternal ? (
+        <OptionLink color="neutral800" {...props} isExternal={isExternal ?? false}>
           <Typography>{props.children}</Typography>
         </OptionLink>
       ) : (
@@ -190,11 +190,19 @@ const MenuItem = ({ onSelect, disabled = false, isLink, ...props }: ItemProps) =
           gap={2}
           {...props}
         >
-          {props.startIcon}
+          {startIcon && (
+            <Flex tag="span" aria-hidden>
+              {startIcon}
+            </Flex>
+          )}
 
           <Typography grow={1}>{props.children}</Typography>
 
-          {props.endIcon}
+          {endIcon && (
+            <Flex tag="span" aria-hidden>
+              {endIcon}
+            </Flex>
+          )}
         </OptionButton>
       )}
     </DropdownMenu.Item>

--- a/packages/design-system/src/components/SimpleMenu/Menu.tsx
+++ b/packages/design-system/src/components/SimpleMenu/Menu.tsx
@@ -190,11 +190,11 @@ const MenuItem = ({ onSelect, disabled = false, isLink, ...props }: ItemProps) =
           gap={2}
           {...props}
         >
-          {props?.startIcon ? props.startIcon : null}
+          {props.startIcon}
 
           <Typography grow={1}>{props.children}</Typography>
 
-          {props?.endIcon ? props.endIcon : null}
+          {props.endIcon}
         </OptionButton>
       )}
     </DropdownMenu.Item>

--- a/packages/design-system/src/components/SimpleMenu/Menu.tsx
+++ b/packages/design-system/src/components/SimpleMenu/Menu.tsx
@@ -146,6 +146,8 @@ interface ItemSharedProps extends Pick<DropdownMenu.MenuItemProps, 'disabled' | 
   children?: React.ReactNode;
   isExternal?: boolean;
   isFocused?: boolean;
+  startIcon?: React.ReactNode;
+  endIcon?: React.ReactNode;
 }
 
 interface ItemExternalLinkProps extends ItemSharedProps, Omit<LinkProps, 'onSelect'> {
@@ -180,8 +182,19 @@ const MenuItem = ({ onSelect, disabled = false, isLink, ...props }: ItemProps) =
           <Typography>{props.children}</Typography>
         </OptionLink>
       ) : (
-        <OptionButton cursor="pointer" color="neutral800" background="transparent" borderStyle="none" {...props}>
-          <Typography>{props.children}</Typography>
+        <OptionButton
+          cursor="pointer"
+          color="neutral800"
+          background="transparent"
+          borderStyle="none"
+          gap={2}
+          {...props}
+        >
+          {props?.startIcon ? props.startIcon : null}
+
+          <Typography grow={1}>{props.children}</Typography>
+
+          {props?.endIcon ? props.endIcon : null}
         </OptionButton>
       )}
     </DropdownMenu.Item>


### PR DESCRIPTION
### What does it do?

Add start and end icons to Menu.Item

### Why is it needed?

The CMS uses icons in Menu.Item's often

### How to test it?

There are unit tests
Otherwise it can be tested locally in the SimpleMenu.stories.tsx file

