### PR TITLE
fix: onLoadMore not being called because of wrongly-placed ref

### DIFF
--- a/.changeset/fuzzy-jokes-melt.md
+++ b/.changeset/fuzzy-jokes-melt.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+fix: onLoadMore not being called because of wrongly-placed ref

--- a/packages/design-system/src/components/Combobox/Combobox.tsx
+++ b/packages/design-system/src/components/Combobox/Combobox.tsx
@@ -140,8 +140,8 @@ const Combobox = React.forwardRef<ComboboxInputElement, ComboboxProps>(
     /**
      * Used for the intersection observer
      */
-    const viewportRef = React.useRef<HTMLDivElement>(null);
     const triggerRef = React.useRef<HTMLInputElement>(null!);
+    const scrollViewportRef = React.useRef<HTMLDivElement>(null);
 
     const composedTriggerRefs = useComposedRefs(triggerRef, forwardedRef);
 
@@ -200,7 +200,7 @@ const Combobox = React.forwardRef<ComboboxInputElement, ComboboxProps>(
     const generatedIntersectionId = useId();
     const intersectionId = `intersection-${stripReactIdOfColon(generatedIntersectionId)}`;
 
-    useIntersection(viewportRef, handleReachEnd, {
+    useIntersection(scrollViewportRef, handleReachEnd, {
       selectorToWatch: `#${intersectionId}`,
       /**
        * We need to know when the select is open because only then will viewportRef
@@ -303,8 +303,8 @@ const Combobox = React.forwardRef<ComboboxInputElement, ComboboxProps>(
         </Trigger>
         <ComboboxPrimitive.Portal>
           <Content sideOffset={4}>
-            <ScrollArea>
-              <ComboboxPrimitive.Viewport ref={viewportRef}>
+            <ScrollArea viewportRef={scrollViewportRef}>
+              <ComboboxPrimitive.Viewport>
                 <Box padding={1}>
                   {shouldVirtualizeOptions ? (
                     <VirtualizedList itemCount={childrenCount}>{children}</VirtualizedList>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?
Replace the ref to the ScrollArea so that `onLoadMore` can be called.

https://github.com/user-attachments/assets/d2d03784-9cf3-42bd-87ba-8789ab477d36

### Why is it needed?
The `onLoadMore` wasn't being called.

### How to test it?
Two ways to test it:
* Create a story in the Combobox to check if `onLoadMore` is being called when hasMoreItems is true.
OR 
* Link design-system to Strapi
* Create two content-types, with at least one Relation field (`manyToMany`).
* Create at least 11 entries in one of the content types.
* Create an entry in the other content type and check that you can scroll down to all 11 entries (not just the first 10).

### Related issue(s)/PR(s)
Fixes https://github.com/strapi/strapi/issues/25280
