### PR TITLE
fix: accordion title overflow issue

### DIFF
--- a/.changeset/famous-dryers-float.md
+++ b/.changeset/famous-dryers-float.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+Fixed accordion title overflow issue

--- a/packages/design-system/src/components/Accordion/Accordion.tsx
+++ b/packages/design-system/src/components/Accordion/Accordion.tsx
@@ -136,18 +136,19 @@ const Trigger = React.forwardRef<TriggerElement, TriggerProps>(
             <CaretDown width={size === 'S' ? '1.2rem' : '1.6rem'} height={size === 'S' ? '1.2rem' : '1.6rem'} />
           </TriggerIcon>
         ) : null}
-        <Flex tag="span" gap={2}>
+        <Flex tag="span" gap={2} style={{ overflow: 'hidden' }}>
           {Icon && size === 'S' ? (
             <IconBox>
               <Icon {...iconProps} />
             </IconBox>
           ) : null}
-          <Flex alignItems="flex-start" direction="column" tag="span" ref={forwardedRef}>
+          <Flex alignItems="flex-start" direction="column" tag="span" ref={forwardedRef} style={{ overflow: 'hidden' }}>
             <Typography
               fontWeight={size === 'S' ? 'bold' : undefined}
               ellipsis
               variant={size === 'M' ? 'delta' : undefined}
               textAlign="left"
+              style={{ width: '100%' }}
             >
               {children}
             </Typography>

--- a/packages/design-system/src/components/Accordion/Accordion.tsx
+++ b/packages/design-system/src/components/Accordion/Accordion.tsx
@@ -201,6 +201,7 @@ const AccordionTrigger = styled(RadixAccordion.Trigger)<{ $caretPosition: Trigge
   padding-block: ${(props) => (props.$size === 'S' ? props.theme.spaces[3] : props.theme.spaces[6])};
   cursor: pointer;
   color: ${(props) => props.theme.colors.neutral800};
+  overflow: hidden;
 
   &[data-disabled] {
     cursor: default;

--- a/packages/design-system/src/components/Accordion/Accordion.tsx
+++ b/packages/design-system/src/components/Accordion/Accordion.tsx
@@ -136,19 +136,19 @@ const Trigger = React.forwardRef<TriggerElement, TriggerProps>(
             <CaretDown width={size === 'S' ? '1.2rem' : '1.6rem'} height={size === 'S' ? '1.2rem' : '1.6rem'} />
           </TriggerIcon>
         ) : null}
-        <Flex tag="span" gap={2} style={{ overflow: 'hidden' }}>
+        <Flex tag="span" gap={2} overflow="hidden">
           {Icon && size === 'S' ? (
             <IconBox>
               <Icon {...iconProps} />
             </IconBox>
           ) : null}
-          <Flex alignItems="flex-start" direction="column" tag="span" ref={forwardedRef} style={{ overflow: 'hidden' }}>
+          <Flex alignItems="flex-start" direction="column" tag="span" ref={forwardedRef} overflow="hidden">
             <Typography
               fontWeight={size === 'S' ? 'bold' : undefined}
               ellipsis
               variant={size === 'M' ? 'delta' : undefined}
               textAlign="left"
-              style={{ width: '100%' }}
+              width="100%"
             >
               {children}
             </Typography>


### PR DESCRIPTION

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?
Prevents title string from overflowing

### Why is it needed?

When the title of Accordion is too long, it pushes away the icons on the right out of the screen. 
See: https://github.com/strapi/strapi/issues/23051

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)
https://github.com/strapi/strapi/issues/23051

