### PR TITLE
feat: add disabled state to the create item option

### DIFF
--- a/.changeset/tender-waves-fry.md
+++ b/.changeset/tender-waves-fry.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': minor
+---
+
+feat: add disabled mode to the combobox create item option

--- a/docs/stories/03-inputs/Combobox.stories.tsx
+++ b/docs/stories/03-inputs/Combobox.stories.tsx
@@ -245,6 +245,65 @@ export const CreatableVisible: Story = {
   },
 };
 
+export const CreatableDisabled: Story = {
+  render: () => {
+    const [value, setValue] = React.useState<string | undefined>('');
+
+    const onCreateOption = () => {
+      console.log('Created option');
+    };
+
+    return (
+      <Combobox
+        placeholder="My favourite fruit is..."
+        value={value}
+        onChange={setValue}
+        onCreateOption={onCreateOption}
+        creatable="visible"
+        creatableDisabled={true}
+        creatableStartIcon={<Plus fill="neutral500" />}
+        createMessage={() => 'Create a fruit'}
+      >
+        {options.map(({ name, value }) => (
+          <ComboboxOption key={value} value={value}>
+            <Flex gap={2} justifyContent="space-between">
+              <Flex gap={2}>
+                <LinkIcon fill="neutral500" />
+                <Typography ellipsis>{name}</Typography>
+              </Flex>
+            </Flex>
+          </ComboboxOption>
+        ))}
+      </Combobox>
+    );
+  },
+  name: 'Creatable Disabled',
+  parameters: {
+    docs: {
+      source: {
+        code: outdent`
+      <Combobox
+        placeholder="My favourite fruit is..."
+        value={value}
+        onChange={setValue}
+        onCreateOption={onCreateOption}
+        creatable="visible"
+        creatableDisabled={true}
+        creatableStartIcon={<Plus fill="neutral500" />}
+        createMessage={() => 'Create a relation'}
+      >
+        {dynamicOptions.map(({ name, value }) => (
+          <ComboboxOption key={value} value={value}>
+            {name}
+          </ComboboxOption>
+        ))}
+      </Combobox>
+        `,
+      },
+    },
+  },
+};
+
 type Autocomplete = 'none' | 'list' | 'both' | { type: 'list'; filter: 'startsWith' | 'contains' };
 
 export const Autocomplete = {

--- a/packages/design-system/src/components/Combobox/Combobox.tsx
+++ b/packages/design-system/src/components/Combobox/Combobox.tsx
@@ -47,6 +47,7 @@ interface ComboboxProps
     Omit<ComboboxPrimitive.TextInputProps, 'required' | 'disabled' | 'value' | 'onChange' | 'size'> {
   clearLabel?: string;
   creatable?: boolean | 'visible';
+  creatableDisabled?: boolean;
   createMessage?: (value: string) => string;
   creatableStartIcon?: React.ReactNode;
   hasMoreItems?: boolean;
@@ -76,6 +77,7 @@ const Combobox = React.forwardRef<ComboboxInputElement, ComboboxProps>(
       className,
       clearLabel = 'Clear',
       creatable = false,
+      creatableDisabled = false,
       creatableStartIcon,
       createMessage = (value) => `Create "${value}"`,
       defaultFilterValue,
@@ -285,7 +287,12 @@ const Combobox = React.forwardRef<ComboboxInputElement, ComboboxProps>(
                 <Box id={intersectionId} width="100%" height="1px" />
               </ScrollAreaCombobox>
               {creatable ? (
-                <ComboboxCreateItem onPointerUp={handleCreateItemClick} onClick={handleCreateItemClick} asChild>
+                <ComboboxCreateItem
+                  onPointerUp={handleCreateItemClick}
+                  onClick={handleCreateItemClick}
+                  disabled={creatableDisabled}
+                  asChild
+                >
                   <OptionBox>
                     <Flex gap={2}>
                       {creatableStartIcon && (
@@ -428,12 +435,24 @@ const ComboboxCreateItem = styled(ComboboxPrimitive.CreateItem)`
   &&[data-highlighted] {
     background-color: transparent;
   }
+  &&[data-disabled] {
+    color: ${({ theme }) => theme.colors.neutral600};
+    background: ${({ theme }) => theme.colors.neutral150};
+    cursor: not-allowed;
+  }
+  &&[data-disabled]:hover {
+    background: ${({ theme }) => theme.colors.neutral150};
+    color: ${({ theme }) => theme.colors.neutral600};
+  }
   && > div {
     padding: ${({ theme }) => theme.spaces[2]} ${({ theme }) => theme.spaces[4]};
   }
   && > div:hover,
   &&[data-highlighted] > div {
     background-color: ${({ theme }) => theme.colors.primary100};
+  }
+  &&[data-disabled] > div:hover {
+    background: ${({ theme }) => theme.colors.neutral150};
   }
 `;
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Add a new disabled state, and style, to the Combobox Create item option

### Why is it needed?

We want to show the combobox options and disable the combobox create item button in case the user has no permission to create an item.

### How to test it?

In the storybook you can find a new Combobox Creatable disabled section to check the solution provided.

### Related issue(s)/PR(s)

CS-1405
