### PR TITLE
fix: skip changeset check on release branches

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -19,6 +19,8 @@ jobs:
   changeset-present:
     name: 'changeset present'
     runs-on: ubuntu-latest
+    # Skip the Changesets release PR, which consumes changesets instead of adding them.
+    if: github.head_ref != 'changeset-release/main'
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4


### PR DESCRIPTION
### What does it do?

Skip the changeset check on release branch PRs.
