### PR TITLE
fix: keep scroll position when focusing a cell by pointer

### DIFF
--- a/.changeset/table-preserve-scroll-on-select.md
+++ b/.changeset/table-preserve-scroll-on-select.md
@@ -1,0 +1,7 @@
+---
+'@strapi/design-system': patch
+---
+
+**`Table`**: preserve the scroll position when selecting a row far down the list
+
+`RawTable` moved roving focus to the active cell on every index change, including pointer and programmatic ones. Clicking a control (e.g. a row checkbox) low in a scrolled table refocused the roving cell and scrolled it into view, snapping the list back to the top. Focus now follows the roving cell only during keyboard navigation; the element a pointer focuses keeps focus.

--- a/packages/design-system/src/components/RawTable/RawTable.test.tsx
+++ b/packages/design-system/src/components/RawTable/RawTable.test.tsx
@@ -1,0 +1,68 @@
+import { render as renderRTL } from '@test/utils';
+import { fireEvent, screen } from '@testing-library/react';
+
+import { RawTd, RawTh } from './RawCell';
+import { RawTable } from './RawTable';
+import { RawTbody } from './RawTbody';
+import { RawThead } from './RawThead';
+import { RawTr } from './RawTr';
+
+import { focusFocusable } from './focusFocusable';
+
+jest.mock('./focusFocusable', () => ({
+  focusFocusable: jest.fn(),
+}));
+
+const focusFocusableMock = focusFocusable as jest.Mock;
+
+const render = () =>
+  renderRTL(
+    <RawTable colCount={1} rowCount={3}>
+      <RawThead>
+        <RawTr>
+          <RawTh>
+            <button type="button">Header</button>
+          </RawTh>
+        </RawTr>
+      </RawThead>
+      <RawTbody>
+        <RawTr>
+          <RawTd>
+            <button type="button">Row one</button>
+          </RawTd>
+        </RawTr>
+        <RawTr>
+          <RawTd>
+            <button type="button">Row two</button>
+          </RawTd>
+        </RawTr>
+      </RawTbody>
+    </RawTable>,
+  );
+
+describe('RawTable roving focus', () => {
+  beforeEach(() => {
+    focusFocusableMock.mockClear();
+  });
+
+  it('moves the roving focus when the index changes via keyboard navigation', () => {
+    render();
+    focusFocusableMock.mockClear(); // ignore mount
+
+    fireEvent.keyDown(screen.getByRole('grid'), { key: 'ArrowDown' });
+
+    expect(focusFocusableMock).toHaveBeenCalled();
+  });
+
+  it('does not move the roving focus when a cell is focused by pointer', () => {
+    // A pointer focus reports its coords through `setTableValues`; re-focusing
+    // the roving cell there would scroll it into view and jump a scrolled table
+    // to the top. The element the user clicked already holds focus.
+    render();
+    focusFocusableMock.mockClear(); // ignore mount
+
+    fireEvent.focus(screen.getByRole('button', { name: 'Row two' }));
+
+    expect(focusFocusableMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/design-system/src/components/RawTable/RawTable.test.tsx
+++ b/packages/design-system/src/components/RawTable/RawTable.test.tsx
@@ -54,10 +54,11 @@ describe('RawTable roving focus', () => {
     expect(focusFocusableMock).toHaveBeenCalled();
   });
 
-  it('does not move the roving focus when a cell is focused by pointer', () => {
-    // A pointer focus reports its coords through `setTableValues`; re-focusing
-    // the roving cell there would scroll it into view and jump a scrolled table
-    // to the top. The element the user clicked already holds focus.
+  it('does not move the roving focus when a cell reports focus through `setTableValues`', () => {
+    // A cell reports focus through `setTableValues` whenever the focus did not
+    // come from the table's own keyboard navigation — a click or a tab both land
+    // here. Re-focusing the roving cell would scroll it into view and jump a
+    // scrolled table to the top; the element that took focus already holds it.
     render();
     focusFocusableMock.mockClear(); // ignore mount
 

--- a/packages/design-system/src/components/RawTable/RawTable.tsx
+++ b/packages/design-system/src/components/RawTable/RawTable.tsx
@@ -18,6 +18,14 @@ export const RawTable = React.forwardRef<HTMLTableElement, RawTableProps>(
   ({ colCount, rowCount, jumpStep = 3, initialCol = 0, initialRow = 0, ...props }, forwardedRef) => {
     const tableRef = React.useRef<HTMLTableElement>(null);
     const mountedRef = React.useRef(false);
+    /**
+     * Focus should follow the roving cell only during keyboard navigation. A
+     * pointer interaction (e.g. clicking a row's checkbox) already focuses the
+     * clicked element and reports its coords through `setTableValues`;
+     * re-focusing the roving cell there would scroll it into view and jump a
+     * scrolled table back to the top.
+     */
+    const shouldSkipFocusRef = React.useRef(false);
     const composedRef = useComposedRefs(tableRef, forwardedRef);
     /**
      * Rows will always have n+1 line because of the <tr><th></th></tr> elements
@@ -26,14 +34,19 @@ export const RawTable = React.forwardRef<HTMLTableElement, RawTableProps>(
     const [colIndex, setColIndex] = React.useState(initialCol);
 
     const setTableValues = React.useCallback(({ colIndex, rowIndex }) => {
+      // Origin is a pointer/programmatic focus — the element is already focused,
+      // so the effect below must not steal focus back to the roving cell.
+      shouldSkipFocusRef.current = true;
       setColIndex(colIndex);
       setRowIndex(rowIndex);
     }, []);
 
     React.useEffect(() => {
-      if (mountedRef.current) {
+      if (mountedRef.current && !shouldSkipFocusRef.current) {
         focusFocusable(tableRef.current);
       }
+
+      shouldSkipFocusRef.current = false;
 
       if (!mountedRef.current) {
         mountedRef.current = true;
@@ -41,6 +54,10 @@ export const RawTable = React.forwardRef<HTMLTableElement, RawTableProps>(
     }, [colIndex, rowIndex]);
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLTableElement>) => {
+      // A key press is keyboard navigation: let focus follow the roving cell
+      // (and scroll it into view) when the index changes below.
+      shouldSkipFocusRef.current = false;
+
       switch (e.key) {
         case KeyboardKeys.RIGHT: {
           e.preventDefault();


### PR DESCRIPTION
### What does it do?

`RawTable` moved roving focus to the active cell on **every** `rowIndex`/`colIndex` change — including pointer and programmatic ones reported through `setTableValues`.

It now tracks a `shouldSkipFocusRef`:

- `setTableValues` (the pointer/programmatic path) sets it, so the focus effect **skips** `focusFocusable` — the element the pointer focused keeps focus.
- `handleKeyDown` clears it, so keyboard navigation still moves focus to the roving cell (and scrolls it into view).

Also adds `RawTable.test.tsx` (keyboard nav moves focus; pointer focus does not) and a changeset (patch).

### Why is it needed?

Clicking a control (e.g. a row's checkbox) far down a scrolled `Table` refocused the roving cell — the first header cell once the index had settled back to `(0, 0)` — and the browser scrolled that cell into view, snapping the list back to the top. The selection applied correctly, but the scroll position was lost on every tick, making bulk-select down a long list impractical.

`RawTable` is shared, so this affects any sufficiently long Strapi table (found during Media Library QA; the Content Manager list view is equally affected).

### How to test it?

Automated:

```
cd packages/design-system
yarn test:unit src/components/RawTable/RawTable.test.tsx
```

Manual (in a consumer — e.g. Strapi's new Media Library **Table view**, or the Content Manager list):

1. Open a table with enough rows to scroll well past one viewport.
2. Scroll to the bottom.
3. Tick a row's checkbox with the **mouse**.

**Expected:** the row is selected and the scroll position stays put. Keyboard arrow navigation still scrolls the focused cell into view.

### Related issue(s)/PR(s)

fix CMS-1567

🚀