### PR TITLE
fix: wrapping content of dialog in overlay to restore pointer-events

### DIFF
--- a/.changeset/tricky-plants-sip.md
+++ b/.changeset/tricky-plants-sip.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+fix: wrapping content of dialog in overlay to restore pointer-events

--- a/docs/stories/04-components/Dialog.stories.tsx
+++ b/docs/stories/04-components/Dialog.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
-import { Button, Dialog, Flex, Radio } from '@strapi/design-system';
+import { Button, Dialog, Field, Flex, Radio, SingleSelect, SingleSelectOption } from '@strapi/design-system';
 import { WarningCircle } from '@strapi/icons';
 import { outdent } from 'outdent';
 
@@ -33,11 +33,24 @@ const meta: Meta<DialogArgs> = {
         code: outdent`
           <Dialog.Root>
             <Dialog.Trigger>
-              <Button variant="danger">Delete</Button>
+              <Button variant="danger">Choose a fruit</Button>
             </Dialog.Trigger>
             <Dialog.Content>
               <Dialog.Header>Confirmation</Dialog.Header>
-              <Dialog.Body icon={<WarningCircle fill="danger600" />}>Are you sure you want to delete this?</Dialog.Body>
+              <Dialog.Body>
+                <Field.Root width="100%">
+                  <Field.Label>What is your favourite fruit?</Field.Label>
+                  <SingleSelect placeholder="Pick a fruit...">
+                    <SingleSelectOption value="apple">Apple</SingleSelectOption>
+                    <SingleSelectOption value="avocado">Avocado</SingleSelectOption>
+                    <SingleSelectOption value="banana">Banana</SingleSelectOption>
+                    <SingleSelectOption value="kiwi">Kiwi</SingleSelectOption>
+                    <SingleSelectOption value="mango">Mango</SingleSelectOption>
+                    <SingleSelectOption value="orange">Orange</SingleSelectOption>
+                    <SingleSelectOption value="strawberry">Strawberry</SingleSelectOption>
+                  </SingleSelect>
+                </Field.Root>
+              </Dialog.Body>
               <Dialog.Footer>
                 <Dialog.Cancel>
                   <Button fullWidth variant="tertiary">
@@ -45,8 +58,8 @@ const meta: Meta<DialogArgs> = {
                   </Button>
                 </Dialog.Cancel>
                 <Dialog.Action>
-                  <Button fullWidth variant="danger-light">
-                    Yes, delete
+                  <Button fullWidth variant="success-light">
+                    Confirm
                   </Button>
                 </Dialog.Action>
               </Dialog.Footer>
@@ -60,7 +73,7 @@ const meta: Meta<DialogArgs> = {
     return (
       <Dialog.Root {...args}>
         <Dialog.Trigger>
-          <Button variant="danger">Delete</Button>
+          <Button variant="default">Fruit manager</Button>
         </Dialog.Trigger>
         <Dialog.Content
           onOpenAutoFocus={onOpenAutoFocus}
@@ -68,7 +81,20 @@ const meta: Meta<DialogArgs> = {
           onEscapeKeyDown={onEscapeKeyDown}
         >
           <Dialog.Header>Confirmation</Dialog.Header>
-          <Dialog.Body icon={icon}>Are you sure you want to delete this?</Dialog.Body>
+          <Dialog.Body>
+            <Field.Root width="100%">
+              <Field.Label>What is your favourite fruit?</Field.Label>
+              <SingleSelect placeholder="Pick a fruit...">
+                <SingleSelectOption value="apple">Apple</SingleSelectOption>
+                <SingleSelectOption value="avocado">Avocado</SingleSelectOption>
+                <SingleSelectOption value="banana">Banana</SingleSelectOption>
+                <SingleSelectOption value="kiwi">Kiwi</SingleSelectOption>
+                <SingleSelectOption value="mango">Mango</SingleSelectOption>
+                <SingleSelectOption value="orange">Orange</SingleSelectOption>
+                <SingleSelectOption value="strawberry">Strawberry</SingleSelectOption>
+              </SingleSelect>
+            </Field.Root>
+          </Dialog.Body>
           <Dialog.Footer>
             <Dialog.Cancel>
               <Button fullWidth variant="tertiary">
@@ -76,8 +102,8 @@ const meta: Meta<DialogArgs> = {
               </Button>
             </Dialog.Cancel>
             <Dialog.Action>
-              <Button fullWidth variant="danger-light">
-                Yes, delete
+              <Button fullWidth variant="success-light">
+                Confirm
               </Button>
             </Dialog.Action>
           </Dialog.Footer>
@@ -108,7 +134,7 @@ export const Children = {
     return (
       <Dialog.Root {...args}>
         <Dialog.Trigger>
-          <Button variant="danger">Delete</Button>
+          <Button variant="default">Fruit manager</Button>
         </Dialog.Trigger>
         <Dialog.Content
           onOpenAutoFocus={onOpenAutoFocus}

--- a/packages/design-system/src/components/Dialog/Dialog.tsx
+++ b/packages/design-system/src/components/Dialog/Dialog.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import * as AlertDialog from '@radix-ui/react-alert-dialog';
 import { styled } from 'styled-components';
 
+import { setOpacity } from '../../helpers/setOpacity';
 import { Flex, FlexComponent, FlexProps } from '../../primitives/Flex';
 import { Typography, TypographyComponent, TypographyProps } from '../../primitives/Typography';
 import { ANIMATIONS } from '../../styles/motion';
@@ -38,18 +39,19 @@ interface ContentProps extends AlertDialog.AlertDialogContentProps {}
 const Content = React.forwardRef<ContentElement, ContentProps>((props, forwardedRef) => {
   return (
     <AlertDialog.Portal>
-      <Overlay />
-      <ContentImpl ref={forwardedRef} {...props} />
+      <Overlay>
+        <ContentImpl ref={forwardedRef} {...props} />
+      </Overlay>
     </AlertDialog.Portal>
   );
 });
 
 const Overlay = styled(AlertDialog.Overlay)`
-  background-color: ${(props) => props.theme.colors.neutral800};
+  background: ${(props) => setOpacity(props.theme.colors.neutral800, 0.2)};
   position: fixed;
   inset: 0;
   z-index: ${(props) => props.theme.zIndices.overlay};
-  opacity: 0.2;
+  will-change: opacity;
 
   @media (prefers-reduced-motion: no-preference) {
     animation: ${ANIMATIONS.overlayFadeIn} ${(props) => props.theme.motion.timings['200']}


### PR DESCRIPTION
### What does it do?

Wraps the content of a dialog inside the overlay to restore the pointer-events and allow user to scroll in select that would be included in a dialog.

### Why is it needed?

The user can't scroll in a select inside a dialog.

### How to test it?

- Go to the admin interface > Content manager
- Pick a localized collection
- Create or edit an item
- Create multiple languages variations of the item (at least 5)
- Create again a new language variation
- Click on the globe icon on top right (Fill in from another locale)

### Related issue(s)/PR(s)

Resolves https://github.com/strapi/strapi/issues/23205

🚀