### PR TITLE
fix: fix the bug CarouselInput shows all slides at once

### DIFF
--- a/.changeset/many-countries-look.md
+++ b/.changeset/many-countries-look.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': minor
+---
+
+fix: carousel slide display when selected

--- a/packages/design-system/src/components/CarouselInput/CarouselSlide.tsx
+++ b/packages/design-system/src/components/CarouselInput/CarouselSlide.tsx
@@ -1,15 +1,20 @@
-import { Flex, FlexProps } from '../../primitives/Flex';
+import { styled } from 'styled-components';
 
+import { Flex, FlexComponent, FlexProps } from '../../primitives/Flex';
 export interface CarouselSlideProps extends FlexProps {
   children: React.ReactNode;
   label: string;
   selected?: boolean;
 }
 
+const CarouselSlideFlex = styled<FlexComponent>(Flex)<{ $selected: boolean }>`
+  display: ${({ $selected }) => ($selected ? 'flex' : 'none')};
+`;
+
 export const CarouselSlide = ({ label, children, selected = false, ...props }: CarouselSlideProps) => (
-  <Flex
+  <CarouselSlideFlex
+    $selected={selected}
     alignItems="center"
-    display={selected ? 'flex' : 'none'}
     role="group"
     aria-roledescription="slide"
     aria-label={label}
@@ -19,5 +24,5 @@ export const CarouselSlide = ({ label, children, selected = false, ...props }: C
     {...props}
   >
     {children}
-  </Flex>
+  </CarouselSlideFlex>
 );


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

it fixes the display property in case a slide is selected, because we had a conflict with the display none and display flex in the CarouselSlide element

### Why is it needed?

Because before CarouselInput shows all slides at once

### How to test it?

Go to the storybook and select the CarouselInput component and check the base case where we have three images to slide

### Related issue(s)/PR(s)

fixes https://github.com/strapi/design-system/issues/1909
