### PR TITLE
feat: use xs iconbutton for combobox, datepicker and searchbar

### DIFF
--- a/.changeset/famous-elephants-confess.md
+++ b/.changeset/famous-elephants-confess.md
@@ -1,0 +1,5 @@
+---
+"@strapi/design-system": patch
+---
+
+feat: use xs iconbutton for combobox, datepicker and searchbar

--- a/.changeset/famous-elephants-confess.md
+++ b/.changeset/famous-elephants-confess.md
@@ -1,5 +1,5 @@
 ---
-"@strapi/design-system": patch
+'@strapi/design-system': patch
 ---
 
 feat: use xs iconbutton for combobox, datepicker and searchbar

--- a/packages/design-system/src/components/Combobox/Combobox.test.tsx
+++ b/packages/design-system/src/components/Combobox/Combobox.test.tsx
@@ -180,11 +180,11 @@ describe('Combobox', () => {
 
       await user.click(getByRole('combobox'));
 
-      expect(queryByRole('button', { name: 'clear', hidden: true })).not.toBeInTheDocument();
+      expect(queryByRole('button', { name: 'Clear', hidden: true })).not.toBeInTheDocument();
 
       await user.type(getByRole('combobox'), 'hamburger');
 
-      expect(getByRole('button', { name: 'clear', hidden: true })).toBeInTheDocument();
+      expect(getByRole('button', { name: 'Clear', hidden: true })).toBeInTheDocument();
     });
 
     it('should handle a custom label being passed', async () => {
@@ -210,7 +210,7 @@ describe('Combobox', () => {
 
       await user.type(getByRole('combobox'), 'hamburger');
 
-      await user.click(getByRole('button', { name: 'clear', hidden: true }));
+      await user.click(getByRole('button', { name: 'Clear', hidden: true }));
 
       expect(getByRole('combobox')).toHaveValue('');
       expect(onClear).toHaveBeenCalledTimes(1);

--- a/packages/design-system/src/components/Combobox/Combobox.tsx
+++ b/packages/design-system/src/components/Combobox/Combobox.tsx
@@ -9,7 +9,7 @@ import { useComposedRefs } from '../../hooks/useComposeRefs';
 import { useControllableState } from '../../hooks/useControllableState';
 import { useId } from '../../hooks/useId';
 import { useIntersection } from '../../hooks/useIntersection';
-import { Box, BoxComponent } from '../../primitives/Box';
+import { Box } from '../../primitives/Box';
 import { Flex } from '../../primitives/Flex';
 import { Typography } from '../../primitives/Typography';
 import { ANIMATIONS } from '../../styles/motion';
@@ -17,6 +17,7 @@ import { inputFocusStyle } from '../../themes';
 import { ScrollArea } from '../../utilities/ScrollArea';
 import { Field, useField } from '../Field';
 import { Loader } from '../Loader';
+import { IconButton } from '../IconButton';
 
 /* -------------------------------------------------------------------------------------------------
  * ComboboxInput
@@ -72,7 +73,7 @@ const Combobox = React.forwardRef<ComboboxInputElement, ComboboxProps>(
       autocomplete,
       children,
       className,
-      clearLabel = 'clear',
+      clearLabel = 'Clear',
       creatable = false,
       createMessage = (value) => `Create "${value}"`,
       defaultFilterValue,
@@ -241,22 +242,17 @@ const Combobox = React.forwardRef<ComboboxInputElement, ComboboxProps>(
           </Flex>
           <Flex tag="span" gap={3}>
             {internalTextValue && onClear ? (
-              <IconBox
-                tag="button"
-                hasRadius
-                background="transparent"
-                type="button"
-                padding={0}
-                color="neutral600"
-                borderStyle="none"
+              <IconButton
+                size='XS' 
+                variant='ghost'
                 onClick={handleClearClick}
                 aria-disabled={disabled}
                 aria-label={clearLabel}
-                title={clearLabel}
+                label={clearLabel}
                 ref={clearRef}
               >
                 <Cross />
-              </IconBox>
+              </IconButton>
             ) : null}
             <DownIcon>
               <CaretDown fill="neutral500" />
@@ -300,10 +296,6 @@ const Combobox = React.forwardRef<ComboboxInputElement, ComboboxProps>(
     );
   },
 );
-
-const IconBox = styled<BoxComponent<'button'>>(Box)`
-  padding: 0;
-`;
 
 const Trigger = styled(ComboboxPrimitive.Trigger)<{
   $hasError?: boolean;

--- a/packages/design-system/src/components/Combobox/Combobox.tsx
+++ b/packages/design-system/src/components/Combobox/Combobox.tsx
@@ -16,8 +16,8 @@ import { ANIMATIONS } from '../../styles/motion';
 import { inputFocusStyle } from '../../themes';
 import { ScrollArea } from '../../utilities/ScrollArea';
 import { Field, useField } from '../Field';
-import { Loader } from '../Loader';
 import { IconButton } from '../IconButton';
+import { Loader } from '../Loader';
 
 /* -------------------------------------------------------------------------------------------------
  * ComboboxInput

--- a/packages/design-system/src/components/Combobox/Combobox.tsx
+++ b/packages/design-system/src/components/Combobox/Combobox.tsx
@@ -243,8 +243,8 @@ const Combobox = React.forwardRef<ComboboxInputElement, ComboboxProps>(
           <Flex tag="span" gap={3}>
             {internalTextValue && onClear ? (
               <IconButton
-                size='XS' 
-                variant='ghost'
+                size="XS"
+                variant="ghost"
                 onClick={handleClearClick}
                 aria-disabled={disabled}
                 aria-label={clearLabel}

--- a/packages/design-system/src/components/DatePicker/DatePicker.tsx
+++ b/packages/design-system/src/components/DatePicker/DatePicker.tsx
@@ -39,8 +39,8 @@ import { useDesignSystem } from '../../utilities/DesignSystemProvider';
 import { DismissibleLayer, DismissibleLayerProps } from '../../utilities/DismissibleLayer';
 import { Portal } from '../../utilities/Portal';
 import { Field, useField } from '../Field';
-import { SingleSelect, SingleSelectOption } from '../Select/SingleSelect';
 import { IconButton } from '../IconButton';
+import { SingleSelect, SingleSelectOption } from '../Select/SingleSelect';
 
 const DEFAULT_PAST_RANGE = 200;
 const DEFAULT_FUTURE_RANGE = 15;
@@ -466,13 +466,6 @@ const TriggerElement = styled<FlexComponent>(Flex)<{ $hasError?: boolean; $size:
   }
 
   ${({ theme, $hasError }) => inputFocusStyle()({ theme, $hasError })};
-`;
-
-const IconBox = styled<BoxComponent<'button'>>(Box)`
-  border: none;
-  color: ${({ theme }) => theme.colors.neutral600};
-  padding: 0;
-  cursor: pointer;
 `;
 
 /* -------------------------------------------------------------------------------------------------

--- a/packages/design-system/src/components/DatePicker/DatePicker.tsx
+++ b/packages/design-system/src/components/DatePicker/DatePicker.tsx
@@ -285,15 +285,15 @@ const DatePicker = React.forwardRef<DatePickerTextInputElement, DatePickerProps>
           <DatePickerTextInput ref={ref} aria-describedby={ariaDescription} id={id} name={name} {...restProps} />
           {textValue && onClear ? (
             <IconButton
-              size='XS' 
-              variant='ghost'
+              size="XS"
+              variant="ghost"
               onClick={handleClearClick}
               aria-disabled={disabled}
               aria-label={clearLabel}
-              label={clearLabel}              
+              label={clearLabel}
               ref={clearRef}
             >
-                <Cross />
+              <Cross />
             </IconButton>
           ) : null}
         </DatePickerTrigger>

--- a/packages/design-system/src/components/DatePicker/DatePicker.tsx
+++ b/packages/design-system/src/components/DatePicker/DatePicker.tsx
@@ -40,6 +40,7 @@ import { DismissibleLayer, DismissibleLayerProps } from '../../utilities/Dismiss
 import { Portal } from '../../utilities/Portal';
 import { Field, useField } from '../Field';
 import { SingleSelect, SingleSelectOption } from '../Select/SingleSelect';
+import { IconButton } from '../IconButton';
 
 const DEFAULT_PAST_RANGE = 200;
 const DEFAULT_FUTURE_RANGE = 15;
@@ -283,19 +284,17 @@ const DatePicker = React.forwardRef<DatePickerTextInputElement, DatePickerProps>
           <Calendar fill="neutral500" aria-hidden />
           <DatePickerTextInput ref={ref} aria-describedby={ariaDescription} id={id} name={name} {...restProps} />
           {textValue && onClear ? (
-            <IconBox
-              tag="button"
-              hasRadius
-              background="transparent"
-              type="button"
+            <IconButton
+              size='XS' 
+              variant='ghost'
               onClick={handleClearClick}
               aria-disabled={disabled}
               aria-label={clearLabel}
-              title={clearLabel}
+              label={clearLabel}              
               ref={clearRef}
             >
-              <Cross />
-            </IconBox>
+                <Cross />
+            </IconButton>
           ) : null}
         </DatePickerTrigger>
         <Portal>

--- a/packages/design-system/src/components/Field/Field.tsx
+++ b/packages/design-system/src/components/Field/Field.tsx
@@ -264,7 +264,7 @@ const InputElement = styled.input<{
 
 const EndAction = styled(Flex)`
   position: absolute;
-  right: ${({ theme }) => theme.spaces[1]};
+  right: ${({ theme }) => theme.spaces[4]};
   top: 50%;
   transform: translateY(-50%);
 `;

--- a/packages/design-system/src/components/Field/Field.tsx
+++ b/packages/design-system/src/components/Field/Field.tsx
@@ -264,7 +264,7 @@ const InputElement = styled.input<{
 
 const EndAction = styled(Flex)`
   position: absolute;
-  right: ${({ theme }) => theme.spaces[4]};
+  right: ${({ theme }) => theme.spaces[1]};
   top: 50%;
   transform: translateY(-50%);
 `;

--- a/packages/design-system/src/components/Searchbar/Searchbar.tsx
+++ b/packages/design-system/src/components/Searchbar/Searchbar.tsx
@@ -7,6 +7,7 @@ import { composeRefs } from '../../hooks/useComposeRefs';
 import { inputFocusStyle } from '../../themes/utils';
 import { VisuallyHidden } from '../../utilities/VisuallyHidden';
 import { Field } from '../Field';
+import { IconButton } from '../IconButton';
 
 const CloseIcon = styled(Cross)`
   font-size: 0.5rem;
@@ -93,7 +94,9 @@ export const Searchbar = React.forwardRef<HTMLInputElement, SearchbarProps>(
                     e.preventDefault();
                   }}
                 >
+                  <IconButton label='Clear' size='XS' variant='ghost'>
                   <CloseIcon />
+                  </IconButton>
                 </Field.Action>
               ) : undefined
             }

--- a/packages/design-system/src/components/Searchbar/Searchbar.tsx
+++ b/packages/design-system/src/components/Searchbar/Searchbar.tsx
@@ -94,8 +94,8 @@ export const Searchbar = React.forwardRef<HTMLInputElement, SearchbarProps>(
                     e.preventDefault();
                   }}
                 >
-                  <IconButton label='Clear' size='XS' variant='ghost'>
-                  <CloseIcon />
+                  <IconButton label="Clear" size="XS" variant="ghost">
+                    <CloseIcon />
                   </IconButton>
                 </Field.Action>
               ) : undefined


### PR DESCRIPTION
### What does it do?

#### Combobox
- Capitalized the first letter of the value of `clearLabel` 
- Replaced `IconBox` by `IconButton`

#### DatePicker
- Replaced `IconBox` by `IconButton`

#### Searchbar
- Wrapped `Cross` icon inside of `IconButton`

#### Field
- Changed the `right` property of `EndAction`

### Why is it needed?

See https://github.com/strapi/design-system/issues/1837, https://github.com/strapi/design-system/issues/1876 and https://github.com/strapi/design-system/issues/1849.

### How to test it?

You'll need to chec the preview.

### Related issue(s)/PR(s)

https://github.com/strapi/design-system/issues/1837
https://github.com/strapi/design-system/issues/1876
https://github.com/strapi/design-system/issues/1849