### PR TITLE
chore: enable experimental release for the DS

### DIFF
--- a/.changeset/proud-rivers-cross.md
+++ b/.changeset/proud-rivers-cross.md
@@ -1,0 +1,7 @@
+---
+'@strapi/design-system': minor
+'@strapi/icons': minor
+'@strapi/ui-primitives': minor
+---
+
+chore: enable the ds pre-release gh action

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Build
         run: yarn build --filter=\!@strapi/design-system-docs
 
+      - name: Exit changeset pre-release mode
+        run: yarn changeset pre exit
+
       - run: ./scripts/pre-publish.sh --yes
         env:
           VERSION: '0.0.0-${{ github.sha }}'

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -50,5 +50,8 @@ jobs:
 
       - run: ./scripts/pre-publish.sh --yes
         env:
-          VERSION: '0.0.0-${{ github.sha }}'
+          VERSION: '0.0.0-experimental.${{ github.sha }}'
           DIST_TAG: experimental
+
+      - name: Re-enter changeset pre-release mode
+        run: yarn changeset pre enter experimental


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

I added a step in the experimental gh action to exit the changeset pre release mode to allow snapshot releases

### Why is it needed?

Because otherwise we have this error
<img width="1138" alt="Screenshot 2025-06-03 alle 15 41 47" src="https://github.com/user-attachments/assets/02647158-967d-4ea2-9d52-c6cc1b2366a7" />


### How to test it?

We need to try an experimental and see if it solve the issue
