### PR TITLE
Fix/2000 loader hardcoded color

### DIFF
--- a/docs/stories/04-components/Loader.stories.tsx
+++ b/docs/stories/04-components/Loader.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
-import { Loader } from '@strapi/design-system';
+import { DesignSystemProvider, Loader, extendTheme, lightTheme } from '@strapi/design-system';
 import { outdent } from 'outdent';
 
 const meta: Meta<typeof Loader> = {
@@ -33,6 +33,40 @@ export const Small = {
       source: {
         code: outdent`
           <Loader small>Loading content...</Loader>
+        `,
+      },
+    },
+  },
+} satisfies Story;
+
+const customTheme = extendTheme(lightTheme, {
+  colors: {
+    primary600: '#ff0000',
+  },
+});
+
+export const CustomThemeColor = {
+  render: () => (
+    <DesignSystemProvider theme={customTheme}>
+      <Loader>Loading content...</Loader>
+    </DesignSystemProvider>
+  ),
+  name: 'custom theme color',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The spinner respects the `primary600` theme color. Here `primary600` is overridden to red (`#ff0000`) to verify the fix — without it the spinner would always appear purple.',
+      },
+      source: {
+        code: outdent`
+          const customTheme = extendTheme(lightTheme, {
+            colors: { primary600: '#ff0000' },
+          });
+
+          <DesignSystemProvider theme={customTheme}>
+            <Loader>Loading content...</Loader>
+          </DesignSystemProvider>
         `,
       },
     },

--- a/packages/design-system/src/components/Loader/Loader.tsx
+++ b/packages/design-system/src/components/Loader/Loader.tsx
@@ -15,7 +15,7 @@ export const Loader = React.forwardRef<HTMLDivElement, LoaderProps>(({ children,
   return (
     <div role="alert" aria-live="assertive" ref={ref} {...props}>
       <VisuallyHidden>{children}</VisuallyHidden>
-      <LoaderImg src={loaderSvg} aria-hidden $small={small} />
+      <LoaderImg aria-hidden $small={small} />
     </div>
   );
 });
@@ -29,7 +29,16 @@ const rotation = keyframes`
   }
 `;
 
-const LoaderImg = styled.img<PropsToTransientProps<Required<Pick<LoaderProps, 'small'>>>>`
+const LoaderImg = styled.div<PropsToTransientProps<Required<Pick<LoaderProps, 'small'>>>>`
+  width: 63px;
+  height: 63px;
+  background-color: ${({ theme }) => theme.colors.primary600};
+  mask-image: url(${loaderSvg});
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  -webkit-mask-image: url(${loaderSvg});
+  -webkit-mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
   animation: ${rotation} 1s infinite linear;
   will-change: transform;
   ${({ $small, theme }) => $small && `width: ${theme.spaces[6]}; height: ${theme.spaces[6]};`}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Replaces the `<img>` tag in the Loader component with a `<div>` using a CSS mask, and drives the color from `theme.colors.primary600` instead of a hardcoded hex value in the SVG. 

### Why is it needed?

The loader SVG had `fill="#4945FF"` hardcoded. Because it was loaded via an `<img>` tag, CSS could not override it — making the loader ignore custom themes and always render blue. 

### How to test it?

Open the Storybook `Components` -> `Loader` -> `custom theme color` story. The spinner renders in red, confirming it picks up the theme's `primary600` value. With the old code it would still be purple.

### Related issue(s)/PR(s)

Fixes #2000 
