### PR TITLE
Fix: input box shadows cropped

### DIFF
--- a/.changeset/quiet-wolves-move.md
+++ b/.changeset/quiet-wolves-move.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': minor
+---
+
+fix: solve the cropped box shadow in input elements when focused

--- a/packages/design-system/src/components/Modal/Modal.tsx
+++ b/packages/design-system/src/components/Modal/Modal.tsx
@@ -189,6 +189,10 @@ const BodyScroll = styled(ScrollArea)`
 
   & > div {
     padding-block: ${(props) => props.theme.spaces[8]};
+    /* Add negative margin and padding to avoid cropping the box shadow when the inputs are focused */
+    margin: 0 -2px 0 -2px;
+    padding-left: 2px;
+    padding-right: 2px;
 
     & > div {
       // the scroll area component applies a display: table to the child, which we don't want.

--- a/packages/design-system/src/themes/utils.ts
+++ b/packages/design-system/src/themes/utils.ts
@@ -13,11 +13,6 @@ export const inputFocusStyle =
     transition-property: border-color, box-shadow, fill;
     transition-duration: 0.2s;
 
-    /* Add a margin left and right to reserve space for the box shadow */
-    ${rootElement} {
-      margin: 0 2px;
-    }
-
     ${rootElement}:focus-within {
       border: 1px solid ${$hasError ? theme.colors.danger600 : theme.colors.primary600};
       box-shadow: ${$hasError ? theme.colors.danger600 : theme.colors.primary600} 0px 0px 0px 2px;

--- a/packages/design-system/src/themes/utils.ts
+++ b/packages/design-system/src/themes/utils.ts
@@ -13,6 +13,11 @@ export const inputFocusStyle =
     transition-property: border-color, box-shadow, fill;
     transition-duration: 0.2s;
 
+    /* Add a margin left and right to reserve space for the box shadow */
+    ${rootElement} {
+      margin: 0 2px;
+    }
+
     ${rootElement}:focus-within {
       border: 1px solid ${$hasError ? theme.colors.danger600 : theme.colors.primary600};
       box-shadow: ${$hasError ? theme.colors.danger600 : theme.colors.primary600} 0px 0px 0px 2px;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Fix the issue we had on the left and right of focused input elements inside modals

### Why is it needed?

the left and right shadows of input elements where sometimes cropped

### How to test it?

Try to test the issue in the Storybook in the Modal component

### Related issue(s)/PR(s)

fixes https://github.com/strapi/design-system/issues/1902
