### PR TITLE
fix: linking the design system to strapi locally

### DIFF
--- a/packages/design-system/src/components/Dialog/Dialog.tsx
+++ b/packages/design-system/src/components/Dialog/Dialog.tsx
@@ -62,7 +62,7 @@ const Overlay = styled(AlertDialog.Overlay)`
 const ContentImpl = styled(AlertDialog.Content)`
   max-width: 42rem;
   height: min-content;
-  width: 100%;
+  width: calc(100% - ${({ theme }) => theme.spaces[8]});
   overflow: hidden;
   margin: 0 auto;
   display: flex;

--- a/packages/design-system/src/components/Modal/Modal.tsx
+++ b/packages/design-system/src/components/Modal/Modal.tsx
@@ -66,7 +66,7 @@ const ContentImpl = styled(Dialog.Content)`
   max-width: 83rem;
   max-height: 90vh;
   height: auto;
-  width: 60%;
+  width: calc(100% - ${({ theme }) => theme.spaces[8]});
   overflow: hidden;
   margin: 0 auto;
   display: flex;
@@ -82,6 +82,9 @@ const ContentImpl = styled(Dialog.Content)`
   box-shadow: ${(props) => props.theme.shadows.popupShadow};
   z-index: ${(props) => props.theme.zIndices.modal};
 
+  ${({ theme }) => theme.breakpoints.medium} {
+    width: calc(100% - ${({ theme }) => theme.spaces[9]});
+  }
   > form {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
### What does it do?

Improve the responsiveness of Dialog and Modal.

- Modal
  - before
    - <img width="376" height="585" alt="Screenshot 2025-09-25 at 11 43 49" src="https://github.com/user-attachments/assets/1ecfea95-f190-4935-9102-77350ee5f589" />
  - after
    - <img width="372" height="585" alt="Screenshot 2025-09-25 at 11 42 09" src="https://github.com/user-attachments/assets/782974ef-dc23-47fe-9517-a15a479314fc" />

- Dialog
  - before
    - <img width="372" height="584" alt="Screenshot 2025-09-25 at 11 43 24" src="https://github.com/user-attachments/assets/27ae20f1-53e4-44ac-813c-6a5638501eb3" />
  - after
    - <img width="371" height="585" alt="Screenshot 2025-09-25 at 11 42 51" src="https://github.com/user-attachments/assets/cdb53611-7d2d-47f0-8b87-04cd72d92427" />

### Why is it needed?

To help the user experience on mobile devices while using the platform.

### How to test it?

- Dialog
  - Go to Storybook
  - Go to Dialog page
  - Open a dialog
  - Resize the window to a mobile size (between 375px and 768px)

- Modal
  - Go to Storybook
  - Go to Modal page
  - Open a dialog
  - Resize the window to a mobile size (between 375px and 768px)

🚀