### PR TITLE
fix: menu zindex

### DIFF
--- a/.changeset/tiny-cups-reflect.md
+++ b/.changeset/tiny-cups-reflect.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+fix: menu z-index

--- a/packages/design-system/src/components/SimpleMenu/Menu.tsx
+++ b/packages/design-system/src/components/SimpleMenu/Menu.tsx
@@ -99,6 +99,7 @@ const MenuContent = React.forwardRef<HTMLDivElement, ContentProps>(
             alignItems="flex-start"
             position="relative"
             overflow="auto"
+            zIndex={({ theme }) => theme.zIndex.popover}
             {...props}
           >
             {children}
@@ -362,6 +363,7 @@ const MenuSubContent = React.forwardRef<HTMLDivElement, SubContentProps>((props,
           padding={1}
           alignItems="flex-start"
           overflow="auto"
+          zIndex={({ theme }) => theme.zIndex.popover}
           {...props}
         />
       </DropdownMenu.SubContent>

--- a/packages/design-system/src/components/SimpleMenu/Menu.tsx
+++ b/packages/design-system/src/components/SimpleMenu/Menu.tsx
@@ -99,7 +99,6 @@ const MenuContent = React.forwardRef<HTMLDivElement, ContentProps>(
             alignItems="flex-start"
             position="relative"
             overflow="auto"
-            zIndex={({ theme }) => theme.zIndex.popover}
             {...props}
           >
             {children}
@@ -115,6 +114,7 @@ const Viewport = styled<FlexComponent>(Flex)`
   scrollbar-width: none;
   -ms-overflow-style: none;
   -webkit-overflow-scrolling: touch;
+  z-index: ${(props) => props.theme.zIndices.popover};
 
   &::-webkit-scrollbar {
     display: none;
@@ -363,7 +363,6 @@ const MenuSubContent = React.forwardRef<HTMLDivElement, SubContentProps>((props,
           padding={1}
           alignItems="flex-start"
           overflow="auto"
-          zIndex={({ theme }) => theme.zIndex.popover}
           {...props}
         />
       </DropdownMenu.SubContent>


### PR DESCRIPTION
### What does it do?

Menu didn't have any zIndex configured, so it was being displayed behind modals, popovers, selects, ...

### Why is it needed?

So its visible in the right z layer.

### How to test it?

Create a Menu inside a modal, and ensure it's visible.


