### PR TITLE
fix: add missing scroll wrapper to `Select` element

### DIFF
--- a/.changeset/tiny-melons-help.md
+++ b/.changeset/tiny-melons-help.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+fix: add missing scrollbar to select elements

--- a/packages/design-system/src/components/Select/SelectParts.tsx
+++ b/packages/design-system/src/components/Select/SelectParts.tsx
@@ -10,6 +10,7 @@ import { Flex, FlexComponent } from '../../primitives/Flex';
 import { Typography, TypographyComponent, TypographyProps } from '../../primitives/Typography';
 import { ANIMATIONS } from '../../styles/motion';
 import { inputFocusStyle } from '../../themes';
+import { ScrollArea } from '../../utilities/ScrollArea';
 import { Field, useField } from '../Field';
 
 /* -------------------------------------------------------------------------------------------------
@@ -196,7 +197,15 @@ const StyledValue = styled(Select.Value)`
  * SelectContent
  * -----------------------------------------------------------------------------------------------*/
 
-const SelectContent = styled(Select.Content)`
+const SelectContent = React.forwardRef<HTMLDivElement, ContentProps>((props, ref) => {
+  return (
+    <StyledContent ref={ref} {...props}>
+      <ScrollArea>{props.children}</ScrollArea>
+    </StyledContent>
+  );
+});
+
+const StyledContent = styled(Select.Content)`
   background: ${({ theme }) => theme.colors.neutral0};
   box-shadow: ${({ theme }) => theme.shadows.filterShadow};
   border: 1px solid ${({ theme }) => theme.colors.neutral150};


### PR DESCRIPTION
As described in https://github.com/strapi/design-system/pull/1841, this PR fixes the missing scroll wrapper of the `Select` component.

[Before](https://design-system-git-main-strapijs.vercel.app/?path=/story/inputs-select--base):
![Screenshot 2025-02-11 at 16 51 57](https://github.com/user-attachments/assets/4ef67460-2d9a-4e44-b8f8-36511a29b218)

[After](https://design-system-git-main-strapijs.vercel.app/?path=/story/inputs-select--base):
![Screenshot 2025-02-11 at 16 52 04](https://github.com/user-attachments/assets/c284a52f-4657-49cf-8a1f-b63ca5d16b7e)

MUCH better user experience!