### PR TITLE
Grid item column fallback

### DIFF
--- a/.changeset/lucky-actors-clean.md
+++ b/.changeset/lucky-actors-clean.md
@@ -1,0 +1,6 @@
+---
+'@strapi/design-system': major
+'@strapi/ui-primitives': major
+---
+
+Fix grid item column fallback value

--- a/docs/stories/Grid.stories.tsx
+++ b/docs/stories/Grid.stories.tsx
@@ -47,6 +47,21 @@ export const BaseGrid = {
   name: 'base grid',
 } satisfies Story;
 
+export const GridItemColSizeFallback = {
+  render: () => (
+    <Grid.Root gap={5}>
+      {Array(12)
+        .fill(null)
+        .map((_, i) => (
+          <Grid.Item key={i} background="success200" col={6}>
+            <Typography>Column {i + 1}</Typography>
+          </Grid.Item>
+        ))}
+    </Grid.Root>
+  ),
+  name: 'Column size fallback to col',
+} satisfies Story;
+
 export const ComplexGrid = {
   render: () => (
     <Grid.Root

--- a/packages/design-system/src/primitives/Grid/Grid.tsx
+++ b/packages/design-system/src/primitives/Grid/Grid.tsx
@@ -57,15 +57,15 @@ type ItemComponent<C extends React.ElementType = 'div'> = <T extends React.Eleme
 ) => JSX.Element;
 
 const Item = styled(Flex)`
-  grid-column: span ${({ $xs }) => $xs ?? 12};
+  grid-column: span ${({ $xs, $col }) => $xs ?? $col ?? 12};
   max-width: 100%;
 
   ${({ theme }) => theme.breakpoints.small} {
-    grid-column: span ${({ $s, $xs }) => $s ?? $xs ?? 12};
+    grid-column: span ${({ $s, $xs, $col }) => $s ?? $xs ?? $col ?? 12};
   }
 
   ${({ theme }) => theme.breakpoints.medium} {
-    grid-column: span ${({ $m, $s, $xs }) => $m ?? $s ?? $xs ?? 12};
+    grid-column: span ${({ $m, $s, $xs, $col }) => $m ?? $s ?? $xs ?? $col ?? 12};
   }
 
   ${({ theme }) => theme.breakpoints.large} {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

This PR changes the default `Grid.Item` column size fallback. Right now, the code always falls back to `12` (a full-width span) unless a breakpoint-specific value (`$s`, `$m`, `$col`) is provided. For example:

At `xs`, if you don’t pass `$xs`, it defaults to 12.
At `s`, if you don’t pass `$s`, it defaults to `$xs` (or `12` if `$xs` wasn’t set).
At `m`, if you don’t pass `$m`, it defaults to `$s` → `$xs` → `12`.
At large, it cascades: `$col` → `$m` → `$s` → `$xs` → `12`.

This means that if you set `col={6}` but don’t define `xs`, `s`, or `m`, the smaller breakpoints will expand the item to `12` columns instead of inheriting `6`.

### Why is it needed?

Describe the issue you are solving.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
