### PR TITLE
fix: Combobox fix background issue in the creatable button on hover

### DIFF
--- a/.changeset/famous-starfishes-marry.md
+++ b/.changeset/famous-starfishes-marry.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': minor
+---
+
+fix: combobox creatable button background on hover

--- a/packages/design-system/src/components/Combobox/Combobox.tsx
+++ b/packages/design-system/src/components/Combobox/Combobox.tsx
@@ -426,7 +426,7 @@ const ComboboxCreateItem = styled(ComboboxPrimitive.CreateItem)`
   }
   &&:hover,
   &&[data-highlighted] {
-    background-color: transparent;
+    background: ${({ theme }) => theme.colors.neutral0};
   }
   && > div {
     padding: ${({ theme }) => theme.spaces[2]} ${({ theme }) => theme.spaces[4]};


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Fix an issue when you hover the creatable button with different options in the Combobox

### Why is it needed?

To solve this issue
<img width="405" alt="Screenshot 2025-04-30 alle 10 04 36" src="https://github.com/user-attachments/assets/5fd1c6bf-ea13-40fa-a889-3d67e1f499be" />

### How to test it?

Check the Combobox creatable option in the storybook and scroll the different options and hover the creatable button to check if the issue is gone

### Related issue(s)/PR(s)

CS-1409
