### PR TITLE
fix: bump @types/react-dom to 18.3.7 to prevent a nested React 19 types copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@testing-library/user-event": "14.5.2",
     "@types/jest": "29.5.12",
     "@types/react": "18.3.3",
-    "@types/react-dom": "18.3.0",
+    "@types/react-dom": "18.3.7",
     "@typescript-eslint/eslint-plugin": "7.12.0",
     "@typescript-eslint/parser": "7.12.0",
     "eslint": "8.57.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4911,21 +4911,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-dom@npm:18.3.0":
-  version: 18.3.0
-  resolution: "@types/react-dom@npm:18.3.0"
-  dependencies:
-    "@types/react": "*"
-  checksum: a0cd9b1b815a6abd2a367a9eabdd8df8dd8f13f95897b2f9e1359ea3ac6619f957c1432ece004af7d95e2a7caddbba19faa045f831f32d6263483fc5404a7596
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:*":
-  version: 19.1.9
-  resolution: "@types/react@npm:19.1.9"
-  dependencies:
-    csstype: ^3.0.2
-  checksum: 531b1f40e7f93aade4385a56b73e98846ec482ac695ccb0d4da1fc53fa398564f71383cd120cf8b8a9a1ea95f207c3e042d145fa8bc26e4fa57d863459e53b29
+"@types/react-dom@npm:18.3.7":
+  version: 18.3.7
+  resolution: "@types/react-dom@npm:18.3.7"
+  peerDependencies:
+    "@types/react": ^18.0.0
+  checksum: c8b63ec944d2a68992b4dba474003fe55ee1d949c4b9c8fe97eecb2290de23f76acfb670b2f7ceb46a5fc8e46808d1745369b03edda48a7a0cf730eff4c5d315
   languageName: node
   linkType: hard
 
@@ -7339,7 +7330,7 @@ __metadata:
     "@testing-library/user-event": 14.5.2
     "@types/jest": 29.5.12
     "@types/react": 18.3.3
-    "@types/react-dom": 18.3.0
+    "@types/react-dom": 18.3.7
     "@typescript-eslint/eslint-plugin": 7.12.0
     "@typescript-eslint/parser": 7.12.0
     "@vueless/storybook-dark-mode": 9.0.6


### PR DESCRIPTION
## What

Bumps the root `@types/react-dom` devDependency from `18.3.0` to `18.3.7` (latest `18.3.x`).

```diff
-    "@types/react-dom": "18.3.0",
+    "@types/react-dom": "18.3.7",
```

`@types/react` stays pinned at `18.3.3` — that is a deliberate React 18 pin, not a workaround.

## Why

`@types/react-dom@18.3.0` declares `@types/react` as a **regular dependency** with the range `"*"`:

```
"@types/react-dom@npm:18.3.0":
  dependencies:
    "@types/react": "*"
```

`"*"` resolves to the latest published version, i.e. 19.x. The result is visible in `yarn.lock` on `main` today — two copies of React's global types side by side:

```
"@types/react@npm:*":
  version: 19.1.9
...
"@types/react@npm:18.3.3":
  version: 18.3.3
```

Two copies of React's global types in one tree produce the usual incompatible `JSX.Element` / `ReactNode` cascade wherever both are reachable. Today nothing in the tree consumes the stray 19.x copy, so it sits there silently; any dependency whose published `.d.ts` files import React types will start pulling it into typechecking.

DefinitelyTyped already fixed this upstream. The declaration changed across the `18.3.x` line:

| version | declaration |
| --- | --- |
| 18.3.0 (current pin) | `dependencies: { "@types/react": "*" }` |
| 18.3.1 | `dependencies: { "@types/react": "*" }` |
| 18.3.2 | `dependencies: { "@types/react": "^18" }` |
| 18.3.3 – 18.3.7 | `dependencies: {}`, `peerDependencies: { "@types/react": "^18.0.0" }` |

From `18.3.3` onwards it is a **peer** dependency constrained to `^18.0.0`, so a nested 19.x copy is no longer possible. This removes the duplicate at the source rather than masking it with a global `resolutions` override.

## Verification

- `yarn install` — logs `@types-react-npm-19.1.9-...zip appears to be unused - removing`.
- `yarn why @types/react` — a single entry, `@types/react@npm:18.3.3 (via npm:18.3.3)`. The `"@types/react@npm:*"` lockfile entry is gone.
- `find node_modules -path '*/node_modules/@types/react/package.json' -not -path 'node_modules/@types/react/*'` — no results. (This repo uses `nodeLinker: node-modules`, so the check is meaningful.) Root copies are `@types/react@18.3.3` and `@types/react-dom@18.3.7`.
- `yarn test:ts` — 6/6 tasks successful.
- `yarn test:unit` — 5/5 tasks successful; `@strapi/design-system` 32 suites / 267 passed, `@strapi/ui-primitives` 46 passed.

## Note for a future React 19 move

`@types/react-dom@18.3.x` peers on `@types/react@^18.0.0`, so moving the repo to React 19 types requires bumping both in lockstep — otherwise yarn reports an unmet peer dependency. That is a loud, visible failure rather than the current silent duplicate, which is the intended trade.

All three published packages (`design-system`, `primitives`, `icons`) currently declare `react: ^18.0.0` / `react-dom: ^18.0.0` peers, and React 17 was dropped from that range recently in #2024, so a React 19 move is a deliberate future step rather than something that can happen by accident.

## Relationship to #2033

#2033 (`chore: migrate from @radix-ui/* to unified radix-ui package`) currently carries a root `resolutions` block pinning `@types/react` to `18.3.3` as a temporary workaround. That duplicate pre-exists on `main` and is not caused by radix — radix packages declare `@types/react` only as a *peer*, and yarn berry does not auto-install peers, so they never created the nested copy. The migration only makes the pre-existing duplicate bite, because radix's published `.d.ts` files import React types.

Once this lands, #2033 can drop the `resolutions` block and regenerate its lockfile. This also addresses @Adzouz's review point on #2033 about the `@types/react` situation for consumers on React 18 — the duplicate is removed at the source, so there is nothing left to document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)