### PR TITLE
fix: experimental release working with the `yarn changeset pre exit` command

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -40,7 +40,18 @@ jobs:
       - name: Build
         run: yarn build --filter=\!@strapi/design-system-docs
 
+      - name: Check changeset pre-release mode
+        id: pre-release
+        run: |
+          if [ -f .changeset/pre.json ]; then
+            echo "active=true" >> "$GITHUB_OUTPUT"
+            echo "tag=$(node -p "require('./.changeset/pre.json').tag")" >> "$GITHUB_OUTPUT"
+          else
+            echo "active=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Exit changeset pre-release mode
+        if: steps.pre-release.outputs.active == 'true'
         run: yarn changeset pre exit
 
       - run: ./scripts/pre-publish.sh --yes
@@ -49,4 +60,5 @@ jobs:
           DIST_TAG: experimental
 
       - name: Re-enter changeset pre-release mode
-        run: yarn changeset pre enter experimental
+        if: steps.pre-release.outputs.active == 'true'
+        run: yarn changeset pre enter ${{ steps.pre-release.outputs.tag }}

--- a/packages/design-system/src/components/JSONInput/__tests__/bundle-codemirror.test.ts
+++ b/packages/design-system/src/components/JSONInput/__tests__/bundle-codemirror.test.ts
@@ -14,9 +14,7 @@ describe('published bundle contract', () => {
   it('does not inline singleton deps into the published bundle', () => {
     const content = readFileSync(distPath, 'utf-8');
 
-    expect(content).not.toContain(
-      'Unrecognized extension value in extension set',
-    );
+    expect(content).not.toContain('Unrecognized extension value in extension set');
     expect(content).toMatch(/from ["']@codemirror\/state["']/);
     expect(content).toMatch(/from ["']@codemirror\/view["']/);
     expect(content).toMatch(/from ["']@tanstack\/react-virtual["']/);

--- a/yarn.lock
+++ b/yarn.lock
@@ -12194,19 +12194,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minizlib@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "minizlib@npm:3.1.0"
+  dependencies:
+    minipass: ^7.1.2
+  checksum: a15e6f0128f514b7d41a1c68ce531155447f4669e32d279bba1c1c071ef6c2abd7e4d4579bb59ccc2ed1531346749665968fdd7be8d83eb6b6ae2fe1f3d370a7
+  languageName: node
+  linkType: hard
+
 "mixme@npm:^0.5.1":
   version: 0.5.10
   resolution: "mixme@npm:0.5.10"
   checksum: 51885f19847b98859645a592917f3939d6f262ba3cc1843a3d7858ac894704b054e7a94737a53163bc1e870e3ea23316ba97d3ba20e1dfd292fe74d5a318be98
-  languageName: node
-  linkType: hard
-
-"mkdirp@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "mkdirp@npm:3.0.1"
-  bin:
-    mkdirp: dist/cjs/src/bin.js
-  checksum: 972deb188e8fb55547f1e58d66bd6b4a3623bf0c7137802582602d73e6480c1c2268dcbafbfb1be466e00cc7e56ac514d7fd9334b7cf33e3e2ab547c16f83a8d
   languageName: node
   linkType: hard
 
@@ -14736,16 +14736,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.4.3":
-  version: 7.4.3
-  resolution: "tar@npm:7.4.3"
+  version: 7.5.22
+  resolution: "tar@npm:7.5.22"
   dependencies:
     "@isaacs/fs-minipass": ^4.0.0
     chownr: ^3.0.0
     minipass: ^7.1.2
-    minizlib: ^3.0.1
-    mkdirp: ^3.0.1
+    minizlib: ^3.1.0
     yallist: ^5.0.0
-  checksum: 8485350c0688331c94493031f417df069b778aadb25598abdad51862e007c39d1dd5310702c7be4a6784731a174799d8885d2fde0484269aea205b724d7b2ffa
+  checksum: e1434f40954410d191ab6d89017bfd40c24869cfd319d19dd74f84db13cbea15370a22bc9b8ecd699d05c2777ec6297f35dac318ed4829b6e776a7cb4f1f7c68
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does it do?
Hopefully fixes experimental releases using Trusted Publishing

### Why is it needed?
So we can release experimental versions of the Design System again

### How to test it?
Once merged, run the experimental action