### PR TITLE
fix: datetime fields responsive

### DIFF
--- a/.changeset/thirty-wasps-explode.md
+++ b/.changeset/thirty-wasps-explode.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+Improve responsive of the DateTimePicker

--- a/packages/design-system/src/components/DateTimePicker/DateTimePicker.tsx
+++ b/packages/design-system/src/components/DateTimePicker/DateTimePicker.tsx
@@ -13,13 +13,11 @@ import { Field, useField } from '../Field';
 import { TimePicker as BaseTimePicker, TimePickerProps } from '../TimePicker';
 
 const DatePicker = styled(DatePickerInput)`
-  flex: 1 1 70%;
-  min-width: 120px;
+  min-width: 180px;
 `;
 
 const TimePicker = styled(BaseTimePicker)`
-  flex: 1 1 30%;
-  min-width: 140px;
+  min-width: 180px;
 `;
 
 export interface DateTimePickerProps
@@ -144,8 +142,8 @@ export const DateTimePicker = React.forwardRef<DatePickerElement, DateTimePicker
     const hasError = Boolean(error) || hasErrorProp;
 
     return (
-      <Flex aria-labelledby={labelNode ? `${id}-label` : undefined} role="group" flex="1" gap={1}>
-        <Field.Root>
+      <Flex aria-labelledby={labelNode ? `${id}-label` : undefined} role="group" flex="1" gap={1} wrap="wrap">
+        <Field.Root flex="1">
           <DatePicker
             {...props}
             size={size}
@@ -159,7 +157,7 @@ export const DateTimePicker = React.forwardRef<DatePickerElement, DateTimePicker
             aria-label={dateLabel}
           />
         </Field.Root>
-        <Field.Root>
+        <Field.Root flex="1">
           <TimePicker
             size={size}
             hasError={hasError}


### PR DESCRIPTION
### What does it do?

Improve the responsive of the datetime picker fields on small containers.

https://github.com/user-attachments/assets/e4816e78-ceaf-484d-bb1d-473d817e01f3

_I also took the liberty to unify the size between the two elements (most of the time it's 50/50 in the admin interface)_

### Why is it needed?

Improve the experience on smaller screens or when including a datetime field inside a modal / small container.

### How to test it?

- Go to storybook > Inputs > DateTimePicker
- Try to resize the window

### Related issue(s)/PR(s)

Resolves [#1853](https://github.com/strapi/design-system/issues/1853)

🚀