### PR TITLE
chore: trusted publisher handshake

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -3,6 +3,11 @@
   "version": "2.2.1",
   "type": "module",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/strapi/design-system.git",
+    "directory": "packages/design-system"
+  },
   "sideEffects": false,
   "source": "./src/index.ts",
   "main": "./dist/index.js",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -3,6 +3,11 @@
   "version": "2.2.1",
   "type": "module",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/strapi/design-system.git",
+    "directory": "packages/icons"
+  },
   "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -3,6 +3,11 @@
   "version": "2.2.1",
   "type": "module",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/strapi/design-system.git",
+    "directory": "packages/primitives"
+  },
   "sideEffects": false,
   "source": "./src/index.ts",
   "main": "./dist/index.js",


### PR DESCRIPTION
### What does it do?

Adding the repository url to the package json so the npm handshake can be confirmed

### Why is it needed?

Provenance cross-checks the published package.json's repository.url against the repo recorded in the signed attestation (https://github.com/strapi/design-system, derived from the GitHub OIDC context). All 3 packages had no repository field, so npm published them with repository.url: "" → mismatch → E422.

