### PR TITLE
fix(DatePicker): increase DEFAULT_FUTURE_RANGE from 15 to 200 years

### DIFF
--- a/.changeset/fix-date-picker-future-range.md
+++ b/.changeset/fix-date-picker-future-range.md
@@ -1,0 +1,5 @@
+---
+"@strapi/design-system": patch
+---
+
+Increase `DEFAULT_FUTURE_RANGE` in `DatePicker` from 15 to 200 years to match `DEFAULT_PAST_RANGE`, removing the artificial ~2041 upper-year cap.

--- a/packages/design-system/src/components/DatePicker/DatePicker.tsx
+++ b/packages/design-system/src/components/DatePicker/DatePicker.tsx
@@ -43,7 +43,7 @@ import { IconButton } from '../IconButton';
 import { SingleSelect, SingleSelectOption } from '../Select/SingleSelect';
 
 const DEFAULT_PAST_RANGE = 200;
-const DEFAULT_FUTURE_RANGE = 15;
+const DEFAULT_FUTURE_RANGE = 200;
 
 /* -------------------------------------------------------------------------------------------------
  * DatePicker


### PR DESCRIPTION
## What

Increase `DEFAULT_FUTURE_RANGE` in `DatePicker` from `15` to `200` to match `DEFAULT_PAST_RANGE`.

## Why

The 15-year future cap limits the year selector to `currentYear + 15` — in 2026 that's **2041**. Users cannot select any date beyond that year without the consuming application explicitly passing a custom `maxDate` prop. This was reported in strapi/strapi#26180 and worked around in strapi/strapi#26209, but the root cause lives here.

`DEFAULT_PAST_RANGE` is already `200`, so aligning both constants is the natural fix and gives users a symmetrical 200-year range in both directions by default.

## How to test

1. Render `<DatePicker />` without a `maxDate` prop.
2. Open the calendar and navigate the year selector — it should now allow selecting years well beyond the current year + 15 (up to current year + 200).
3. Verify that passing an explicit `maxDate` still overrides the default range.

## Changeset

A `patch` changeset is included for `@strapi/design-system`.

Closes strapi/strapi#26180