### PR TITLE
Allow vertically resizing Textarea

### DIFF
--- a/packages/design-system/src/components/Textarea/Textarea.tsx
+++ b/packages/design-system/src/components/Textarea/Textarea.tsx
@@ -54,13 +54,13 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
 );
 
 const Wrapper = styled<BoxComponent>(Box)<{ $hasError?: boolean }>`
-  height: 10.5rem;
+  min-height: 10.5rem;
   ${inputFocusStyle()}
 `;
 
 const TextareaElement = styled<BoxComponent<'textarea'>>(Box)`
   border: none;
-  resize: none;
+  resize: vertical;
 
   &::placeholder {
     color: ${({ theme }) => theme.colors.neutral600};


### PR DESCRIPTION
### What does it do?

Changed the height attribute to min-height and allowed the textarea to be resized.

### Why is it needed?

As described in https://github.com/strapi/design-system/issues/1916 it would be nice to resize Textareas for better editing. In a later PR it would be nice to add the ability to specify another min-height's for each textarea input

### How to test it?

Create a new multiline text input in any entity and then go to the content view of that entity and see that the textarea is resizeable

### Related issue(s)/PR(s)

Fixes #1916 
