### PR TITLE
Revert "chore: version packages for release (#2012)"

### DIFF
--- a/.changeset/brave-jeans-tie.md
+++ b/.changeset/brave-jeans-tie.md
@@ -1,0 +1,9 @@
+---
+"@strapi/design-system": patch
+"@strapi/icons": patch
+"@strapi/ui-primitives": patch
+---
+
+Upgrade Storybook dependencies to the 9.1 line and refresh transitive lockfile resolutions.
+
+This includes updating Storybook family packages and deduplicating the lockfile without intended runtime API changes.

--- a/.changeset/clever-spoons-play.md
+++ b/.changeset/clever-spoons-play.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': major
+---
+
+increases the maximum height of the Combobox dropdown to show more options

--- a/.changeset/tough-monkeys-draw.md
+++ b/.changeset/tough-monkeys-draw.md
@@ -1,0 +1,5 @@
+---
+"@strapi/design-system": patch
+---
+
+Upgrade `lodash` to include security fixes and keep dependencies up to date.

--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -1,23 +1,5 @@
 # @strapi/design-system
 
-## 3.0.0
-
-### Major Changes
-
-- [#2016](https://github.com/strapi/design-system/pull/2016) [`8408992`](https://github.com/strapi/design-system/commit/84089928888e154cf390ea20aa3d8982d2fcb7ce) Thanks [@mathildeleg](https://github.com/mathildeleg)! - increases the maximum height of the Combobox dropdown to show more options
-
-### Patch Changes
-
-- [#2013](https://github.com/strapi/design-system/pull/2013) [`2290e6b`](https://github.com/strapi/design-system/commit/2290e6b7cacf7ec42b5afbdd6cb1d79bd9759817) Thanks [@innerdvations](https://github.com/innerdvations)! - Upgrade Storybook dependencies to the 9.1 line and refresh transitive lockfile resolutions.
-
-  This includes updating Storybook family packages and deduplicating the lockfile without intended runtime API changes.
-
-- [#2011](https://github.com/strapi/design-system/pull/2011) [`a1b92d9`](https://github.com/strapi/design-system/commit/a1b92d9ce385f9a77d7ad58cffe6abad55a82e5d) Thanks [@innerdvations](https://github.com/innerdvations)! - Upgrade `lodash` to include security fixes and keep dependencies up to date.
-
-- Updated dependencies [[`2290e6b`](https://github.com/strapi/design-system/commit/2290e6b7cacf7ec42b5afbdd6cb1d79bd9759817)]:
-  - @strapi/icons@3.0.0
-  - @strapi/ui-primitives@3.0.0
-
 ## 2.2.0
 
 ### Minor Changes

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strapi/design-system",
-  "version": "3.0.0",
+  "version": "2.2.0",
   "type": "module",
   "license": "MIT",
   "sideEffects": false,
@@ -33,13 +33,13 @@
     "@radix-ui/react-tabs": "1.0.4",
     "@radix-ui/react-tooltip": "1.0.7",
     "@radix-ui/react-use-callback-ref": "1.0.1",
-    "@strapi/ui-primitives": "3.0.0",
+    "@strapi/ui-primitives": "2.2.0",
     "@uiw/react-codemirror": "4.22.2",
     "lodash": "4.18.1",
     "react-remove-scroll": "2.5.10"
   },
   "devDependencies": {
-    "@strapi/icons": "3.0.0",
+    "@strapi/icons": "2.2.0",
     "@types/lodash": "^4.17.23",
     "@vitejs/plugin-react-swc": "^3.7.0",
     "jest": "29.7.0",
@@ -53,7 +53,7 @@
     "vite-plugin-externalize-deps": "^0.8.0"
   },
   "peerDependencies": {
-    "@strapi/icons": "^3.0.0",
+    "@strapi/icons": "^2.0.0 || ^2.0.0-beta || ^2.0.0-alpha",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
     "styled-components": "^6.0.0"

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @strapi/icons
 
-## 3.0.0
-
-### Patch Changes
-
-- [#2013](https://github.com/strapi/design-system/pull/2013) [`2290e6b`](https://github.com/strapi/design-system/commit/2290e6b7cacf7ec42b5afbdd6cb1d79bd9759817) Thanks [@innerdvations](https://github.com/innerdvations)! - Upgrade Storybook dependencies to the 9.1 line and refresh transitive lockfile resolutions.
-
-  This includes updating Storybook family packages and deduplicating the lockfile without intended runtime API changes.
-
 ## 2.2.0
 
 ## 2.1.2

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strapi/icons",
-  "version": "3.0.0",
+  "version": "2.2.0",
   "type": "module",
   "license": "MIT",
   "sideEffects": false,

--- a/packages/primitives/CHANGELOG.md
+++ b/packages/primitives/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @strapi/ui-primitives
 
-## 3.0.0
-
-### Patch Changes
-
-- [#2013](https://github.com/strapi/design-system/pull/2013) [`2290e6b`](https://github.com/strapi/design-system/commit/2290e6b7cacf7ec42b5afbdd6cb1d79bd9759817) Thanks [@innerdvations](https://github.com/innerdvations)! - Upgrade Storybook dependencies to the 9.1 line and refresh transitive lockfile resolutions.
-
-  This includes updating Storybook family packages and deduplicating the lockfile without intended runtime API changes.
-
 ## 2.2.0
 
 ## 2.1.2

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strapi/ui-primitives",
-  "version": "3.0.0",
+  "version": "2.2.0",
   "type": "module",
   "license": "MIT",
   "sideEffects": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3898,8 +3898,8 @@ __metadata:
     "@radix-ui/react-tabs": 1.0.4
     "@radix-ui/react-tooltip": 1.0.7
     "@radix-ui/react-use-callback-ref": 1.0.1
-    "@strapi/icons": 3.0.0
-    "@strapi/ui-primitives": 3.0.0
+    "@strapi/icons": 2.2.0
+    "@strapi/ui-primitives": 2.2.0
     "@types/lodash": ^4.17.23
     "@uiw/react-codemirror": 4.22.2
     "@vitejs/plugin-react-swc": ^3.7.0
@@ -3915,7 +3915,7 @@ __metadata:
     vite-plugin-dts: ^4.3.0
     vite-plugin-externalize-deps: ^0.8.0
   peerDependencies:
-    "@strapi/icons": ^3.0.0
+    "@strapi/icons": ^2.0.0 || ^2.0.0-beta || ^2.0.0-alpha
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
     styled-components: ^6.0.0
@@ -3953,7 +3953,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@strapi/icons@3.0.0, @strapi/icons@workspace:*, @strapi/icons@workspace:packages/icons":
+"@strapi/icons@2.2.0, @strapi/icons@workspace:*, @strapi/icons@workspace:packages/icons":
   version: 0.0.0-use.local
   resolution: "@strapi/icons@workspace:packages/icons"
   dependencies:
@@ -3973,7 +3973,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/ui-primitives@3.0.0, @strapi/ui-primitives@workspace:*, @strapi/ui-primitives@workspace:packages/primitives":
+"@strapi/ui-primitives@2.2.0, @strapi/ui-primitives@workspace:*, @strapi/ui-primitives@workspace:packages/primitives":
   version: 0.0.0-use.local
   resolution: "@strapi/ui-primitives@workspace:packages/primitives"
   dependencies:


### PR DESCRIPTION
This reverts commit 7297ed6d09d68a3db5a768d902eee841e9cc3000, reversing changes made to 9083aba2ea07a4bca54d4d09aa82d76950a49a74.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?
Revert release to avoid bumping design-system to v3.

### Why is it needed?
Design-system should stay at v2.
