### PR TITLE
fix: guard against undefined theme size in Button for XS variant

### DIFF
--- a/packages/design-system/src/components/Button/Button.tsx
+++ b/packages/design-system/src/components/Button/Button.tsx
@@ -115,19 +115,20 @@ const ButtonWrapper = styled<FlexComponent<'button'>>(Flex)<ButtonWrapperProps>`
   ${({ theme, $size }) => {
     const sizeValue = theme.sizes.button[$size];
 
+    if (!sizeValue) return '';
+
     if (typeof sizeValue === 'string') {
       return `height: ${sizeValue};`;
     }
 
     const styles: string[] = [];
     Object.entries(sizeValue).forEach(([breakpoint, breakpointValue]) => {
-      if (breakpointValue) {
-        if (breakpoint === 'initial') {
-          styles.push(`height: ${breakpointValue};`);
-        } else if (breakpoint in theme.breakpoints) {
-          const breakpointQuery = theme.breakpoints[breakpoint as keyof typeof theme.breakpoints];
-          styles.push(`${breakpointQuery} { height: ${breakpointValue}; }`);
-        }
+      if (!breakpointValue) return;
+      if (breakpoint === 'initial') {
+        styles.push(`height: ${breakpointValue};`);
+      } else if (breakpoint in theme.breakpoints) {
+        const breakpointQuery = theme.breakpoints[breakpoint as keyof typeof theme.breakpoints];
+        styles.push(`${breakpointQuery} { height: ${breakpointValue}; }`);
       }
     });
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Adds a guard in `ButtonWrapper`'s styled-component interpolation to return early when `theme.sizes.button[$size]` is `undefined`. Also replaces the raw `Object.entries` call with a safe loop that only emits `@media` blocks for known breakpoints. 

### Why is it needed?

The `theme.sizes.button` only defines entries for S, M, and L. When a Button is rendered with size="XS", the interpolation called `Object.entries(undefined)` which throws a runtime error and produces invalid CSS output in the stylesheet.

### How to test it?

  1. Render a Button with size="XS" (e.g. in a Storybook story or unit test).
  2. Before this fix, the component throws and injects broken CSS.
  3. After this fix, the button renders without a height style (graceful fallback) and no error is thrown.

### Related issue(s)/PR(s)

Fixes #2006 