### PR TITLE
Fix/pagination dots scrollbar

### DIFF
--- a/packages/design-system/src/components/Button/Button.tsx
+++ b/packages/design-system/src/components/Button/Button.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { Loader } from '@strapi/icons';
-import { styled, keyframes } from 'styled-components';
+import { styled, keyframes, css } from 'styled-components';
 
 import { Flex, FlexComponent, FlexProps } from '../../primitives/Flex';
 import { Typography } from '../../primitives/Typography';
@@ -116,22 +116,32 @@ const ButtonWrapper = styled<FlexComponent<'button'>>(Flex)<ButtonWrapperProps>`
     const sizeValue = theme.sizes.button[$size];
 
     if (typeof sizeValue === 'string') {
-      return `height: ${sizeValue};`;
+      return css`
+        height: ${sizeValue};
+      `;
     }
 
-    const styles: string[] = [];
-    Object.entries(sizeValue).forEach(([breakpoint, breakpointValue]) => {
+    const styles = Object.entries(sizeValue).map(([breakpoint, breakpointValue]) => {
       if (breakpointValue) {
         if (breakpoint === 'initial') {
-          styles.push(`height: ${breakpointValue};`);
+          return css`
+            height: ${breakpointValue};
+          `;
         } else if (breakpoint in theme.breakpoints) {
           const breakpointQuery = theme.breakpoints[breakpoint as keyof typeof theme.breakpoints];
-          styles.push(`${breakpointQuery} { height: ${breakpointValue}; }`);
+          return css`
+            ${breakpointQuery} {
+              height: ${breakpointValue};
+            }
+          `;
         }
       }
+      return null;
     });
 
-    return styles.join('\n');
+    return css`
+      ${styles}
+    `;
   }}
   text-decoration: none;
   ${getVariantStyle}

--- a/packages/design-system/src/components/Pagination/components.tsx
+++ b/packages/design-system/src/components/Pagination/components.tsx
@@ -130,8 +130,8 @@ const PageLinkWrapper = styled(LinkWrapper)<{ $active?: boolean }>`
 
 interface DotsProps extends BoxProps {}
 
-const Dots = ({ children, ...props }: DotsProps) => (
-  <Box {...props}>
+const Dots = ({ children, position = 'relative', ...props }: DotsProps) => (
+  <Box position={position} {...props}>
     <VisuallyHidden>{children}</VisuallyHidden>
     <Typography aria-hidden lineHeight="revert" textColor="neutral800" variant="pi">
       …


### PR DESCRIPTION
### What does it do?

It updates the `Dots` component inside the `Pagination` component to default its `<Box>` container position to `'relative'`.

### Why is it needed?

When a collection has a large number of items and the list page scrolls, a double scrollbar is rendered in Chromium-based browsers. This happens because the `VisuallyHidden` component inside `Dots` is absolutely positioned. Without `position="relative"` on its parent `<Box>`, `VisuallyHidden` is positioned relative to the root `<html>` or `<body>` element instead of the `Dots` container. As a result, the hidden element overflows the page boundaries when scrolling, triggering a secondary scrollbar on the page body.

### How to test it?

1. Build the packages locally by running `yarn build` (which completes successfully).
2. Render a list page with a pagination component containing enough items/pages to show the `Dots` component (e.g. `1 2 3 ... 10`) and ensure the page is scrollable.
3. Observe that only the main body/container scrollbar is visible, and no secondary scrollbar is generated on Chromium-based browsers.

### Related issue(s)/PR(s)

Fixes double scrollbar issues in list pages when pagination `Dots` are rendered. 
Closes Issue #2004 
