### PR TITLE
enhancement: combobox hides options too much

### DIFF
--- a/.changeset/clever-spoons-play.md
+++ b/.changeset/clever-spoons-play.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': major
+---
+
+increases the maximum height of the Combobox dropdown to show more options

--- a/packages/design-system/src/components/Combobox/Combobox.tsx
+++ b/packages/design-system/src/components/Combobox/Combobox.tsx
@@ -434,7 +434,7 @@ const Content = styled(ComboboxPrimitive.Content)`
   border-radius: ${({ theme }) => theme.borderRadius};
   width: var(--radix-combobox-trigger-width);
   /* This is from the design-system figma file. */
-  max-height: 15rem;
+  max-height: 35.5rem;
   z-index: ${({ theme }) => theme.zIndices.popover};
 
   &:focus-visible {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?
Increases the maximum height of the Combobox dropdown panel (Content) from `15rem` to `35.5rem`, aligned with the Product Designer. The list can show more options before scrolling and cuts off the last option visible (if there are more) to show the list is scrollable.
**BEFORE**
<img width="406" height="258" alt="Capture d’écran 2026-06-04 à 14 52 32" src="https://github.com/user-attachments/assets/8f17b29b-aef4-4527-b4ba-0faa56d7a2ad" />


**AFTER**
https://github.com/user-attachments/assets/6e997ffa-ba71-4844-92dd-8c9a2433066e
<img width="373" height="441" alt="Capture d’écran 2026-06-04 à 14 53 05" src="https://github.com/user-attachments/assets/292c501e-5228-4520-9594-11e2fca7ff99" />


### Why is it needed?
At `15rem`, the dropdown was too short for long option lists. Users had to scroll inside a very small panel, and many options felt hidden or hard to browse. The new value matches the intended design and improves usability for large datasets.

### How to test it?
#### Design system (Storybook):
- Open Inputs → Combobox (e.g. Virtualized or a story with many options).
- Open the dropdown and confirm:
- The panel can grow up to ~`35.5rem` before scrolling.
- Scrolling and option selection work.
- Keyboard navigation (arrows, Enter) still works.

#### Strapi admin:
- Link the Design System in your Strapi repo and restart the admin dev server.
- Go to a content-type that has a relation with Draft & Published enabled (=> the options should have status tags).
- Open the relation Combobox and verify:
  - More options are visible at once.
  - The last option visible is cut off appropriately.
  - You can scroll the list and click/select an option.
 Do the same manual test with a Relation that doesn't have Draft & Published enabled (=> the options shouldn't have status tags).

### Related issue(s)/PR(s)
Fixes https://github.com/strapi/strapi/issues/25858
Fixes CMS-646
