### PR TITLE
fix: disabled checked checkboxes border

### DIFF
--- a/.changeset/wise-doors-hope.md
+++ b/.changeset/wise-doors-hope.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+fix: disabled checked checkboxes border

--- a/docs/stories/03-inputs/Checkbox.stories.tsx
+++ b/docs/stories/03-inputs/Checkbox.stories.tsx
@@ -123,12 +123,13 @@ export const Indeterminate = {
 export const Disabled = {
   args: {
     disabled: true,
+    checked: true,
   },
   name: 'Disabled',
   parameters: {
     docs: {
       source: {
-        code: '<Checkbox disabled>Remember me</Checkbox>',
+        code: '<Checkbox disabled checked>Remember me</Checkbox>',
       },
     },
   },

--- a/packages/design-system/src/components/Checkbox/Checkbox.tsx
+++ b/packages/design-system/src/components/Checkbox/Checkbox.tsx
@@ -75,8 +75,8 @@ const CheckboxRoot = styled(Checkbox.Root)`
   // this ensures the checkbox is always a square even in flex-containers.
   flex: 0 0 2rem;
 
-  &[data-state='checked'],
-  &[data-state='indeterminate'] {
+  &[data-state='checked']:not([data-disabled]),
+  &[data-state='indeterminate']:not([data-disabled]) {
     border: 1px solid ${(props) => props.theme.colors.primary600};
     background-color: ${(props) => props.theme.colors.primary600};
   }


### PR DESCRIPTION
### What does it do?

Fix the border color of checked disabled checboxes. They are supposed to be grey but currently they are blue due to a little CSS condition missing in the target rule.

Screenshot of the issue:
![image](https://github.com/user-attachments/assets/cd02d03e-924b-4621-8daf-bb072ddb0bd0)


### Why is it needed?

It's not very intuitive for the user and he couldn't understand if the checkbox is focused, active or not.

### How to test it?

- Go to the admin interface > Settings > Roles
- Click on Super Admin role to display the disabled checboxes

### Related issue(s)/PR(s)

Resolves https://github.com/strapi/strapi/issues/22032

🚀