### PR TITLE
feat(primitives): add modal prop to Combobox Root

### DIFF
--- a/.changeset/combobox-modal-prop.md
+++ b/.changeset/combobox-modal-prop.md
@@ -1,0 +1,16 @@
+---
+'@strapi/ui-primitives': minor
+---
+
+**`Combobox`**: add `modal` prop to `Root`
+
+The `Combobox.Root` component now accepts a `modal` prop (default `true`).
+
+When `modal={false}`, the three modal-mode behaviours are disabled:
+- `aria-hidden` is not applied to elements outside the trigger and content
+- Page scroll is not locked while the listbox is open
+- Focus is not trapped inside the trigger
+
+This is useful when the combobox is placed inside a dialog or other container that already manages focus trapping and aria-hiding, or when pointer events outside the open listbox must remain active.
+
+The default (`modal={true}`) is unchanged, so existing usage is unaffected.

--- a/packages/primitives/src/components/Combobox/Combobox.test.tsx
+++ b/packages/primitives/src/components/Combobox/Combobox.test.tsx
@@ -987,4 +987,33 @@ describe('Combobox', () => {
       expect(getByText('No value found')).toBeInTheDocument();
     });
   });
+
+  describe('modal prop', () => {
+    it('should open the listbox when modal is false', async () => {
+      const { getByRole, user } = render({ modal: false });
+
+      await user.click(getByRole('combobox'));
+
+      expect(getByRole('listbox')).toBeInTheDocument();
+    });
+
+    it('should close the listbox on Escape when modal is false', async () => {
+      const { getByRole, queryByRole, user } = render({ modal: false });
+
+      await user.click(getByRole('combobox'));
+      expect(getByRole('listbox')).toBeInTheDocument();
+
+      await user.keyboard('[Escape]');
+      expect(queryByRole('listbox')).not.toBeInTheDocument();
+    });
+
+    it('should allow selecting an item when modal is false', async () => {
+      const { getByRole, user } = render({ modal: false });
+
+      await user.click(getByRole('combobox'));
+      await user.click(getByRole('option', { name: 'Option 1' }));
+
+      expect(getByRole('combobox')).toHaveValue('Option 1');
+    });
+  });
 });

--- a/packages/primitives/src/components/Combobox/Combobox.tsx
+++ b/packages/primitives/src/components/Combobox/Combobox.tsx
@@ -69,6 +69,7 @@ type ComboboxContextValue = {
   contentId: string;
   disabled?: boolean;
   locale: string;
+  modal: boolean;
   onOpenChange(open: boolean): void;
   onTriggerChange(node: ComboboxInputElement | null): void;
   onValueChange(value: string | undefined): void;
@@ -106,6 +107,13 @@ interface RootProps {
   defaultTextValue?: string;
   disabled?: boolean;
   locale?: string;
+  /**
+   * The modality of the combobox. When set to `true`, interaction with
+   * outside elements will be disabled and only the combobox content will
+   * be visible to screen readers.
+   * @default true
+   */
+  modal?: boolean;
   onOpenChange?(open: boolean): void;
   onValueChange?(value: string): void;
   onTextValueChange?(textValue: string): void;
@@ -177,6 +185,7 @@ const Combobox = (props: RootProps) => {
     disabled,
     required = false,
     locale = 'en-EN',
+    modal = true,
     onTextValueChange,
     textValue: textValueProp,
     defaultTextValue,
@@ -266,8 +275,8 @@ const Combobox = (props: RootProps) => {
 
   // aria-hide everything except the content (better supported equivalent to setting aria-modal)
   React.useEffect(() => {
-    if (content && trigger) return hideOthers([content, trigger]);
-  }, [content, trigger]);
+    if (modal && content && trigger) return hideOthers([content, trigger]);
+  }, [modal, content, trigger]);
 
   return (
     <ComboboxProviders>
@@ -284,6 +293,7 @@ const Combobox = (props: RootProps) => {
         onOpenChange={setOpen}
         disabled={disabled}
         locale={locale}
+        modal={modal}
         focusFirst={focusFirst}
         textValue={textValue}
         onTextValueChange={setTextValue}
@@ -330,7 +340,7 @@ const ComboboxTrigger = React.forwardRef<ComboboxTriggerElement, TriggerProps>((
         asChild
         // we make sure we're not trapping once it's been closed
         // (closed !== unmounted when animating out)
-        trapped={context.open}
+        trapped={context.modal && context.open}
         onMountAutoFocus={(event) => {
           // we prevent open autofocus because we manually focus the selected item
           event.preventDefault();
@@ -858,41 +868,41 @@ const ComboboxContentImpl = React.forwardRef<ComboboxContentImplElement, Combobo
       };
     }, [onOpenChange]);
 
-    return (
-      <RemoveScroll allowPinchZoom>
-        <DismissableLayer
-          asChild
-          onEscapeKeyDown={onEscapeKeyDown}
-          onPointerDownOutside={onPointerDownOutside}
-          // When focus is trapped, a focusout event may still happen.
-          // We make sure we don't trigger our `onDismiss` in such case.
-          onFocusOutside={(event) => {
-            event.preventDefault();
+    const content = (
+      <DismissableLayer
+        asChild
+        onEscapeKeyDown={onEscapeKeyDown}
+        onPointerDownOutside={onPointerDownOutside}
+        // When focus is trapped, a focusout event may still happen.
+        // We make sure we don't trigger our `onDismiss` in such case.
+        onFocusOutside={(event) => {
+          event.preventDefault();
+        }}
+        onDismiss={() => {
+          context.onOpenChange(false);
+          context.trigger?.focus({ preventScroll: true });
+        }}
+      >
+        <ComboboxPopperPosition
+          role="listbox"
+          id={context.contentId}
+          data-state={context.open ? 'open' : 'closed'}
+          onContextMenu={(event) => event.preventDefault()}
+          {...contentProps}
+          ref={composedRefs}
+          style={{
+            // flex layout so we can place the scroll buttons properly
+            display: 'flex',
+            flexDirection: 'column',
+            // reset the outline by default as the content MAY get focused
+            outline: 'none',
+            ...contentProps.style,
           }}
-          onDismiss={() => {
-            context.onOpenChange(false);
-            context.trigger?.focus({ preventScroll: true });
-          }}
-        >
-          <ComboboxPopperPosition
-            role="listbox"
-            id={context.contentId}
-            data-state={context.open ? 'open' : 'closed'}
-            onContextMenu={(event) => event.preventDefault()}
-            {...contentProps}
-            ref={composedRefs}
-            style={{
-              // flex layout so we can place the scroll buttons properly
-              display: 'flex',
-              flexDirection: 'column',
-              // reset the outline by default as the content MAY get focused
-              outline: 'none',
-              ...contentProps.style,
-            }}
-          />
-        </DismissableLayer>
-      </RemoveScroll>
+        />
+      </DismissableLayer>
     );
+
+    return context.modal ? <RemoveScroll allowPinchZoom>{content}</RemoveScroll> : content;
   },
 );
 


### PR DESCRIPTION
## What

Adds a `modal` prop (default `true`) to `Combobox.Root` in the primitives package, mirroring the same prop on Radix's Popover and Select primitives.

Closes #1032.

## Why

When `modal` is `true` (the current default and the backward-compatible behavior):
- `hideOthers` aria-hides everything outside the trigger + content — screen readers see only the combobox
- `RemoveScroll` prevents page scrolling while the listbox is open
- `FocusScope` traps keyboard focus inside the trigger

These defaults are correct for most cases, but can conflict when:
- The combobox is placed inside a dialog that already manages aria-hiding and focus trapping
- The product needs pointer events outside the listbox to remain active (e.g. a floating combobox over a canvas)

Setting `modal={false}` disables all three behaviors so the parent context stays in control.

## Changes

- `Combobox.tsx`: `modal` added to `RootProps` (with JSDoc), `ComboboxContextValue`, and the `Combobox` component. `hideOthers`, `FocusScope trapped`, and `RemoveScroll` are each gated on `context.modal`.
- `Combobox.test.tsx`: three new tests covering open, Escape dismiss, and item selection with `modal={false}`.

## Verification

- All 50 existing unit tests pass unchanged (default `modal={true}` behavior is unaffected).
- 3 new tests for `modal={false}` pass.
- `oxlint` and `tsc --noEmit` clean.