### PR TITLE
fix(design-system): externalize @codemirror/state in JSONInput bundle

### DIFF
--- a/.changeset/fix-codemirror-bundle-externals.md
+++ b/.changeset/fix-codemirror-bundle-externals.md
@@ -2,8 +2,4 @@
 '@strapi/design-system': patch
 ---
 
-fix(design-system): externalize singleton deps in published bundle
-
-Declare @codemirror/state, @codemirror/view, and @tanstack/react-virtual as
-dependencies so the Vite build externalizes them instead of inlining copies
-into dist. Fixes production admin crashes (strapi/strapi#26951, #2032).
+fix: externalize singleton deps in published bundle

--- a/.changeset/fix-codemirror-bundle-externals.md
+++ b/.changeset/fix-codemirror-bundle-externals.md
@@ -1,0 +1,7 @@
+---
+'@strapi/design-system': patch
+---
+
+fix(design-system): externalize @codemirror/state and @codemirror/view in JSONInput bundle
+
+Fixes regression of #1706 where the Vite build inlined @codemirror/state while @uiw/react-codemirror uses the package from node_modules, causing production admin crashes (strapi/strapi#26951, #2032).

--- a/.changeset/fix-codemirror-bundle-externals.md
+++ b/.changeset/fix-codemirror-bundle-externals.md
@@ -2,6 +2,8 @@
 '@strapi/design-system': patch
 ---
 
-fix(design-system): externalize @codemirror/state and @codemirror/view in JSONInput bundle
+fix(design-system): externalize singleton deps in published bundle
 
-Fixes regression of #1706 where the Vite build inlined @codemirror/state while @uiw/react-codemirror uses the package from node_modules, causing production admin crashes (strapi/strapi#26951, #2032).
+Declare @codemirror/state, @codemirror/view, and @tanstack/react-virtual as
+dependencies so the Vite build externalizes them instead of inlining copies
+into dist. Fixes production admin crashes (strapi/strapi#26951, #2032).

--- a/package.json
+++ b/package.json
@@ -77,6 +77,9 @@
     "typescript": "^5.1.3"
   },
   "packageManager": "yarn@3.6.4",
+  "resolutions": {
+    "@codemirror/state": "6.7.1"
+  },
   "dependencies": {
     "@vueless/storybook-dark-mode": "9.0.6"
   }

--- a/package.json
+++ b/package.json
@@ -77,9 +77,6 @@
     "typescript": "^5.1.3"
   },
   "packageManager": "yarn@3.6.4",
-  "resolutions": {
-    "@codemirror/state": "6.7.1"
-  },
   "dependencies": {
     "@vueless/storybook-dark-mode": "9.0.6"
   }

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -18,6 +18,8 @@
   ],
   "dependencies": {
     "@codemirror/lang-json": "6.0.1",
+    "@codemirror/state": "6.7.1",
+    "@codemirror/view": "6.43.0",
     "@floating-ui/react-dom": "2.1.0",
     "@internationalized/date": "3.5.4",
     "@internationalized/number": "3.5.3",

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -41,6 +41,7 @@
     "@radix-ui/react-tooltip": "1.0.7",
     "@radix-ui/react-use-callback-ref": "1.0.1",
     "@strapi/ui-primitives": "2.2.2",
+    "@tanstack/react-virtual": "^3.10.8",
     "@uiw/react-codemirror": "4.22.2",
     "lodash": "4.18.1",
     "react-remove-scroll": "2.5.10"

--- a/packages/design-system/src/components/JSONInput/__tests__/bundle-codemirror.test.ts
+++ b/packages/design-system/src/components/JSONInput/__tests__/bundle-codemirror.test.ts
@@ -4,15 +4,14 @@ import { resolve } from 'path';
 /**
  * Regression guard for design-system #2032 / strapi/strapi #26951.
  *
- * JSONInput builds a StateField from @codemirror/state and passes it to
- * @uiw/react-codemirror. If design-system inlines @codemirror/state into dist
- * while react-codemirror resolves the package from node_modules, instanceof
- * checks fail in production and the edit view crashes.
+ * Singleton deps used across package boundaries must be external in dist — not
+ * inlined — or production admin builds can load two copies and break instanceof
+ * checks (CodeMirror) or shared runtime state (react-virtual).
  */
-describe('JSONInput bundle output', () => {
+describe('published bundle contract', () => {
   const distPath = resolve(__dirname, '../../../../dist/index.mjs');
 
-  it('does not inline @codemirror/state into the published bundle', () => {
+  it('does not inline singleton deps into the published bundle', () => {
     const content = readFileSync(distPath, 'utf-8');
 
     expect(content).not.toContain(
@@ -20,5 +19,6 @@ describe('JSONInput bundle output', () => {
     );
     expect(content).toMatch(/from ["']@codemirror\/state["']/);
     expect(content).toMatch(/from ["']@codemirror\/view["']/);
+    expect(content).toMatch(/from ["']@tanstack\/react-virtual["']/);
   });
 });

--- a/packages/design-system/src/components/JSONInput/__tests__/bundle-codemirror.test.ts
+++ b/packages/design-system/src/components/JSONInput/__tests__/bundle-codemirror.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Regression guard for design-system #2032 / strapi/strapi #26951.
+ *
+ * JSONInput builds a StateField from @codemirror/state and passes it to
+ * @uiw/react-codemirror. If design-system inlines @codemirror/state into dist
+ * while react-codemirror resolves the package from node_modules, instanceof
+ * checks fail in production and the edit view crashes.
+ */
+describe('JSONInput bundle output', () => {
+  const distPath = resolve(__dirname, '../../../../dist/index.mjs');
+
+  it('does not inline @codemirror/state into the published bundle', () => {
+    const content = readFileSync(distPath, 'utf-8');
+
+    expect(content).not.toContain(
+      'Unrecognized extension value in extension set',
+    );
+    expect(content).toMatch(/from ["']@codemirror\/state["']/);
+    expect(content).toMatch(/from ["']@codemirror\/view["']/);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3914,6 +3914,7 @@ __metadata:
     "@radix-ui/react-use-callback-ref": 1.0.1
     "@strapi/icons": 2.2.2
     "@strapi/ui-primitives": 2.2.2
+    "@tanstack/react-virtual": ^3.10.8
     "@types/lodash": ^4.17.23
     "@uiw/react-codemirror": 4.22.2
     "@vitejs/plugin-react-swc": ^3.7.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -786,12 +786,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@codemirror/state@npm:^6.0.0, @codemirror/state@npm:^6.1.1, @codemirror/state@npm:^6.4.0, @codemirror/state@npm:^6.5.0":
-  version: 6.5.2
-  resolution: "@codemirror/state@npm:6.5.2"
+"@codemirror/state@npm:6.7.1":
+  version: 6.7.1
+  resolution: "@codemirror/state@npm:6.7.1"
   dependencies:
     "@marijn/find-cluster-break": ^1.0.0
-  checksum: 4473a79475070d73f2e72f2eaaee5b69d2833b5020faa9714609d95dd03f0e5ad02cad8031a541dcd748436842a300332a2925317b39ffa09e3b4831145d98bc
+  checksum: 9e14da291d0af8db1fdebdb6a121e6a16e60430394b2958f26f41b3c529a9fc75a9efa75549368304a43f1bbcd332b8dec65755f939753ba6ed9a644f38aebd1
   languageName: node
   linkType: hard
 
@@ -804,6 +804,18 @@ __metadata:
     "@codemirror/view": ^6.0.0
     "@lezer/highlight": ^1.0.0
   checksum: 6cb1ae509234d3a11ca7d901238b14bbeedff3d9d8fa6a451d97357b06af29625dd7f2ab450a2b7c3b4e7fab2733afbebba7029b7d13dece61ac678e84cddb15
+  languageName: node
+  linkType: hard
+
+"@codemirror/view@npm:6.43.0":
+  version: 6.43.0
+  resolution: "@codemirror/view@npm:6.43.0"
+  dependencies:
+    "@codemirror/state": ^6.6.0
+    crelt: ^1.0.6
+    style-mod: ^4.1.0
+    w3c-keyname: ^2.2.4
+  checksum: c5731ec8504ab824b79a138a12dd50c32fca7819e5f6a08b374bb7c29903baa76d9eaf2c2deb1d423bc0bff6d4d3383389ee326e202283b1ca6827b4651ea8ec
   languageName: node
   linkType: hard
 
@@ -3878,6 +3890,8 @@ __metadata:
   resolution: "@strapi/design-system@workspace:packages/design-system"
   dependencies:
     "@codemirror/lang-json": 6.0.1
+    "@codemirror/state": 6.7.1
+    "@codemirror/view": 6.43.0
     "@floating-ui/react-dom": 2.1.0
     "@internationalized/date": 3.5.4
     "@internationalized/number": 3.5.3

--- a/yarn.lock
+++ b/yarn.lock
@@ -786,7 +786,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@codemirror/state@npm:6.7.1":
+"@codemirror/state@npm:6.7.1, @codemirror/state@npm:^6.0.0, @codemirror/state@npm:^6.1.1, @codemirror/state@npm:^6.4.0, @codemirror/state@npm:^6.5.0, @codemirror/state@npm:^6.6.0":
   version: 6.7.1
   resolution: "@codemirror/state@npm:6.7.1"
   dependencies:


### PR DESCRIPTION
### What does it do?

Declares singleton dependencies in `@strapi/design-system` so the Vite build **externalizes** them instead of inlining copies into `dist/index.mjs`:

- `@codemirror/state@6.7.1` and `@codemirror/view@6.43.0` — used by `JSONInput` error-line highlighting
- `@tanstack/react-virtual@^3.10.8` — used by Combobox `VirtualizedList`

Adds a **bundle contract test** (`bundle-codemirror.test.ts`) that fails when those packages are inlined into the published dist.

Fix #2032

### Why is it needed?

Production admin edit views can crash when a **JSON field** mounts (or a component containing one, e.g. SEO `structuredData`):

```
Unrecognized extension value in extension set ([object Object]).
This sometimes happens because multiple instances of @codemirror/state are loaded, breaking instanceof checks.
```

**In plain terms:** the JSON editor and a custom highlight helper inside design-system were each using a *different copy* of CodeMirror. CodeMirror checks “is this extension from *my* copy?” — when the answer is no, it throws and React Router blocks the whole edit view.

This is a **regression of #1706 / #1709** after the packup → Vite migration: `@codemirror/state` and `@codemirror/view` were imported in source but not declared in `package.json`, so `vite-plugin-externalize-deps` inlined them into dist while `@uiw/react-codemirror` still loads CodeMirror from `node_modules`.

The same undeclared-import → inlined pattern affected `@tanstack/react-virtual` in Combobox (already correctly external in `@strapi/ui-primitives`).

**Why it surfaced recently:** the bundling bug has been latent since DS ≥ 2.1.0, but **`@codemirror/state@6.7.1` (July 5)** changed duplicate-instance extensions from silently ignored to an explicit throw — so fresh lockfile installs started crashing without a Strapi release.

Also reported as [strapi/strapi#26951](https://github.com/strapi/strapi/issues/26951).

#### Affected versions

| What matters | Detail |
|--------------|--------|
| **Broken** | `@strapi/design-system` **≥ 2.1.0** through **2.2.2** |
| **Not broken** | `@strapi/design-system` **2.0.0** and earlier |
| **Strapi** | Any Strapi 5.x that resolves to an affected DS version. Rolling back Strapi alone does **not** fix it if the broken DS bundle is still installed. |

### How to test it?

1. `yarn install && yarn build --filter=@strapi/design-system`
2. `cd packages/design-system && npx jest -c jest.config.mjs --testPathPattern=bundle-codemirror` — should pass
3. Sanity check on dist:

   ```bash
   grep -c "Unrecognized extension value" packages/design-system/dist/index.mjs
   # expect 0

   grep "@codemirror/state" packages/design-system/dist/index.mjs
   grep "@tanstack/react-virtual" packages/design-system/dist/index.mjs
   # expect external import lines
   ```

4. After release: bump `@strapi/design-system` in strapi/strapi, production build (`yarn build && yarn start`), open a Content Manager edit view with a **json** field — should load without console errors.

### Related issue(s)/PR(s)

- Fixes #2032
- Regression of #1706 / #1709
- [strapi/strapi#26951](https://github.com/strapi/strapi/issues/26951)