### PR TITLE
fix: forward crossOrigin on Avatar.Item

### DIFF
--- a/.changeset/quick-tigers-reply.md
+++ b/.changeset/quick-tigers-reply.md
@@ -1,0 +1,5 @@
+---
+'@strapi/design-system': minor
+---
+
+Added crossOrigin support to the Avatar.Item component

--- a/.changeset/quick-tigers-reply.md
+++ b/.changeset/quick-tigers-reply.md
@@ -1,5 +1,5 @@
 ---
-'@strapi/design-system': minor
+'@strapi/design-system': patch
 ---
 
 fix: added crossOrigin support to the Avatar.Item component

--- a/.changeset/quick-tigers-reply.md
+++ b/.changeset/quick-tigers-reply.md
@@ -2,4 +2,4 @@
 '@strapi/design-system': minor
 ---
 
-Added crossOrigin support to the Avatar.Item component
+fix: added crossOrigin support to the Avatar.Item component

--- a/packages/design-system/src/components/Avatar/Avatar.test.tsx
+++ b/packages/design-system/src/components/Avatar/Avatar.test.tsx
@@ -1,0 +1,78 @@
+import { render as renderRTL, waitFor } from '@test/utils';
+
+import { Item, ItemProps } from './Avatar';
+
+const render = (props: Partial<ItemProps> = {}) =>
+  renderRTL(<Item src="http://example.com/avatar.png" alt="an avatar" fallback="AV" {...props} />);
+
+/**
+ * Radix's `Avatar.Image` only mounts the `<img>` element once its internal
+ * image loader reports `loaded`. jsdom never fires `onload` on its own, so we
+ * stub the `Image` constructor to resolve immediately.
+ */
+const mockImageLoading = () => {
+  const OriginalImage = window.Image;
+
+  window.Image = class extends OriginalImage {
+    constructor() {
+      super();
+      setTimeout(() => {
+        this.dispatchEvent(new Event('load'));
+      }, 0);
+    }
+  };
+
+  return () => {
+    window.Image = OriginalImage;
+  };
+};
+
+describe('Avatar', () => {
+  it('should render the fallback while the image is not loaded', async () => {
+    const { findByText } = render({ delayMs: 0 });
+
+    expect(await findByText('AV')).toBeInTheDocument();
+  });
+
+  it('should forward crossOrigin to the avatar image', async () => {
+    const restore = mockImageLoading();
+
+    try {
+      const { container } = render({ crossOrigin: 'anonymous' });
+
+      await waitFor(() => {
+        // eslint-disable-next-line testing-library/no-container
+        const img = container.querySelector('img');
+        expect(img).toBeInTheDocument();
+        expect(img).toHaveAttribute('crossorigin', 'anonymous');
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it('should forward crossOrigin to the hover preview image', async () => {
+    const restore = mockImageLoading();
+
+    try {
+      const { getAllByRole, user } = render({ crossOrigin: 'anonymous', preview: true });
+
+      const trigger = await waitFor(() => {
+        const img = getAllByRole('img').find((el) => el.getAttribute('crossorigin') === 'anonymous');
+        expect(img).toBeInTheDocument();
+        return img!;
+      });
+
+      await user.hover(trigger);
+
+      // Both the thumbnail and the tooltip preview must carry the same crossorigin.
+      await waitFor(() => {
+        const imgs = getAllByRole('img');
+        expect(imgs.length).toBeGreaterThan(1);
+        imgs.forEach((img) => expect(img).toHaveAttribute('crossorigin', 'anonymous'));
+      });
+    } finally {
+      restore();
+    }
+  });
+});

--- a/packages/design-system/src/components/Avatar/Avatar.tsx
+++ b/packages/design-system/src/components/Avatar/Avatar.tsx
@@ -25,7 +25,9 @@ const PREVIEW_SCALE = 2;
 
 type ItemElement = HTMLSpanElement;
 
-interface ItemProps extends Avatar.AvatarProps, Pick<Avatar.AvatarImageProps, 'onLoadingStatusChange' | 'src' | 'alt'> {
+interface ItemProps
+  extends Avatar.AvatarProps,
+    Pick<Avatar.AvatarImageProps, 'onLoadingStatusChange' | 'src' | 'alt' | 'crossOrigin'> {
   /**
    * @default 600
    * @description Useful for delaying rendering so it only
@@ -42,7 +44,10 @@ interface ItemProps extends Avatar.AvatarProps, Pick<Avatar.AvatarImageProps, 'o
 }
 
 const Item = React.forwardRef<ItemElement, ItemProps>(
-  ({ onLoadingStatusChange, delayMs = 600, src, alt, fallback, preview = false, ...restProps }, forwardedRef) => {
+  (
+    { onLoadingStatusChange, delayMs = 600, src, alt, crossOrigin, fallback, preview = false, ...restProps },
+    forwardedRef,
+  ) => {
     const [loadingStatus, setLoadingStatus] = useControllableState({
       onChange: onLoadingStatusChange,
     });
@@ -70,7 +75,7 @@ const Item = React.forwardRef<ItemElement, ItemProps>(
                 style={{ opacity: tooltipOpen ? 0.4 : 0 }}
               />
             ) : null}
-            <AvatarImage src={src} alt={alt} onLoadingStatusChange={setLoadingStatus} />
+            <AvatarImage src={src} alt={alt} crossOrigin={crossOrigin} onLoadingStatusChange={setLoadingStatus} />
             <Avatar.Fallback delayMs={delayMs}>
               <Typography fontWeight="bold" textTransform="uppercase">
                 {fallback}
@@ -81,7 +86,7 @@ const Item = React.forwardRef<ItemElement, ItemProps>(
         {hasPreview ? (
           <Tooltip.Portal>
             <PreviewContent side="top" sideOffset={4}>
-              <PreviewImg src={src} alt={alt} />
+              <PreviewImg src={src} alt={alt} crossOrigin={crossOrigin} />
             </PreviewContent>
           </Tooltip.Portal>
         ) : null}


### PR DESCRIPTION
### What does it do?

`Avatar.Item` accepts a `crossOrigin` prop and forwards it to both `<img>` elements it renders — the visible thumbnail (`AvatarImage`) and the hover-tooltip preview (`PreviewImg`).

Previously `ItemProps` only picked `onLoadingStatusChange | src | alt` from the underlying Radix image props, so `crossOrigin` was silently dropped even though `Avatar.AvatarImageProps` already supports it. This adds `crossOrigin` to the `Pick` and threads it through to both images.

### Why is it needed?

Companion change to a CMS-side fix for a CORS bug on private S3 buckets / signed URLs (strapi/strapi#26581). AWS S3 doesn't send `Vary: Origin` and only returns `Access-Control-Allow-Origin` when the request carries an `Origin` header. Chrome/Safari then cache a plain (no-CORS) response and reuse it for a later `crossOrigin="anonymous"` request, which fails the CORS check.

The Media Library list-view thumbnail renders via `Avatar.Item`, so with `crossOrigin` unforwardable it always loaded plain — poisoning the shared browser cache and breaking a subsequent cross-origin preview. Letting consumers pass `crossOrigin` makes every load use one consistent mode, so the browser caches a single CORS-valid response.

### How to test it?

- `yarn test:unit` — new tests in `Avatar.test.tsx` assert `crossorigin="anonymous"` reaches both the thumbnail and the hover-preview `<img>`.
- Passing `crossOrigin` is opt-in and defaults to `undefined`, so existing usages are unchanged.

### Related issue(s)/PR(s)

- Closes the design-system gap for strapi/strapi#26581 (reference only — not closed by this PR).
- Follow-up required in `strapi/strapi`: bump `@strapi/design-system` and pass `crossOrigin` from `PreviewCell.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)