### PR TITLE
fixing h3 font size

### DIFF
--- a/docs/components/Typography.tsx
+++ b/docs/components/Typography.tsx
@@ -10,15 +10,7 @@ const H2 = (props: TypographyProps) => (
 );
 
 const H3 = (props: TypographyProps) => (
-  <Typography
-    {...props}
-    tag="h3"
-    variant="delta"
-    textColor="neutral800"
-    marginBottom="1em"
-    marginTop="1.4em"
-    fontSize={4}
-  />
+  <Typography {...props} tag="h3" variant="delta" textColor="neutral800" marginBottom="1em" marginTop="1.4em" />
 );
 
 const H4 = (props: TypographyProps) => (


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?
h3 tags were rendered with the same font-size of the h2 tags

### Why is it needed?
Readability of the documentation is much better.

### How to test it?
Navigate to any documentation page containing a h3

