### PR TITLE
fix: export color scheme from theme

### DIFF
--- a/.changeset/spicy-days-breathe.md
+++ b/.changeset/spicy-days-breathe.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': patch
+---
+
+chore: add colorScheme to theme

--- a/packages/design-system/src/themes/__tests__/extendTheme.test.ts
+++ b/packages/design-system/src/themes/__tests__/extendTheme.test.ts
@@ -23,7 +23,8 @@ describe('extendTheme', () => {
       import { lightTheme, extendTheme } from '@strapi/design-system';
 
       const myCustomTheme = extendTheme(lightTheme, {
-          colors: /* put the overrides for the colors key */,
+          colorScheme: /* put the overrides for the colorScheme key */,
+      colors: /* put the overrides for the colors key */,
       shadows: /* put the overrides for the shadows key */,
       sizes: /* put the overrides for the sizes key */,
       zIndices: /* put the overrides for the zIndices key */,
@@ -59,7 +60,8 @@ describe('extendTheme', () => {
       import { lightTheme, extendTheme } from '@strapi/design-system';
 
       const myCustomTheme = extendTheme(lightTheme, {
-          colors: /* put the overrides for the colors key */,
+          colorScheme: /* put the overrides for the colorScheme key */,
+      colors: /* put the overrides for the colors key */,
       shadows: /* put the overrides for the shadows key */,
       sizes: /* put the overrides for the sizes key */,
       zIndices: /* put the overrides for the zIndices key */,

--- a/packages/design-system/src/themes/darkTheme/index.ts
+++ b/packages/design-system/src/themes/darkTheme/index.ts
@@ -6,6 +6,7 @@ import { darkColorTokenObject } from './dark-colors';
 import { darkShadowTokenObject } from './dark-shadows';
 
 export const darkTheme: DefaultTheme = {
+  colorScheme: 'dark',
   colors: darkColorTokenObject.color,
   shadows: darkShadowTokenObject.shadow,
   ...commonTheme,

--- a/packages/design-system/src/themes/index.ts
+++ b/packages/design-system/src/themes/index.ts
@@ -6,7 +6,15 @@ export * from './darkTheme';
 export * from './extendTheme';
 export * from './utils';
 
+/**
+ * Identifies which built-in color scheme a theme is based on. Read it from a
+ * `styled-components` theme (`theme.colorScheme`) when a style genuinely has to
+ * branch on light vs dark — prefer semantic color tokens whenever one exists.
+ */
+export type ColorScheme = 'light' | 'dark';
+
 export interface StrapiTheme extends CommonTheme {
   colors: Colors;
   shadows: Shadows;
+  colorScheme: ColorScheme;
 }

--- a/packages/design-system/src/themes/lightTheme/index.ts
+++ b/packages/design-system/src/themes/lightTheme/index.ts
@@ -6,6 +6,7 @@ import { lightColorTokenObject } from './light-colors';
 import { lightShadowTokenObject } from './light-shadows';
 
 export const lightTheme: DefaultTheme = {
+  colorScheme: 'light',
   colors: lightColorTokenObject.color,
   shadows: lightShadowTokenObject.shadow,
   ...commonTheme,


### PR DESCRIPTION
### What does it do?

Adds a `colorScheme` property to the `StrapiTheme` so consumers can tell which built-in scheme a theme is based on.

- Exports a new `ColorScheme` type (`'light' | 'dark'`) from `packages/design-system/src/themes`.
- Adds `colorScheme: ColorScheme` to the `StrapiTheme` interface.
- Sets `colorScheme: 'light'` on `lightTheme` and `colorScheme: 'dark'` on `darkTheme`.

The value is exposed through the `styled-components` theme, so it can be read in any styled component via `theme.colorScheme`.

### Why is it needed?

Some styles genuinely need to branch on light vs dark. Until now there was no reliable way to know the active scheme from the theme itself — consumers had to infer it or thread a separate prop. Exposing `colorScheme` on the theme gives a single source of truth.

> Note: prefer semantic color tokens whenever one exists; `colorScheme` is the escape hatch for the cases where branching is unavoidable.

### How to test it?

1. Launch Storybook:
   ```sh
   yarn install
   yarn build
   yarn develop
   ```
2. In any component, read and log the scheme from the theme:
   ```tsx
   import { useTheme } from 'styled-components';

   const { colorScheme } = useTheme();
   console.log('colorScheme:', colorScheme);
   ```
3. Open that component's page in Storybook and use the dark-mode toggle in the toolbar to switch the scheme.
4. Watch the browser console: the logged value flips between `'light'` and `'dark'` as you toggle.

### Related issue(s)/PR(s)

🚀