### PR TITLE
fix: remove selected item background

### DIFF
--- a/.changeset/fifty-hats-itch.md
+++ b/.changeset/fifty-hats-itch.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+fix: remove selected item background

--- a/packages/design-system/src/components/Select/SelectParts.tsx
+++ b/packages/design-system/src/components/Select/SelectParts.tsx
@@ -278,11 +278,11 @@ const StyledSelectItem = styled(Select.Item)`
 
   &:hover {
     background-color: ${({ theme }) => theme.colors.primary100};
+    cursor: pointer;
   }
 
   &[data-state='checked'] {
     font-weight: bold;
-    background-color: ${({ theme }) => theme.colors.primary100};
     color: ${({ theme }) => theme.colors.primary600};
     font-weight: bold;
   }


### PR DESCRIPTION
### What does it do?

- Removed the background of the `Select.Item` when it's selected.
- Added a cursor change to pointer when `Select.Item` is hovered.

### Why is it needed?

See https://github.com/strapi/design-system/issues/1808.

### How to test it?

You can check the multiple `Select` [here](https://design-system.strapi.io/?path=/story/inputs-select--multiple).

### Related issue(s)/PR(s)

fixes https://github.com/strapi/design-system/issues/1808