### PR TITLE
fix: Combobox creatable visible button needs to close the combobox when clicked

### DIFF
--- a/.changeset/proud-doors-knock.md
+++ b/.changeset/proud-doors-knock.md
@@ -1,0 +1,6 @@
+---
+'@strapi/design-system': minor
+'@strapi/ui-primitives': minor
+---
+
+fix: combobox creatable visible close when clicked

--- a/packages/design-system/src/components/Combobox/Combobox.test.tsx
+++ b/packages/design-system/src/components/Combobox/Combobox.test.tsx
@@ -313,6 +313,7 @@ describe('Combobox', () => {
       await user.click(createOption);
 
       expect(onCreateOption).toHaveBeenCalledWith('newValue');
+      expect(onCreateOption).toHaveBeenCalledTimes(1);
     });
 
     it('should handle clicking the visible creatable option without typing', async () => {
@@ -330,7 +331,7 @@ describe('Combobox', () => {
       expect(createOption).toBeInTheDocument();
       await user.click(createOption);
 
-      expect(onCreateOption).toHaveBeenCalled();
+      expect(onCreateOption).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/design-system/src/components/Combobox/Combobox.tsx
+++ b/packages/design-system/src/components/Combobox/Combobox.tsx
@@ -182,6 +182,7 @@ const Combobox = React.forwardRef<ComboboxInputElement, ComboboxProps>(
         onCreateOption(internalTextValue);
       } else if (onCreateOption && creatable === 'visible') {
         onCreateOption();
+        setInternalIsOpen(false);
       }
     };
 

--- a/packages/design-system/src/components/Combobox/Combobox.tsx
+++ b/packages/design-system/src/components/Combobox/Combobox.tsx
@@ -177,7 +177,7 @@ const Combobox = React.forwardRef<ComboboxInputElement, ComboboxProps>(
       }
     };
 
-    const handleCreateItemClick = () => {
+    const handleCreateItemClick = (event) => {
       if (onCreateOption && internalTextValue && creatable !== 'visible') {
         onCreateOption(internalTextValue);
       } else if (onCreateOption && creatable === 'visible') {
@@ -284,7 +284,7 @@ const Combobox = React.forwardRef<ComboboxInputElement, ComboboxProps>(
                 <Box id={intersectionId} width="100%" height="1px" />
               </ScrollAreaCombobox>
               {creatable ? (
-                <ComboboxCreateItem onPointerUp={handleCreateItemClick} asChild>
+                <ComboboxCreateItem onClick={handleCreateItemClick} asChild>
                   <OptionBox>
                     <Flex gap={2}>
                       {creatableStartIcon && (

--- a/packages/design-system/src/components/Combobox/Combobox.tsx
+++ b/packages/design-system/src/components/Combobox/Combobox.tsx
@@ -285,7 +285,7 @@ const Combobox = React.forwardRef<ComboboxInputElement, ComboboxProps>(
                 <Box id={intersectionId} width="100%" height="1px" />
               </ScrollAreaCombobox>
               {creatable ? (
-                <ComboboxCreateItem onClick={handleCreateItemClick} asChild>
+                <ComboboxCreateItem onPointerUp={handleCreateItemClick} onClick={handleCreateItemClick} asChild>
                   <OptionBox>
                     <Flex gap={2}>
                       {creatableStartIcon && (

--- a/packages/design-system/src/components/Combobox/Combobox.tsx
+++ b/packages/design-system/src/components/Combobox/Combobox.tsx
@@ -177,7 +177,7 @@ const Combobox = React.forwardRef<ComboboxInputElement, ComboboxProps>(
       }
     };
 
-    const handleCreateItemClick = (event) => {
+    const handleCreateItemClick = () => {
       if (onCreateOption && internalTextValue && creatable !== 'visible') {
         onCreateOption(internalTextValue);
       } else if (onCreateOption && creatable === 'visible') {

--- a/packages/primitives/src/components/Combobox/Combobox.tsx
+++ b/packages/primitives/src/components/Combobox/Combobox.tsx
@@ -1132,7 +1132,7 @@ const ComboboxItemImpl = React.forwardRef<ComboboxItemImplElement, ItemImplProps
       {...restProps}
       id={id}
       ref={composedRefs}
-      onClick={composeEventHandlers(restProps.onClick, handleSelect)}
+      onPointerUp={composeEventHandlers(restProps.onPointerUp, handleSelect)}
     />
   );
 });
@@ -1316,7 +1316,7 @@ const ComboboxCreateItem = React.forwardRef<ComboboxItemElement, CreateItemProps
         {...restProps}
         id={id}
         ref={composedRefs}
-        onClick={composeEventHandlers(restProps.onClick, handleSelect)}
+        onPointerUp={composeEventHandlers(restProps.onPointerUp, handleSelect)}
       />
     </Collection.ItemSlot>
   );

--- a/packages/primitives/src/components/Combobox/Combobox.tsx
+++ b/packages/primitives/src/components/Combobox/Combobox.tsx
@@ -1132,7 +1132,7 @@ const ComboboxItemImpl = React.forwardRef<ComboboxItemImplElement, ItemImplProps
       {...restProps}
       id={id}
       ref={composedRefs}
-      onPointerUp={composeEventHandlers(restProps.onPointerUp, handleSelect)}
+      onClick={composeEventHandlers(restProps.onClick, handleSelect)}
     />
   );
 });
@@ -1316,7 +1316,7 @@ const ComboboxCreateItem = React.forwardRef<ComboboxItemElement, CreateItemProps
         {...restProps}
         id={id}
         ref={composedRefs}
-        onClick={composeEventHandlers(restProps.onPointerUp, handleSelect)}
+        onClick={composeEventHandlers(restProps.onClick, handleSelect)}
       />
     </Collection.ItemSlot>
   );


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

It fixes some small errors we introduced with the refactoring of the Combobox

### Why is it needed?

it doesn't close the combobox when the creatable button is clicked with creatable="visible"

### How to test it?

Try to click on the creatable button in the Creatable Visible scenario in the storybook (with mouse and keyboard) and check if the combobox is then closed

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
