### PR TITLE
feat: updating for trusted publishing

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -10,13 +10,15 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 permissions:
   contents: read # to fetch code (actions/checkout)
-  id-token: write # required for npm trusted publishing (OIDC)
 
 jobs:
   publish:
     name: 'Publish'
     runs-on: ubuntu-latest
     if: github.repository == 'strapi/design-system'
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      id-token: write # required for npm trusted publishing (OIDC)
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -10,6 +10,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 permissions:
   contents: read # to fetch code (actions/checkout)
+  id-token: write # required for npm trusted publishing (OIDC)
 
 jobs:
   publish:
@@ -22,16 +23,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup npm auth
-        run: |
-          echo "registry=https://registry.npmjs.org" >> ~/.npmrc
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
-
       - name: Setup node
         uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
+
+      - name: Update npm for trusted publishing
+        run: npm install -g npm@latest # OIDC trusted publishing requires npm >= 11.5.1
 
       - name: 'Restore cache'
         uses: actions/cache@v4

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -8,9 +8,6 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
-permissions:
-  contents: read # to fetch code (actions/checkout)
-
 jobs:
   publish:
     name: 'Publish'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,15 +9,17 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 permissions:
-  contents: write
-  pull-requests: write
-  id-token: write # required for npm trusted publishing (OIDC)
+  contents: read
 
 jobs:
   release:
     name: Release
     if: github.repository == 'strapi/design-system'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write # required for npm trusted publishing (OIDC)
     outputs:
       published_packages: ${{ steps.changesets.outputs.publishedPackages }}
       published: ${{ steps.changesets.outputs.published }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 permissions:
   contents: write
   pull-requests: write
+  id-token: write # required for npm trusted publishing (OIDC)
 
 jobs:
   release:
@@ -31,6 +32,9 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
+
+      - name: Update npm for trusted publishing
+        run: npm install -g npm@latest # OIDC trusted publishing requires npm >= 11.5.1
 
       - name: 'Restore cache'
         uses: actions/cache@v4
@@ -54,7 +58,6 @@ jobs:
           title: 'chore: version packages for release'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   find_package_version:
     name: Find Package Versions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,6 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
-permissions:
-  contents: read
-
 jobs:
   release:
     name: Release
@@ -66,6 +63,8 @@ jobs:
     needs: [release]
     runs-on: ubuntu-latest
     if: github.repository == 'strapi/design-system' && needs.release.outputs.published == 'true'
+    permissions:
+      contents: read
     outputs:
       package_version: ${{ steps.find_package_version.outputs.package_version }}
     steps:
@@ -93,6 +92,7 @@ jobs:
     needs: [release, find_package_version]
     runs-on: ubuntu-latest
     if: github.repository == 'strapi/design-system' && needs.release.outputs.published == 'true'
+    permissions: {}
     steps:
       - name: send message to slack
         uses: slackapi/slack-github-action@v1.24.0
@@ -140,6 +140,7 @@ jobs:
     name: notify on error
     runs-on: ubuntu-latest
     if: failure()
+    permissions: {}
     steps:
       - name: send message to slack
         uses: slackapi/slack-github-action@v1.24.0


### PR DESCRIPTION
### What does it do?

changing the yaml files to take into account **Trusted publishing**

### Why is it needed?

Dropping token usage on npm in favour of **Trusted publishing**, which is now the recommended way 

### How to test it?

Good question
