### PR TITLE
fix: two copiers write `docs/public` into the storybook build

### DIFF
--- a/docs/.storybook/main.ts
+++ b/docs/.storybook/main.ts
@@ -38,6 +38,9 @@ const config: StorybookConfig = {
       exclude: [...(optimizeDeps.exclude ?? []), '@strapi/design-system'],
     };
 
+    // Storybook already copies docs/public, so Vite must not copy it again
+    config.publicDir = false;
+
     return config;
   },
 


### PR DESCRIPTION
### What does it do?

One line in `docs/.storybook/main.ts` sets `config.publicDir = false`, so Vite no longer copies `docs/public`. Storybook stays the only copier through `staticDirs`.

### Why is it needed?

The `chromatic` check fails with `Error: EEXIST: file already exists, mkdir '/tmp/chromatic--<id>/stories'`.

Two copiers write `docs/public` into the output at the same time. Storybook copies `staticDirs` with `fs.cp` in the same `Promise.all` as the preview build, and Vite copies its own `publicDir` when Rollup finishes. If Vite creates a directory in the event-loop hop between the check and the `mkdir` of `fs.cp`, the copy fails and the build stops.

With one copier the race cannot occur.

### How to test it?

Run `yarn --cwd docs build`. The output must hold all 14 files from `docs/public`.

Run `yarn --cwd docs develop`. The sidebar logo, the Avatar stories and the Foundations images must render, with no 404 under `/Foundations/`, `/getting-started/`, `/site/` or `/stories/`.

A green `chromatic` run is not proof, because this is a race. PR #2054 passed once with both copiers still present. An `fs` trace of the build confirms that only Storybook copies `docs/public`.

### Related issue(s)/PR(s)

Storybook fixed the same race upstream in 10.5, with storybookjs/storybook#34499. This repository is on 9.1.20, which predates that fix.

Unblocks the `chromatic` check on #2055.
