### PR TITLE
fix: scroll in combobox inside modal

### DIFF
--- a/.changeset/wild-geese-lay.md
+++ b/.changeset/wild-geese-lay.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+fix: modal issues (scrolling and combobox)

--- a/packages/design-system/src/components/Modal/Modal.tsx
+++ b/packages/design-system/src/components/Modal/Modal.tsx
@@ -4,6 +4,7 @@ import * as Dialog from '@radix-ui/react-dialog';
 import { Cross } from '@strapi/icons';
 import { styled } from 'styled-components';
 
+import { setOpacity } from '../../helpers/setOpacity';
 import { Flex, type FlexComponent, type FlexProps } from '../../primitives/Flex';
 import { Typography, TypographyProps } from '../../primitives/Typography';
 import { ANIMATIONS } from '../../styles/motion';
@@ -41,18 +42,18 @@ interface ContentProps extends Dialog.DialogContentProps {}
 const Content = React.forwardRef<ContentElement, ContentProps>((props, forwardedRef) => {
   return (
     <Dialog.Portal>
-      <Overlay />
-      <ContentImpl ref={forwardedRef} {...props} />
+      <Overlay>
+        <ContentImpl ref={forwardedRef} {...props} />
+      </Overlay>
     </Dialog.Portal>
   );
 });
 
 const Overlay = styled(Dialog.Overlay)`
-  background-color: ${(props) => props.theme.colors.neutral800};
+  background: ${(props) => setOpacity(props.theme.colors.neutral800, 0.2)};
   position: fixed;
   inset: 0;
   z-index: ${(props) => props.theme.zIndices.overlay};
-  opacity: 0.2;
   will-change: opacity;
 
   @media (prefers-reduced-motion: no-preference) {
@@ -81,6 +82,11 @@ const ContentImpl = styled(Dialog.Content)`
   box-shadow: ${(props) => props.theme.shadows.popupShadow};
   z-index: ${(props) => props.theme.zIndices.modal};
 
+  > form {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
   @media (prefers-reduced-motion: no-preference) {
     &[data-state='open'] {
       animation-duration: ${(props) => props.theme.motion.timings['200']};
@@ -185,7 +191,7 @@ const Body = React.forwardRef<BodyElement, BodyProps>(({ children, ...restProps 
 });
 
 const BodyScroll = styled(ScrollArea)`
-  padding-inline: ${(props) => props.theme.spaces[8]};
+  padding-inline: ${(props) => props.theme.spaces[7]};
 
   & > div {
     padding-block: ${(props) => props.theme.spaces[8]};


### PR DESCRIPTION
fix: scroll body modal that contains a form
fix: decrease body padding of modal

### What does it do?

Fixes various issues with modals.
- The scroll in a combobox is not working inside a modal
- The scroll inside the modal is not working when a form wraps the Modal.Body
- The padding of the body is too big (should be 32px instead of 40px, see strapi/strapi issue [#20821](https://github.com/strapi/strapi/issues/20821))

First tab showed is current behaviour and second tab is the design system fixed:
https://github.com/user-attachments/assets/2aee564e-7351-404f-9b75-37e2d6645ba9


### Why is it needed?

The user has some trouble using the modals correctly (especially the scroll of the combobox) making it very difficult to perform actions.

### How to test it?

In Storybook:
- Go to Components > Modal and choose the story you want
- Resize the window and try to scroll inside the modal when shrinked
- Click on the combobox and try to scroll inside the results list

On strapi admin interface:
- Go to Releases
- Click on + New release
- Resize the window and try to scroll inside the modal when shrinked
- Click on the combobox and try to scroll inside the results list

### Related issue(s)/PR(s)

Resolves strapi/strapi issues:
- [#23205](https://github.com/strapi/strapi/issues/23205)
- [#23497](https://github.com/strapi/strapi/issues/23497)
- [#20821](https://github.com/strapi/strapi/issues/20821)

🚀