### PR TITLE
chore(deps): upgrade lodash to 4.18.1

### DIFF
--- a/.changeset/tough-monkeys-draw.md
+++ b/.changeset/tough-monkeys-draw.md
@@ -1,0 +1,5 @@
+---
+"@strapi/design-system": patch
+---
+
+Upgrade `lodash` to include security fixes and keep dependencies up to date.

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -35,7 +35,7 @@
     "@radix-ui/react-use-callback-ref": "1.0.1",
     "@strapi/ui-primitives": "2.2.0",
     "@uiw/react-codemirror": "4.22.2",
-    "lodash": "4.17.23",
+    "lodash": "4.18.1",
     "react-remove-scroll": "2.5.10"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4088,7 +4088,7 @@ __metadata:
     "@uiw/react-codemirror": 4.22.2
     "@vitejs/plugin-react-swc": ^3.7.0
     jest: 29.7.0
-    lodash: 4.17.23
+    lodash: 4.18.1
     react: 18.3.1
     react-dom: 18.3.1
     react-remove-scroll: 2.5.10
@@ -11515,17 +11515,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.23":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 7daad39758a72872e94651630fbb54ba76868f904211089721a64516ce865506a759d9ad3d8ff22a2a49a50a09db5d27c36f22762d21766e47e3ba918d6d7bab
+"lodash@npm:4.18.1, lodash@npm:^4.17.21":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: bb5f5b49aad29614e709af02b64c56b0f8b78c6a81434a3c1ae527d2f0f78ca08f9d9fb22aa825a053876c9d2166e9c01f31c356014b5e2bdc0556c057433102
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.21, lodash@npm:~4.17.15":
-  version: 4.17.21
-  resolution: "lodash@npm:4.17.21"
-  checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
+"lodash@npm:~4.17.15":
+  version: 4.17.23
+  resolution: "lodash@npm:4.17.23"
+  checksum: 7daad39758a72872e94651630fbb54ba76868f904211089721a64516ce865506a759d9ad3d8ff22a2a49a50a09db5d27c36f22762d21766e47e3ba918d6d7bab
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does it do?

upgrade lodash from 4.17.23 to 4.18.1

### Why is it needed?

Several security vullnerabilities

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Fixes CMS-908