### PR TITLE
fix(Button): wrap responsive height styles in css helper

### DIFF
--- a/packages/design-system/src/components/Button/Button.tsx
+++ b/packages/design-system/src/components/Button/Button.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { Loader } from '@strapi/icons';
-import { styled, keyframes } from 'styled-components';
+import { styled, keyframes, css } from 'styled-components';
 
 import { Flex, FlexComponent, FlexProps } from '../../primitives/Flex';
 import { Typography } from '../../primitives/Typography';
@@ -116,22 +116,32 @@ const ButtonWrapper = styled<FlexComponent<'button'>>(Flex)<ButtonWrapperProps>`
     const sizeValue = theme.sizes.button[$size];
 
     if (typeof sizeValue === 'string') {
-      return `height: ${sizeValue};`;
+      return css`
+        height: ${sizeValue};
+      `;
     }
 
-    const styles: string[] = [];
-    Object.entries(sizeValue).forEach(([breakpoint, breakpointValue]) => {
+    const styles = Object.entries(sizeValue).map(([breakpoint, breakpointValue]) => {
       if (breakpointValue) {
         if (breakpoint === 'initial') {
-          styles.push(`height: ${breakpointValue};`);
+          return css`
+            height: ${breakpointValue};
+          `;
         } else if (breakpoint in theme.breakpoints) {
           const breakpointQuery = theme.breakpoints[breakpoint as keyof typeof theme.breakpoints];
-          styles.push(`${breakpointQuery} { height: ${breakpointValue}; }`);
+          return css`
+            ${breakpointQuery} {
+              height: ${breakpointValue};
+            }
+          `;
         }
       }
+      return null;
     });
 
-    return styles.join('\n');
+    return css`
+      ${styles}
+    `;
   }}
   text-decoration: none;
   ${getVariantStyle}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

It fixes invalid CSS generation in the `Button` component when rendering responsive button heights. It imports the `css` helper from `styled-components` and wraps the dynamic height styles in `css` templates rather than returning a raw concatenated string.

### Why is it needed?

After updating Strapi, custom plugins using `<Button variant="secondary" fullWidth ...>` encountered invalid CSS-styles. In `styled-components` v6, returning a raw string containing media query brace blocks (`@media (...) { ... }`) from functional interpolations can break the CSS stylesheet parser (stylis v4). Using the `css` template helper compiles the styles correctly as nested AST rules, avoiding formatting and syntax breakages in the generated stylesheet.

### How to test it?

1. Build the library locally by running `yarn build` (which builds successfully).
2. Render a component utilizing `<Button variant="secondary" fullWidth ...>` and inspect the button element styles. The height styles should be successfully applied across breakpoints without syntax errors in the document stylesheets.

### Related issue(s)/PR(s)

Resolves the invalid CSS styles issue with the `Button` component following responsive mobile size adjustments. #2006 
