### PR TITLE
feat: introduce combobox sticky footer prop

### DIFF
--- a/.changeset/dirty-camels-beg.md
+++ b/.changeset/dirty-camels-beg.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': minor
+---
+
+feat: introduce the sticky footer prop in the Combobox

--- a/docs/stories/03-inputs/Combobox.stories.tsx
+++ b/docs/stories/03-inputs/Combobox.stories.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 
 import { Meta, StoryObj } from '@storybook/react';
-import { Combobox, ComboboxOption, Field } from '@strapi/design-system';
+import { Button, Combobox, ComboboxOption, Field, Menu } from '@strapi/design-system';
+import { Plus } from '@strapi/icons';
 import { default as outdent } from 'outdent';
 
 const options = [
@@ -54,6 +55,31 @@ export const Base: Story = {
         <ComboboxOption value="orange">Orange</ComboboxOption>
         <ComboboxOption value="strawberry">Strawberry</ComboboxOption>
       </Combobox>
+        `,
+      },
+    },
+  },
+};
+
+export const NoOptions: Story = {
+  render: (props) => (
+    <Combobox {...props}>
+      {[].map(({ name, value }) => (
+        <ComboboxOption key={value} value={value}>
+          {name}
+        </ComboboxOption>
+      ))}
+    </Combobox>
+  ),
+  parameters: {
+    docs: {
+      source: {
+        code: outdent`
+      {options.map(({ name, value }) => (
+          <ComboboxOption key={value} value={value}>
+            {name}
+          </ComboboxOption>
+        ))}
         `,
       },
     },
@@ -131,6 +157,170 @@ export const Loading: Story = {
           </ComboboxOption>
         ))}
       </Combobox>
+        `,
+      },
+    },
+  },
+};
+
+export const WithStickyFooter: Story = {
+  render: () => {
+    const [isLoading, setIsLoading] = React.useState(false);
+    const handleLoadMore = () => setIsLoading(true);
+
+    React.useEffect(() => {
+      if (isLoading) {
+        const timeout = setTimeout(() => setIsLoading(false), 2000);
+        return () => clearTimeout(timeout);
+      }
+    }, [isLoading]);
+
+    const handleClickButton = () => {
+      // Handle button click to open modal or perform an action
+      console.log('Button clicked');
+    };
+
+    // Create a sticky footer with a button that triggers the modal
+    const createRelationTrigger = (
+      <Button variant="ghost" startIcon={<Plus />} onClick={handleClickButton} fullWidth justifyContent={'start'}>
+        Create a relation
+      </Button>
+    );
+
+    return (
+      <>
+        <Combobox
+          placeholder="My favourite fruit is..."
+          loading={isLoading}
+          onLoadMore={handleLoadMore}
+          hasMoreItems
+          stickyFooter={createRelationTrigger}
+        >
+          {options.map(({ name, value }) => (
+            <ComboboxOption key={value} value={value}>
+              {name}
+            </ComboboxOption>
+          ))}
+        </Combobox>
+      </>
+    );
+  },
+  name: 'With Sticky Footer',
+  parameters: {
+    docs: {
+      source: {
+        code: outdent`
+      // Create a sticky footer with a button that triggers the modal
+      const createRelationTrigger = (
+        <Button 
+          variant="ghost" 
+          startIcon={<Plus />} 
+          onClick={handleModalOpen} 
+          fullWidth
+        >
+          Create a relation
+        </Button>
+      );
+      
+      return (
+        <>
+          <Combobox 
+            placeholder="My favourite fruit is..."
+            loading={isLoading}
+            onLoadMore={handleLoadMore}
+            hasMoreItems
+            stickyFooter={createRelationTrigger}
+          >
+            {options.map(({ name, value }) => (
+              <ComboboxOption key={value} value={value}>
+                {name}
+              </ComboboxOption>
+            ))}
+          </Combobox>          
+        </>
+      );
+        `,
+      },
+    },
+  },
+};
+
+export const WithStickyFooterNoOptions: Story = {
+  render: () => {
+    const [isLoading, setIsLoading] = React.useState(false);
+    const handleLoadMore = () => setIsLoading(true);
+
+    React.useEffect(() => {
+      if (isLoading) {
+        const timeout = setTimeout(() => setIsLoading(false), 2000);
+        return () => clearTimeout(timeout);
+      }
+    }, [isLoading]);
+
+    const handleClickButton = () => {
+      // Handle button click to open modal or perform an action
+      console.log('Button clicked');
+    };
+
+    // Create a sticky footer with a button that triggers the modal
+    const createRelationTrigger = (
+      <Button variant="ghost" startIcon={<Plus />} onClick={handleClickButton} fullWidth>
+        Create a relation
+      </Button>
+    );
+
+    return (
+      <>
+        <Combobox
+          placeholder="My favourite fruit is..."
+          loading={isLoading}
+          onLoadMore={handleLoadMore}
+          hasMoreItems
+          stickyFooter={createRelationTrigger}
+        >
+          {[].map(({ name, value }) => (
+            <ComboboxOption key={value} value={value}>
+              {name}
+            </ComboboxOption>
+          ))}
+        </Combobox>
+      </>
+    );
+  },
+  name: 'With Sticky Footer No Options',
+  parameters: {
+    docs: {
+      source: {
+        code: outdent`
+      // Create a sticky footer with a button that triggers the modal
+      const createRelationTrigger = (
+        <Button 
+          variant="ghost" 
+          startIcon={<Plus />} 
+          onClick={handleModalOpen} 
+          fullWidth
+        >
+          Create a relation
+        </Button>
+      );
+      
+      return (
+        <>
+          <Combobox 
+            placeholder="My favourite fruit is..."
+            loading={isLoading}
+            onLoadMore={handleLoadMore}
+            hasMoreItems
+            stickyFooter={createRelationTrigger}
+          >
+            {[].map(({ name, value }) => (
+              <ComboboxOption key={value} value={value}>
+                {name}
+              </ComboboxOption>
+            ))}
+          </Combobox>          
+        </>
+      );
         `,
       },
     },

--- a/packages/design-system/src/components/Combobox/Combobox.test.tsx
+++ b/packages/design-system/src/components/Combobox/Combobox.test.tsx
@@ -296,4 +296,59 @@ describe('Combobox', () => {
       expect(onCreateOption).toHaveBeenCalledWith('hamb');
     });
   });
+
+  it('should render the sticky footer when provided', async () => {
+    const onFooterClick = jest.fn();
+    const stickyFooter = <button onClick={onFooterClick}>Create new</button>;
+
+    const { getByRole, user } = render({
+      stickyFooter,
+    });
+
+    // Initially the sticky footer should not be visible as the dropdown is closed
+    expect(() => getByRole('button', { name: 'Create new' })).toThrow();
+
+    // Open the dropdown
+    await user.click(getByRole('combobox'));
+
+    // Now the footer should be visible
+    expect(getByRole('button', { name: 'Create new' })).toBeInTheDocument();
+  });
+
+  it('should handle interactions with the sticky footer', async () => {
+    const onFooterClick = jest.fn();
+    const stickyFooter = <button onClick={onFooterClick}>Create new</button>;
+
+    const { getByRole, user } = render({
+      stickyFooter,
+    });
+
+    // Open the dropdown
+    await user.click(getByRole('combobox'));
+
+    // Click the button in the footer
+    await user.click(getByRole('button', { name: 'Create new' }));
+
+    // Check if the click handler was called
+    expect(onFooterClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should render the sticky footer even when there are no options', async () => {
+    const onFooterClick = jest.fn();
+    const stickyFooter = <button onClick={onFooterClick}>Create new</button>;
+
+    const { getByRole, user } = render({
+      options: [],
+      stickyFooter,
+    });
+
+    // Open the dropdown
+    await user.click(getByRole('combobox'));
+
+    // The footer should be visible
+    expect(getByRole('button', { name: 'Create new' })).toBeInTheDocument();
+
+    // And the "No results found" message should also be displayed
+    expect(getByRole('listbox')).toHaveTextContent('No results found');
+  });
 });

--- a/packages/design-system/src/components/Combobox/Combobox.tsx
+++ b/packages/design-system/src/components/Combobox/Combobox.tsx
@@ -62,6 +62,10 @@ interface ComboboxProps
    */
   size?: 'S' | 'M';
   startIcon?: React.ReactNode;
+  /**
+   * Content to be displayed as a sticky footer
+   */
+  stickyFooter?: React.ReactNode;
 }
 
 type ComboboxInputElement = HTMLInputElement;
@@ -102,6 +106,7 @@ const Combobox = React.forwardRef<ComboboxInputElement, ComboboxProps>(
       required: requiredProp = false,
       size = 'M',
       startIcon,
+      stickyFooter,
       textValue,
       value,
       ...restProps
@@ -290,6 +295,7 @@ const Combobox = React.forwardRef<ComboboxInputElement, ComboboxProps>(
                 <Box id={intersectionId} width="100%" height="1px" />
               </Viewport>
             </ScrollArea>
+            {stickyFooter && <StickyFooter>{stickyFooter}</StickyFooter>}
           </Content>
         </ComboboxPrimitive.Portal>
       </ComboboxPrimitive.Root>
@@ -402,6 +408,15 @@ const Content = styled(ComboboxPrimitive.Content)`
 
 const Viewport = styled(ComboboxPrimitive.Viewport)`
   padding: ${({ theme }) => theme.spaces[1]};
+`;
+
+const StickyFooter = styled(Box)`
+  position: sticky;
+  bottom: 0;
+  width: 100%;
+  background: ${({ theme }) => theme.colors.neutral0};
+  border-top: 1px solid ${({ theme }) => theme.colors.neutral150};
+  padding: ${({ theme }) => theme.spaces[2]};
 `;
 
 /* -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

It adds an optional prop, in the Combobox component, to add a sticky element at the bottom of the combobox options

### Why is it needed?

It is needed to add the Create a relation trigger in the Relation field in the CMS but it can be useful to add everything in the future

### How to test it?

In the Storybook select the Combobox input, you can find the sticky footer in the variant "With Sticky Footer" and "With Sticky Footer No options"
