### PR TITLE
feat: add a single Tailwind consumer entry

### DIFF
--- a/.changeset/quiet-otters-listen.md
+++ b/.changeset/quiet-otters-listen.md
@@ -3,8 +3,19 @@
 ---
 
 Add Tailwind CSS and shadcn at `@strapi/design-system/next`, with a Button as the
-first component. Import the stylesheet from `@strapi/design-system/next/styles.css`.
-The old import path does not change.
+first component. The old import path does not change.
+
+Import `@strapi/design-system/next/source.css` to get the stylesheet, the tokens and
+the `dark` variant. Then add an `@source` for your own files:
+
+```css
+@import '@strapi/design-system/next/source.css';
+@source './src/**/*.{ts,tsx}';
+```
+
+The entry keeps automatic scanning off, because Tailwind reads a CSS value in a
+styled-components template literal as a class name. Tailwind resolves the `@source`
+path from the stylesheet that holds it.
 
 `DesignSystemProvider` writes the `dark` class on the document root, so both systems
 share one theme. A `useColorScheme` hook at `/next` does the same without the

--- a/.changeset/quiet-otters-listen.md
+++ b/.changeset/quiet-otters-listen.md
@@ -13,9 +13,9 @@ the `dark` variant. Then add an `@source` for your own files:
 @source './src/**/*.{ts,tsx}';
 ```
 
-The entry keeps automatic scanning off, because Tailwind reads a CSS value in a
-styled-components template literal as a class name. Tailwind resolves the `@source`
-path from the stylesheet that holds it.
+The entry keeps automatic scanning off, because the package cannot know the file paths of your project. Tailwind resolves the `@source` path from the stylesheet that holds it.
+
+The `@strapi/design-system/next/theme.css` export is removed. If you use it with `@reference`, import `source.css` instead.
 
 `DesignSystemProvider` writes the `dark` class on the document root, so both systems
 share one theme. A `useColorScheme` hook at `/next` does the same without the

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -8,7 +8,9 @@
     "url": "git+https://github.com/strapi/design-system.git",
     "directory": "packages/design-system"
   },
-  "sideEffects": ["**/*.css"],
+  "sideEffects": [
+    "**/*.css"
+  ],
   "source": "./src/index.ts",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -27,7 +29,7 @@
       "default": "./dist/next/index.mjs"
     },
     "./next/styles.css": "./dist/next/styles.css",
-    "./next/theme.css": "./src/next/theme.css",
+    "./next/source.css": "./src/next/source.css",
     "./dist/*": {
       "types": [
         "./dist/*",
@@ -39,7 +41,8 @@
   },
   "files": [
     "dist",
-    "src/next/theme.css"
+    "src/next/theme.css",
+    "src/next/source.css"
   ],
   "dependencies": {
     "@base-ui/react": "1.7.0",
@@ -98,7 +101,13 @@
     "@strapi/icons": "^2.0.0 || ^2.0.0-beta || ^2.0.0-alpha",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "styled-components": "^6.0.0"
+    "styled-components": "^6.0.0",
+    "tailwindcss": "^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "tailwindcss": {
+      "optional": true
+    }
   },
   "scripts": {
     "build": "vite build",

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -102,7 +102,7 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "styled-components": "^6.0.0",
-    "tailwindcss": "^4.0.0"
+    "tailwindcss": "^4.3.0"
   },
   "peerDependenciesMeta": {
     "tailwindcss": {

--- a/packages/design-system/src/next/source.css
+++ b/packages/design-system/src/next/source.css
@@ -1,0 +1,14 @@
+/*
+ * The Tailwind entry for @strapi/design-system/next
+ *
+ * A consumer imports this file and their build must process it.
+ * The bare `tailwindcss/*` imports resolve from the copy of Tailwind that build owns, which is why we declare it as a peer dependency.
+ */
+
+@import '@strapi/design-system/next/styles.css';
+@import 'tailwindcss/theme.css' theme(reference);
+@import './theme.css' theme(reference);
+/* `source(none)` keeps automatic scanning off. Otherwise Tailwind reads a CSS value in a
+   styled-components template literal as a class name. A consumer must add their own `@source`,
+   and Tailwind resolves that path from the file that holds the line */
+@import 'tailwindcss/utilities.css' source(none);

--- a/packages/design-system/src/next/source.css
+++ b/packages/design-system/src/next/source.css
@@ -8,7 +8,7 @@
 @import '@strapi/design-system/next/styles.css';
 @import 'tailwindcss/theme.css' theme(reference);
 @import './theme.css' theme(reference);
-/* `source(none)` keeps automatic scanning off. Otherwise Tailwind reads a CSS value in a
-   styled-components template literal as a class name. A consumer must add their own `@source`,
-   and Tailwind resolves that path from the file that holds the line */
+/* `source(none)` keeps automatic scanning off, because this package cannot know the file paths of a
+   consumer. A consumer must add their own `@source`, and Tailwind resolves that path from the file
+   that holds the line */
 @import 'tailwindcss/utilities.css' source(none);

--- a/packages/design-system/src/next/styles.css
+++ b/packages/design-system/src/next/styles.css
@@ -15,8 +15,6 @@
 @source './**/*.{ts,tsx}';
 @source not './**/*.test.{ts,tsx}';
 
-@custom-variant dark (&:is(.dark *));
-
 :root {
   --background: oklch(1 0 0);
   --foreground: oklch(0.33 0.047 283);

--- a/packages/design-system/src/next/theme.css
+++ b/packages/design-system/src/next/theme.css
@@ -1,8 +1,10 @@
 /*
  * The design tokens for @strapi/design-system/next
  *
- * Published from `src` (i.e. uncompiled) so a consumer can read it with `@reference`.
+ * Published from `src` (i.e. uncompiled) so `source.css` can import it as a theme reference.
  */
+
+@custom-variant dark (&:is(.dark *));
 
 @theme static {
   /* The root font size rule makes 1rem 10px, so these override the Tailwind defaults multiplied by 1.6.

--- a/yarn.lock
+++ b/yarn.lock
@@ -4090,6 +4090,10 @@ __metadata:
     react: ^18.0.0
     react-dom: ^18.0.0
     styled-components: ^6.0.0
+    tailwindcss: ^4.0.0
+  peerDependenciesMeta:
+    tailwindcss:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### What does it do?

Adds `@strapi/design-system/next/source.css`: one entry that imports the compiled stylesheet, references the Tailwind and design system themes, then generates the utilities. Automatic scanning stays off, so the consumer adds their own `@source`.

The `dark` variant moves to `theme.css`, which the theme reference carries through to the consumer build. `tailwindcss` becomes an optional peer dependency.

### Why is it needed?

Before this, a consumer had to import `styles.css`, then add a `@reference` to `theme.css`, then set up Tailwind. Three steps, and each one is easy to get wrong.

The utilities also did not work correctly (e.g. `dark:` classes), because the package shipped no entry that generates them. This gives one import instead:

```css
@import '@strapi/design-system/next/source.css';
@source './src/**/*.{ts,tsx}';
```

Most importantly: this will allow us to wire it up to the CMS so we can start using it there.

How to test it?

1. Install the experimental release in a Vite or Next.js app that has Tailwind v4.
2. Put the two lines above in the app stylesheet.
3. Use a `/next` component and a Tailwind utility class in the same file. Both must render.
4. Add the `dark` class to the document root. The `dark:` utilities must apply.

Related issue(s)/PR(s)

Follow-up to #2050.