### PR TITLE
fix: wrong padding on IconButton causing glitch on input heights

### DIFF
--- a/.changeset/brave-years-yell.md
+++ b/.changeset/brave-years-yell.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+fix: glitch of height on inputs caused by wrong padding on IconButton

--- a/docs/stories/03-inputs/Combobox.stories.tsx
+++ b/docs/stories/03-inputs/Combobox.stories.tsx
@@ -317,6 +317,15 @@ export const Size: Story = {
   args: {
     size: 'S',
   },
+  render: (props) => (
+    <Combobox {...props}>
+      {options.map(({ name, value }) => (
+        <ComboboxOption key={value} value={value}>
+          {name}
+        </ComboboxOption>
+      ))}
+    </Combobox>
+  ),
   parameters: {
     docs: {
       source: {

--- a/packages/design-system/src/components/IconButton/IconButton.tsx
+++ b/packages/design-system/src/components/IconButton/IconButton.tsx
@@ -81,8 +81,8 @@ const IconButtonWrapper = styled<FlexComponent<'button'>>(Flex)<IconButtonWrappe
     switch (props.$size) {
       case 'XS': {
         return css`
-          padding-block: 0.25rem;
-          padding-inline: 0.25rem;
+          padding-block: 0.2rem;
+          padding-inline: 0.2rem;
         `;
       }
       case 'S': {

--- a/packages/design-system/src/components/Select/SelectParts.tsx
+++ b/packages/design-system/src/components/Select/SelectParts.tsx
@@ -168,6 +168,7 @@ const ValueType = styled<TypographyComponent>(Typography)`
   flex: 1;
   font-size: 1.4rem;
   line-height: 2.2rem;
+  min-height: 2.2rem;
 `;
 
 const StyledValue = styled(Select.Value)`


### PR DESCRIPTION
### What does it do?

Updated the padding on IconButton that was causing a glitch of height on inputs / fields that use them.

Rules:
The line-height of the content is 22px.
The actual padding of the IconButton is 5px, the icon 16px = 23px.
It should be 22px if we don't want the field to glitch.

### Why is it needed?

It's shifting the content in the CMS and it's not good.

### How to test it?

- Go to Storybook
- You can try any of the input with an IconButton (Combobox, DatePicker, DateTimePicker, Select, TextInput or TimePicker)
- Write / select a value to make the clear icon appearing and glitching the height.

### Related issue(s)/PR(s)

Resolves #1925 and #1924 by @lucasboilly

🚀