### PR TITLE
chore: check changeset presence + block major

### DIFF
--- a/.github/scripts/check-changeset.cjs
+++ b/.github/scripts/check-changeset.cjs
@@ -1,0 +1,76 @@
+'use strict';
+
+const { execSync } = require('node:child_process');
+const fs = require('node:fs');
+
+// folder name under packages/ -> published npm package name
+const PUBLISHED_PACKAGES = {
+  'design-system': '@strapi/design-system',
+  icons: '@strapi/icons',
+  primitives: '@strapi/ui-primitives',
+};
+
+const base = process.env.BASE_REF || 'main';
+const range = `origin/${base}...HEAD`;
+
+function git(args) {
+  return execSync(`git diff --name-only ${args} ${range}`, { encoding: 'utf8' })
+    .split('\n')
+    .filter(Boolean);
+}
+
+const changed = git('');
+const added = git('--diff-filter=A');
+
+const changedPackages = new Set();
+
+for (const file of changed) {
+  for (const [folder, pkgName] of Object.entries(PUBLISHED_PACKAGES)) {
+    if (
+      file.startsWith(`packages/${folder}/src/`) ||
+      file.startsWith(`packages/${folder}/assets/`) ||
+      file === `packages/${folder}/package.json`
+    ) {
+      changedPackages.add(pkgName);
+    }
+  }
+}
+
+if (changedPackages.size === 0) {
+  console.log('No published-package changes detected. Skipping changeset check.');
+  process.exit(0);
+}
+
+const newChangesets = added.filter((file) => {
+  return file.startsWith('.changeset/') && file.endsWith('.md') && !file.endsWith('README.md');
+});
+
+// collect package names bumped by the new changesets
+const bumpedPackages = new Set();
+
+for (const file of newChangesets) {
+  const content = fs.readFileSync(file, 'utf8');
+  const frontmatter = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!frontmatter) continue;
+
+  for (const rawLine of frontmatter[1].split('\n')) {
+    const match = rawLine.trim().match(/^['"]?([^'":]+)['"]?\s*:\s*(?:major|minor|patch)\s*$/);
+    if (match) {
+      bumpedPackages.add(match[1].trim());
+    }
+  }
+}
+
+const missing = [...changedPackages].filter((pkg) => !bumpedPackages.has(pkg));
+
+if (missing.length > 0) {
+  console.error(`::error::The following changed packages have no matching changeset: ${missing.join(', ')}.`);
+  console.error('Run `yarn release:add` and select every package you modified.');
+  process.exit(1);
+}
+
+console.log(`Changed packages: ${[...changedPackages].join(', ')}`);
+console.log(`All covered by ${newChangesets.length} new changeset(s):`);
+for (const file of newChangesets) {
+  console.log(`  - ${file}`);
+}

--- a/.github/scripts/check-major-changeset.cjs
+++ b/.github/scripts/check-major-changeset.cjs
@@ -1,0 +1,39 @@
+'use strict';
+
+const { execSync } = require('node:child_process');
+const fs = require('node:fs');
+
+const base = process.env.BASE_REF || 'main';
+const range = `origin/${base}...HEAD`;
+
+const addedChangesets = execSync(`git diff --name-only --diff-filter=A ${range}`, { encoding: 'utf8' })
+  .split('\n')
+  .filter((file) => file.startsWith('.changeset/') && file.endsWith('.md') && !file.endsWith('README.md'));
+
+const offenders = [];
+
+for (const file of addedChangesets) {
+  const content = fs.readFileSync(file, 'utf8');
+  const frontmatter = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!frontmatter) continue;
+
+  for (const rawLine of frontmatter[1].split('\n')) {
+    const line = rawLine.trim();
+    const match = line.match(/^['"]?[^'":]+['"]?\s*:\s*(major|minor|patch)\s*$/);
+    if (match && match[1] === 'major') {
+      offenders.push({ file, line });
+    }
+  }
+}
+
+if (offenders.length > 0) {
+  console.error('::error::Major version bump detected in the following changesets:');
+  for (const offender of offenders) {
+    console.error(`  ${offender.file}: ${offender.line}`);
+  }
+  console.error('');
+  console.error("If this major bump is intentional, add the 'flag: allow-major' label to the PR.");
+  process.exit(1);
+}
+
+console.log('No major bumps detected in new changesets.');

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -1,0 +1,52 @@
+name: 'Changeset Check'
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  changeset-present:
+    name: 'changeset present'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch base branch
+        run: git fetch --no-tags --depth=50 origin ${{ github.event.pull_request.base.ref }}
+
+      - name: Verify changeset present
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: node .github/scripts/check-changeset.cjs
+
+  no-major-bump:
+    name: 'no accidental major bump'
+    runs-on: ubuntu-latest
+    if: "${{ !contains(github.event.pull_request.labels.*.name, 'flag: allow-major') }}"
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch base branch
+        run: git fetch --no-tags --depth=50 origin ${{ github.event.pull_request.base.ref }}
+
+      - name: Block accidental major bump
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: node .github/scripts/check-major-changeset.cjs


### PR DESCRIPTION
### What does it do?

- Adds a check for changeset presence in every PR
- Block merging the PR if changeset flagged as major (overridable by a dedicated `flag: allow-major` label)

### Why is it needed?

It's happening way too much that we forget to add changesets for every PR. This PR is so that we won't forget.
We also almost released a major version (fortunately that failed) so adding just an additional security to be sure this won't happen again.

### How to test it?

- Create a new PR with some changes but no changeset
→ The merge should be blocked and the pipeline should fail at step `changeset-check`

- Create a new PR with some changes and a changeset with a major version bump
→ The merge should be blocked and the pipeline should fail at step `check-major-changeset`

🚀